### PR TITLE
Load Gravatar over HTTPS

### DIFF
--- a/lib/gravatar/index.js
+++ b/lib/gravatar/index.js
@@ -20,7 +20,7 @@ function createURL(parsedEmail) {
   //  var md5sum = createHash('md5').update(parsedEmail);
   // As it does not work in IE9 :(
 
-  return 'http://www.gravatar.com/avatar/' + md5(parsedEmail) + '?d=404';
+  return 'https://www.gravatar.com/avatar/' + md5(parsedEmail) + '?d=404';
 
 }
 


### PR DESCRIPTION
To avoid Google Chrome (and other browsers) display insecure resources warning:

From "cert icon":

> However, this page includes other resources which are not secure. These resources can be viewed by others while in transit, and can be modified by an attacker to change the look of the page.

From the console:

> The page at '...' was loaded over HTTPS, but displayed insecure content from 'http://www.gravatar.com/avatar/...?d=404': this content should also be loaded over HTTPS.
