### PR TITLE
remove duplicate keys which break json5

### DIFF
--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -1,6 +1,5 @@
 {
   "//": "This is an automatic translation. Help us to improve it.",
-  "//": "Some improvements by human :)",
   "loadingTitle":                   "Подождите...",
   "close":                          "Закрыть",
   "windowsAuthTitle":               "Windows аутентификация",


### PR DESCRIPTION
This relates to #54, because most of the other translations require json5-loader for this project to be built with webpack (browserify alternative).
Another idea would be to fix the trailing commas in some of the other translations so they could be loaded with json-loader (which supports duplicate keys).
