### PR TITLE
Added AD Usernaame Provider

### DIFF
--- a/lib/mode-signin/index.js
+++ b/lib/mode-signin/index.js
@@ -426,7 +426,10 @@ SigninPanel.prototype.enableHRD = function (adConnection, emailDomain) {
 
   this.query('.a0-email label').text(placeholder);
   emailField.focus();
-  if (emailParsed.length > 1 && this.options.defaultADUsernameFromEmailPrefix) {
+  
+  if (this.options.adUsernameProvider) {
+    emailField.val(this.options.adUsernameProvider(emailField.val()));
+  } else if (emailParsed.length > 1 && this.options.defaultADUsernameFromEmailPrefix) {
     emailField.val(emailParsed[1]);
   } else {
     emailField.val('');

--- a/lib/options-manager/index.js
+++ b/lib/options-manager/index.js
@@ -113,6 +113,9 @@ function OptionsManager(widget, options) {
   // This variable is used
   this.defaultADUsernameFromEmailPrefix = null != options.defaultADUsernameFromEmailPrefix ? !!options.defaultADUsernameFromEmailPrefix : true;
 
+  // Allow specifying the AD username logic in code.
+  this.adUsernameProvider = 'function' === typeof options.adUsernameProvider ? options.adUsernameProvider : null;
+
   // SSO by default. User&Password can be authenticated with an ajax call
   // However, since this call is CORS or JSONP it will not set the cookie,
   // hence SSO will not work.


### PR DESCRIPTION
Allow injecting your own logic to resolve the AD username. Eg:

```
            lock.show({
              adUsernameProvider: function(email) {
                var name = email.substring(0, email.lastIndexOf("@"));
                var domain = email.substring(email.lastIndexOf("@") + 1).replace('.com', '');
                return domain + '\\' + name;
              },
              callbackURL: window.location.href,
              responseType: 'token'
            });
```

As a result, instead of just showing the username in the AD login form, it will show: `contoso\jon`