### PR TITLE
Add footerText to signin and reset modes

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,6 +18,7 @@
     "signupText":                  "Sign Up",
     "forgotText":                  "Reset password",
     "cancelAction":                "Cancel",
+    "footerText":                  "",
     "emailPlaceholder":            "Email",
     "usernamePlaceholder":         "Username",
     "passwordPlaceholder":         "Password",
@@ -59,7 +60,7 @@
       "specialCharacters" : "Special characters (e.g. !@#$%^&*)",
       "identicalChars": "No more than %d identical characters in a row (e.g., \"%s\" not allowed)"
     }
-    
+
   },
   "reset": {
     "title":                       "Reset Password",
@@ -68,6 +69,7 @@
     "passwordPlaceholder":         "New Password",
     "repeatPasswordPlaceholder":   "Confirm New Password",
     "cancelAction":                "Cancel",
+    "footerText":                  "",
     "successText":                 "We've just sent you an email to reset your password.",
     "enterSamePasswordText":       "Please enter the same password.",
     "headerText":                  "Please enter your email and the new password. We will send you an email to confirm the password change.",

--- a/lib/css/themes/default.less
+++ b/lib/css/themes/default.less
@@ -276,7 +276,7 @@
     margin-bottom: 10px;
     display: block;
     overflow: hidden;
-   
+
     .logo{
       margin-top: 0;
       display: block;
@@ -554,8 +554,18 @@
   }
 
 
-  /*==========  Signup  ==========*/
+  /*==========  Footer text  ==========*/
   .signup-footer small{
+    margin-top: 10px;
+    display: block;
+  }
+
+  .signin-footer small{
+    margin-top: 10px;
+    display: block;
+  }
+
+  .reset-footer small{
     margin-top: 10px;
     display: block;
   }
@@ -644,7 +654,7 @@
           }
         }
       }
-      
+
       li {
         line-height: 1.5;
         margin-top: 5px;

--- a/lib/mode-reset/reset.ejs
+++ b/lib/mode-reset/reset.ejs
@@ -63,6 +63,13 @@
                     <a href="javascript: {}" class="a0-centered a0-btn-small a0-cancel"><%= i18n.t('reset:cancelAction') %></a>
                 </div>
             </div>
+            <% if (i18n.t('reset:footerText') && i18n.t('reset:footerText').length) { %>
+            <div class="a0-reset-footer">
+                <small>
+                    <%- i18n.t('reset:footerText') %>
+                </small>
+            </div>
+            <% } %>
         </div>
     </form>
 </div>

--- a/lib/mode-signin/signin.ejs
+++ b/lib/mode-signin/signin.ejs
@@ -58,6 +58,13 @@
                 <div class="a0-db-actions">
                 </div>
             </div>
+            <% if (i18n.t('signin:footerText') && i18n.t('signin:footerText').length) { %>
+            <div class="a0-signin-footer">
+                <small>
+                    <%- i18n.t('signin:footerText') %>
+                </small>
+            </div>
+            <% } %>
         </div>
     </form>
 </div>

--- a/lib/mode-signin/signin.ejs
+++ b/lib/mode-signin/signin.ejs
@@ -1,60 +1,63 @@
 <div class="a0-notloggedin a0-mode">
     <form novalidate>
-      <div class="a0-collapse-social">
-        <div class="a0-iconlist a0-hide"><p class="a0-hide"><%= i18n.t('signin:or') %></p></div>
-        <div class="a0-separator a0-hide"><span><%= i18n.t('signin:separatorText') %></span></div>
-      </div>
-      <div class="a0-corporate-credentials a0-hide">Please enter your <strong>corporate</strong> credentials at <span class="a0-domain"></span>.</div>
-      <div class="a0-emailPassword">
-        <div class="a0-inputs">
-
-          <div class="a0-email">
-              <%
-                var emailPlaceholder = i18n.t('signin:emailPlaceholder')
-                  + ( _isUsernameRequired() ? ' / ' + i18n.t('signin:usernamePlaceholder') : '' )
-                var inputBudicon = _isUsernameRequired() || 'username' === usernameStyle ? '1' : '5';
-              %>
-              <label for="a0-signin_easy_email" class="a0-sad-placeholder">
-                <%= emailPlaceholder %>
-              </label>
-
-              <div class="a0-input-box">
-                <i class="a0-icon-budicon-<%= inputBudicon %>"></i>
-
-                <input name="email"
-                       id="a0-signin_easy_email"
-                       type="email"
-                       placeholder="<%= emailPlaceholder %>"
-                       title="<%= emailPlaceholder %>">
-              </div>
-          </div>
-
-          <div class="a0-password a0-hide">
-            <label for="a0-signin_easy_password" class="a0-sad-placeholder">
-              <%= i18n.t('signin:passwordPlaceholder') %>
-            </label>
-
-            <div class="a0-input-box">
-              <i class="a0-icon-budicon"></i>
-
-              <input name="password"
-                     id="a0-signin_easy_password"
-                     type="password"
-                     placeholder="<%= i18n.t('signin:passwordPlaceholder') %>"
-                     title="<%= i18n.t('signin:passwordPlaceholder') %>">
-            </div>
-          </div>
-
+        <div class="a0-collapse-social">
+            <div class="a0-iconlist a0-hide"><p class="a0-hide"><%= i18n.t('signin:or') %></p></div>
+            <div class="a0-separator a0-hide"><span><%= i18n.t('signin:separatorText') %></span></div>
         </div>
-        <!-- .a0-inputs -->
+        <div class="a0-corporate-credentials a0-hide">Please enter your <strong>corporate</strong> credentials at <span
+                    class="a0-domain"></span>.
+        </div>
+        <div class="a0-emailPassword">
+            <div class="a0-inputs">
 
-        <div class="a0-sso-notice-container a0-hide"><i class="a0-icon-budicon"></i> <span class="a0-sso-notice">Single Sign-on enabled</span></div>
+                <div class="a0-email">
+                    <%
+                    var emailPlaceholder = i18n.t('signin:emailPlaceholder')
+                            + ( _isUsernameRequired() ? ' / ' + i18n.t('signin:usernamePlaceholder') : '' )
+                    var inputBudicon = _isUsernameRequired() || 'username' === usernameStyle ? '1' : '5';
+                    %>
+                    <label for="a0-signin_easy_email" class="a0-sad-placeholder">
+                        <%= emailPlaceholder %>
+                    </label>
 
-        <div class="a0-action">
-            <button type="submit" class="a0-primary a0-next"><%= i18n.t('signin:action') %></button>
-            <div class="a0-db-actions">
+                    <div class="a0-input-box">
+                        <i class="a0-icon-budicon-<%= inputBudicon %>"></i>
+
+                        <input name="email"
+                               id="a0-signin_easy_email"
+                               type="email"
+                               placeholder="<%= emailPlaceholder %>"
+                               title="<%= emailPlaceholder %>">
+                    </div>
+                </div>
+
+                <div class="a0-password a0-hide">
+                    <label for="a0-signin_easy_password" class="a0-sad-placeholder">
+                        <%= i18n.t('signin:passwordPlaceholder') %>
+                    </label>
+
+                    <div class="a0-input-box">
+                        <i class="a0-icon-budicon"></i>
+
+                        <input name="password"
+                               id="a0-signin_easy_password"
+                               type="password"
+                               placeholder="<%= i18n.t('signin:passwordPlaceholder') %>"
+                               title="<%= i18n.t('signin:passwordPlaceholder') %>">
+                    </div>
+                </div>
+
+            </div>
+            <!-- .a0-inputs -->
+
+            <div class="a0-sso-notice-container a0-hide"><i class="a0-icon-budicon"></i> <span class="a0-sso-notice">Single Sign-on enabled</span>
+            </div>
+
+            <div class="a0-action">
+                <button type="submit" class="a0-primary a0-next"><%= i18n.t('signin:action') %></button>
+                <div class="a0-db-actions">
+                </div>
             </div>
         </div>
-      </div>
     </form>
 </div>

--- a/lib/mode-signup/signup.ejs
+++ b/lib/mode-signup/signup.ejs
@@ -2,68 +2,71 @@
     <form novalidate>
         <div class="a0-header"><%= i18n.t('signup:description') %></div>
         <div class="a0-collapse-social-signup">
-          <div class="a0-iconlist"><p class="a0-hide"><%= i18n.t('signin:or') %></p></div>
-          <div class="a0-separator"><span><%= i18n.t('signin:separatorText') %></span></div>
+            <div class="a0-iconlist"><p class="a0-hide"><%= i18n.t('signin:or') %></p></div>
+            <div class="a0-separator"><span><%= i18n.t('signin:separatorText') %></span></div>
         </div>
         <div class="a0-instructions"><%= i18n.t('signup:headerText') %></div>
         <div class="a0-emailPassword">
-            <div class="a0-inputs-wrapper">      
-              <div class="a0-inputs">
-                <% if(_isUsernameRequired()) { %>
-                  <div class="a0-username">
-                      <label for="a0-signup_easy_username" class="a0-sad-placeholder">
-                        <%= i18n.t('signup:usernamePlaceholder') %>
-                      </label>
-                      <div class="a0-input-box">
-                        <i class="a0-icon-budicon-1"></i>
-                        <input name="username" id="a0-signup_easy_username"
-                             type="text" value=""
-                             placeholder="<%= i18n.t('signup:usernamePlaceholder') %>"
-                             title="<%= i18n.t('signup:usernamePlaceholder') %>">
-                      </div>
-                  </div>
-                <% }%>
-                <div class="a0-email">
-                    <label for="a0-signup_easy_email" class="a0-sad-placeholder">
-                      <%= i18n.t('signup:emailPlaceholder') %>
-                    </label>
-                    <div class="a0-input-box">
-                      <i class="a0-icon-budicon-5"></i>
-                      <input name="email" id="a0-signup_easy_email"
-                           type="email" value=""
-                           placeholder="<%= i18n.t('signup:emailPlaceholder') %>"
-                           title="<%= i18n.t('signup:emailPlaceholder') %>">
+            <div class="a0-inputs-wrapper">
+                <div class="a0-inputs">
+                    <% if(_isUsernameRequired()) { %>
+                    <div class="a0-username">
+                        <label for="a0-signup_easy_username" class="a0-sad-placeholder">
+                            <%= i18n.t('signup:usernamePlaceholder') %>
+                        </label>
+
+                        <div class="a0-input-box">
+                            <i class="a0-icon-budicon-1"></i>
+                            <input name="username" id="a0-signup_easy_username"
+                                   type="text" value=""
+                                   placeholder="<%= i18n.t('signup:usernamePlaceholder') %>"
+                                   title="<%= i18n.t('signup:usernamePlaceholder') %>">
+                        </div>
+                    </div>
+                    <% } %>
+                    <div class="a0-email">
+                        <label for="a0-signup_easy_email" class="a0-sad-placeholder">
+                            <%= i18n.t('signup:emailPlaceholder') %>
+                        </label>
+
+                        <div class="a0-input-box">
+                            <i class="a0-icon-budicon-5"></i>
+                            <input name="email" id="a0-signup_easy_email"
+                                   type="email" value=""
+                                   placeholder="<%= i18n.t('signup:emailPlaceholder') %>"
+                                   title="<%= i18n.t('signup:emailPlaceholder') %>">
+                        </div>
+                    </div>
+                    <div class="a0-password">
+                        <label for="a0-signup_easy_password" class="a0-sad-placeholder">
+                            <%= i18n.t('signup:passwordPlaceholder') %>
+                        </label>
+
+                        <div class="a0-input-box">
+                            <i class="a0-icon-budicon"></i>
+                            <input name="password" id="a0-signup_easy_password"
+                                   type="password" value=""
+                                   placeholder="<%= i18n.t('signup:passwordPlaceholder') %>"
+                                   title="<%= i18n.t('signup:passwordPlaceholder') %>">
+
+                        </div>
+
                     </div>
                 </div>
-                <div class="a0-password">
-                    <label for="a0-signup_easy_password" class="a0-sad-placeholder">
-                      <%= i18n.t('signup:passwordPlaceholder') %>
-                    </label>
-
-                    <div class="a0-input-box">
-                      <i class="a0-icon-budicon"></i>
-                      <input name="password" id="a0-signup_easy_password"
-                             type="password" value=""
-                             placeholder="<%= i18n.t('signup:passwordPlaceholder') %>"
-                             title="<%= i18n.t('signup:passwordPlaceholder') %>">
-
-                    </div>
-
-                </div>
-              </div>
-              <div class="a0-password_policy"></div>
-            </div>  
+                <div class="a0-password_policy"></div>
+            </div>
             <div class="a0-action">
                 <button type="submit" class="a0-primary a0-next"><%= i18n.t('signup:action') %></button>
                 <div class="a0-options">
-                    <a href="javascript: {}" class="a0-centered a0-btn-small a0-cancel"><%= i18n.t('signup:cancelAction') %></a>
+                    <a href="javascript: {}"
+                       class="a0-centered a0-btn-small a0-cancel"><%= i18n.t('signup:cancelAction') %></a>
                 </div>
             </div>
             <% if (i18n.t('signup:footerText') && i18n.t('signup:footerText').length) { %>
             <div class="a0-signup-footer">
-              <small>
-                <%- i18n.t('signup:footerText') %>
-              </small>
+                <small>
+                    <%- i18n.t('signup:footerText') %>
+                </small>
             </div>
             <% } %>
         </div>


### PR DESCRIPTION
This allows setting a footer that is consistent across all modes, not just `signup`.

![screen shot 2015-03-12 at 7 21 25 pm](https://cloud.githubusercontent.com/assets/829698/6629547/e972dfcc-c8ed-11e4-909e-7fc2ab7602fb.png)![screen shot 2015-03-12 at 7 21 16 pm](https://cloud.githubusercontent.com/assets/829698/6629548/e9737824-c8ed-11e4-8521-e6cb435ad337.png)![screen shot 2015-03-12 at 7 21 31 pm](https://cloud.githubusercontent.com/assets/829698/6629549/e9759046-c8ed-11e4-9b2d-3d404bcfdb71.png)


