### PR TITLE
Just append to the document head

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,8 +181,7 @@ Auth0Lock.prototype.getClientConfiguration = function (done) {
     global.window.Auth0.script_tags[this.$options.clientID] = script;
 
     // Insert script in DOM head
-    var firstScript = document.getElementsByTagName('script')[0];
-    firstScript.parentNode.insertBefore(script, firstScript);
+    document.getElementsByTagName('head')[0].appendChild(script);
   }
 
   // Handle load and error for client config


### PR DESCRIPTION
The unnecessary work of finding the last script tag can lead to breakage when there are no script elements on the page