### PR TITLE
Adding jshintrc from code conventions repo

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,6 +14,7 @@
   "strict": false,
   "smarttabs": true,
   "expr": true,
+  "laxbreak": true,
 
 
   "evil": true,


### PR DESCRIPTION
The idea is to change to what we see fit.
