### PR TITLE
Fix email/username browser autocomplete mismatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -950,7 +950,7 @@ Auth0Lock.prototype._signin = function (panel) {
   var message;
 
   var emailD = panel.query('.a0-email');
-  var email_input = panel.query('input[name=email]');
+  var email_input = panel.query('.a0-email input');
 
   // Send out the signin event, allowing users to dynamically change the options.
   this.emit('signin submit', this.options, { email: email_input.val() });
@@ -1020,8 +1020,8 @@ Auth0Lock.prototype._signin = function (panel) {
 Auth0Lock.prototype._signinWithAuth0 = function (panel, connection) {
   var self = this;
   var options = this.options;
-  var email_input = panel.query('input[name=email]');
-  var password_input = panel.query('input[name=password]');
+  var email_input = panel.query('.a0-email input');
+  var password_input = panel.query('.a0-password input');
   var username = email_input.val();
   var password = password_input.val();
   connection = connection || options._getAuth0Connection(username);
@@ -1136,8 +1136,8 @@ Auth0Lock.prototype._signinSocial = function (e, connection, extraParams, panel)
 
 Auth0Lock.prototype._signinPopupNoRedirect = function (connectionName, popupCallback, extraParams, panel) {
   var self = this;
-  var email_input = panel.query('input[name=email]');
-  var password_input = panel.query('input[name=password]');
+  var email_input = panel.query('.a0-email input');
+  var password_input = panel.query('.a0-password input');
   var options = this.options;
   var callback = popupCallback || options.popupCallback;
 

--- a/lib/mode-reset/index.js
+++ b/lib/mode-reset/index.js
@@ -175,16 +175,16 @@ ResetPanel.prototype.oncancel = function(e) {
 
 ResetPanel.prototype.valid = function () {
   var ok = true;
-  var email_input = this.query('input[name=email]');
+  var email_input = this.query('.a0-email input');
   var email = trim(email_input.val());
   var email_empty = empty.test(email);
   var email_parsed = email_parser.exec(email.toLowerCase());
   var validate_username = this.options._isUsernameRequired();
   var username_parsed = regex.username_parser.exec(email_input.val().toLowerCase());
-  var password_input = this.query('input[name=password]');
+  var password_input = this.query('.a0-password input');
   var password = password_input.val();
   var password_empty = empty.test(password);
-  var repeat_password_input = this.query('input[name=repeat_password]');
+  var repeat_password_input = this.query('.a0-repeatPassword input');
   var repeat_password = repeat_password_input.val();
   var repeat_password_empty = empty.test(repeat_password);
   var widget = this.widget;
@@ -233,11 +233,11 @@ ResetPanel.prototype.valid = function () {
 ResetPanel.prototype.submit = function () {
   var panel = this;
   var widget = panel.widget;
-  var email_input = this.query('input[name=email]');
+  var email_input = this.query('.a0-email input');
   var username = email_input.val();
-  var password_input = this.query('input[name=password]');
+  var password_input = this.query('.a0-password input');
   var password = password_input.val();
-  var repeat_password_input = this.query('input[name=repeat_password]');
+  var repeat_password_input = this.query('.a0-repeatPassword input');
   var connection  = this.options._getAuth0Connection();
   var callback = panel.options.popupCallback;
 

--- a/lib/mode-signin/index.js
+++ b/lib/mode-signin/index.js
@@ -309,13 +309,13 @@ SigninPanel.prototype.onsubmit = function(e) {
   var options = this.options;
 
   var ok = true;
-  var password_input = this.query('input[name=password]');
+  var password_input = this.query('.a0-password input');
   var password_empty = regex.empty.test(password_input.val());
   var password_disabled = password_input.attr('disabled');
   var password_required = options._isThereAnyDBConnection();
 
   var validate_username = options._isUsernameRequired();
-  var email_input = this.query('input[name=email]');
+  var email_input = this.query('.a0-email input');
   var email_parsed = regex.email_parser.exec(email_input.val().toLowerCase());
   var username_parsed = regex.username_parser.exec(email_input.val().toLowerCase());
   var email_empty = regex.empty.test(email_input.val());

--- a/lib/mode-signin/index.js
+++ b/lib/mode-signin/index.js
@@ -179,6 +179,7 @@ SigninPanel.prototype.bindAll = function() {
     var placeholder = options.i18n.t('signin:usernamePlaceholder');
 
     this.query('.a0-email input')
+      .attr('name', 'username')
       .attr('type', 'text')
       .attr('title', placeholder)
       .attr('placeholder', placeholder);

--- a/lib/mode-signup/index.js
+++ b/lib/mode-signup/index.js
@@ -237,11 +237,11 @@ SignupPanel.prototype.submit = function() {
   var widget = this.widget;
   var options = this.options;
   var connection  = options._getAuth0Connection();
-  var email_input = this.query('input[name=email]');
+  var email_input = this.query('.a0-email input');
   var email = email_input.val();
   var username_input = this.query('.a0-username input');
   var username = username_input.val();
-  var password_input = this.query('input[name=password]');
+  var password_input = this.query('.a0-password input');
   var password = password_input.val();
   var callback = widget.options.popupCallback;
 
@@ -334,10 +334,10 @@ SignupPanel.prototype.valid = function() {
   // TODO: Lot of duplicated validation logic with `mode-signin` and `mode-reset`.
   // Will be better to create a new object that handle input validations.
   var ok = true;
-  var email_input = this.query('input[name=email]');
+  var email_input = this.query('.a0-email input');
   var email_empty = empty.test(email_input.val());
   var email_parsed = email_parser.exec(email_input.val().toLowerCase());
-  var password_input = this.query('input[name=password]');
+  var password_input = this.query('.a0-password input');
   var password_empty = empty.test(password_input.val());
   var widget = this.widget;
 
@@ -357,7 +357,7 @@ SignupPanel.prototype.valid = function() {
   }
 
   if(this.options._isUsernameRequired()) {
-    var username_input = this.query('input[name=username]');
+    var username_input = this.query('.a0-username input');
     var username_empty = empty.test(username_input.val());
     var username_parsed = username_parser.exec(username_input.val().toLowerCase());
 


### PR DESCRIPTION
1. Stop browser from presenting list of emails as autocomplete options when `usernameStyle === 'username'`
2. Consistent input selection hooks via  `.a0-{camelCaseRef} input` instead of `[name={snake_case_ref}]`, which stops 1 from breaking and makes code internally consistent