### PR TITLE
Improve SSO experience

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ require('./lib/insert-css');
  */
 
 var bonzo = require('bonzo');
+var bean = require('bean');
 var _ = require('underscore');
 var debug = require('debug')('auth0-lock');
 var Auth0 = require('auth0-js');
@@ -804,6 +805,12 @@ Auth0Lock.prototype.setPanel = function(panel, name) {
 
   this.query('.a0-mode-container').html(el);
   this.emit('%s ready'.replace('%s', pname));
+  
+  // When navigating to a different panel, clear the previous panel history.
+  // The signin panel will handle this inside the panel.
+  if (pname !== 'signin') {
+    this._clearPreviousPanel();
+  }
 };
 
 /**
@@ -931,6 +938,21 @@ Auth0Lock.prototype._focusError = function(input, message) {
   if (!message) return;
   input.parent()
     .append($.create('<span class="a0-error-message">' + message + '</span>'));
+};
+
+/**
+ * Set the email address in the current panel if possible.
+ *
+ * @param {String} email
+ * @private
+ */
+
+Auth0Lock.prototype._setEmail = function(email) {
+  var email_input = this.query('input[name=email]');
+  if (email_input && email_input.length === 1) {
+    email_input.val(email);
+    bean.fire(email_input[0], 'input');
+  }
 };
 
 /**
@@ -1303,6 +1325,40 @@ Auth0Lock.prototype.focusInput = function() {
   } catch(err) {}
 
   return this;
+};
+
+/**
+ * Set the previous panel.
+ * This value is used when returning back from the HRD/SSO state.
+ *
+ * @param {String} panelName
+ * @public
+ */
+
+Auth0Lock.prototype._setPreviousPanel = function (panelName) {
+  this._previousPanel = panelName;
+};
+
+/**
+ * Get the previous panel.
+ * This value is used when returning back from the HRD/SSO state.
+ *
+ * @return {String}
+ * @public
+ */
+
+Auth0Lock.prototype._getPreviousPanel = function () {
+  return this._previousPanel;
+};
+
+/**
+ * Clear the previous panel, to prevent infinite redirects to the previous panel.
+ *
+ * @public
+ */
+
+Auth0Lock.prototype._clearPreviousPanel = function () {
+  this._setPreviousPanel(null);
 };
 
 /**

--- a/lib/mode-reset/index.js
+++ b/lib/mode-reset/index.js
@@ -130,11 +130,37 @@ ResetPanel.prototype.bindAll = function() {
   this.query('.a0-options .a0-cancel')
     .a0_on('click', bind(this.oncancel, this));
 
+  this.query('input[name=email]')
+    .a0_on('input', bind(this.onemailinput, this));
+
   var passwordStrength = new PasswordStrength(this.query('.a0-password_policy'),
                                               this.query('#a0-reset_easy_password'),
                                               this.options);
 
   return this;
+};
+
+/**
+ * Handler for email input event
+ *
+ * @param {Event} e
+ * @private
+ */
+ResetPanel.prototype.onemailinput = function() {
+  var mailField = this.query('input[name=email]');
+  var email = mailField.val();
+
+  if (this.options._isConnectionEmail(email)) {
+
+    var widget = this.widget;
+    widget._setPreviousPanel('reset');
+    widget._showSuccess();
+    widget._showError();
+    widget._focusError();
+    widget._signinPanel();
+    widget._setEmail(email);
+    return;
+  }
 };
 
 /**

--- a/lib/mode-signin/index.js
+++ b/lib/mode-signin/index.js
@@ -245,6 +245,7 @@ SigninPanel.prototype.onemailinput = function (e) {
 
     this.query('.a0-sso-notice-container').removeClass('a0-hide');
     this.query('.a0-password').addClass('a0-hide');
+    this.query('.a0-db-actions').addClass('a0-hide');
     this.oldText = nextButton.text();
 
     msg = this.options.i18n.t('signin:actionDomain');
@@ -267,6 +268,7 @@ SigninPanel.prototype.onemailinput = function (e) {
   if (isEnterpriseConnection) {
     this.query('.a0-sso-notice-container').removeClass('a0-hide');
     this.query('.a0-password').addClass('a0-hide');
+    this.query('.a0-db-actions').addClass('a0-hide');
     this.oldText = nextButton.text();
 
     msg = this.options.i18n.t('signin:actionDomain');
@@ -280,6 +282,20 @@ SigninPanel.prototype.onemailinput = function (e) {
 
   this.query('.a0-sso-notice-container').addClass('a0-hide');
   this.query('.a0-password').removeClass('a0-hide');
+  this.query('.a0-db-actions').removeClass('a0-hide');
+
+  // If HRD was triggered by a previous panel, return to the panel if we no longer have HRD.
+  var widget = this.widget;
+  var previousPanel = widget._getPreviousPanel();
+  if (previousPanel) {
+    widget._clearPreviousPanel();
+    switch (previousPanel) {
+      case 'reset':
+        widget._resetPanel();
+      case 'signup':
+        widget._signupPanel();
+    }
+  }
 
   return pwdField.removeAttr('disabled');
 };

--- a/lib/mode-signup/index.js
+++ b/lib/mode-signup/index.js
@@ -206,11 +206,23 @@ SignupPanel.prototype.oncancel = function(e) {
   widget._signinPanel();
 };
 
-SignupPanel.prototype.onemailinput = function () {
+SignupPanel.prototype.onemailinput = function() {
   var mailField = this.query('.a0-email input');
+  var email = mailField.val();
+
+  if (this.options._isConnectionEmail(email)) {
+    var widget = this.widget;
+    widget._setPreviousPanel('signup');
+    widget._showSuccess();
+    widget._showError();
+    widget._focusError();
+    widget._signinPanel();
+    widget._setEmail(email);
+    return;
+  }
 
   if ('username' !== this.options.usernameStyle && this.options.gravatar) {
-    this.gravatar(mailField.val());
+    this.gravatar(email);
   }
 };
 

--- a/lib/options-manager/index.js
+++ b/lib/options-manager/index.js
@@ -361,6 +361,23 @@ OptionsManager.prototype._filterConnections = function (domain, strategies, crit
 };
 
 /**
+ * Given an email verifies if the email address matches a specific connection.
+ * In that case the login will happen through an external platform (SSO enabled).
+ *
+ * @param {String} email
+ *
+ * @return {Boolean}
+ */
+OptionsManager.prototype._isConnectionEmail = function(email) {
+  var emailDomain = this._extractEmailDomain(email || '');
+  var adConnection = this._findConnectionByADDomain(emailDomain);
+  var isEnterpriseConnection =
+    this._isEnterpriseConnection(email || '');
+  return ('username' !== this.usernameStyle && adConnection) ||
+    isEnterpriseConnection;
+};
+
+/**
  * Resolves wether `email`'s domain belongs to
  * an enterprise connection or not, and alters
  * `output` object in the way...


### PR DESCRIPTION
This will improve the SSO experience when a user enters their email address for which the email suffix has been configured on a connection:

 - Signup and Reset buttons are hidden when we are in HRD mode
 - If you enter an SSO enabled email address on the SignUp or Reset panel, the Lock will navigate back to SignIn, enter your email address there and trigger HRD
 - If you then edit your email address and no longer have an SSO enabled email address, you'll be redirected back to the previous panel (SignUp or Reset). This is required when we start the Lock in SignUp mode only for example