### PR TITLE
Added Lifecycle events

### DIFF
--- a/lib/errors/ValidationError.js
+++ b/lib/errors/ValidationError.js
@@ -1,0 +1,31 @@
+/**
+ * Expose `LoginError`
+ */
+
+module.exports = ValidationError;
+
+/**
+ * Create a `ValidationError` by extend of `Error`
+ *
+ * @param {String} mesage
+ * @public
+ */
+
+function ValidationError(message) {
+  message = message || 'Validation error';
+
+  var err = Error.call(this, message);
+
+  return err;
+}
+
+/**
+ * Extend `ValidationError.prototype` with `Error.prototype`
+ * and `ValidationError` as constructor
+ */
+
+if (Object && Object.create) {
+  ValidationError.prototype = Object.create(Error.prototype, {
+    constructor: { value: ValidationError }
+  });
+}

--- a/lib/mode-kerberos/index.js
+++ b/lib/mode-kerberos/index.js
@@ -120,6 +120,7 @@ KerberosPanel.prototype.bindAll = function() {
 
   this.query('form').a0_on('submit', function (e) {
     stop(e);
+    widget.emit('kerberos submit', widget.options);
     widget._signInEnterprise(e);
   });
 

--- a/lib/mode-loggedin/index.js
+++ b/lib/mode-loggedin/index.js
@@ -121,6 +121,7 @@ LoggedinPanel.prototype.bindAll = function() {
 
   this.query('form').a0_on('submit', function (e) {
     stop(e);
+    widget.emit('loggedin submit', widget.options);
     widget._signInEnterprise(e);
   });
 
@@ -146,6 +147,7 @@ LoggedinPanel.prototype.bindAll = function() {
   this.query('.a0-strategy .a0-zocial[data-strategy]').a0_on('click', function (e) {
     stop(e);
 
+    widget.emit('loggedin submit', widget.options, widget.$ssoData);
     widget._signinSocial(
       strategy_name,
       widget.$ssoData.lastUsedConnection && widget.$ssoData.lastUsedConnection.name,

--- a/lib/mode-reset/index.js
+++ b/lib/mode-reset/index.js
@@ -12,6 +12,7 @@ var bind = require('../bind');
 var template = require('./reset.ejs');
 var regex = require('../regex');
 var PasswordStrength = require('../password-strength');
+var ValidationError = require('../errors/ValidationError');
 var empty = regex.empty;
 var trim = require('trim');
 var email_parser = regex.email_parser;
@@ -221,34 +222,42 @@ ResetPanel.prototype.valid = function () {
   widget._focusError();
 
   if (email_empty) {
+    var error_message = validate_username ? 'username empty' : 'email empty';
+    widget.emit('reset error', new ValidationError(error_message));
     widget._focusError(email_input);
     ok = false;
   }
 
   if (!email_parsed && !email_empty) {
-    if(validate_username && !username_parsed) {
-      ok = false || (validate_username && username_parsed);
-      if(!ok) widget._focusError(email_input, widget.options.i18n.t('invalid'));
+    ok = false || (validate_username && username_parsed);
+
+    if (!ok) {
+      var invalid_error = validate_username ? 'username invalid' : 'email invalid';
+      widget.emit('reset error', new ValidationError(invalid_error));
+      widget._focusError(email_input, widget.options.i18n.t('invalid'));
     }
   }
 
   if (password_empty) {
+    widget.emit('reset error', new ValidationError('password empty'));
     widget._focusError(password_input);
     ok = false;
   }
 
   if (repeat_password_empty) {
+    widget.emit('reset error', new ValidationError('repeat password empty'));
     widget._focusError(repeat_password_input);
     ok = false;
   }
 
   if (repeat_password_input.val() !== password_input.val()) {
+    widget.emit('reset error', new ValidationError('password missmatch'));
     widget._focusError(repeat_password_input, widget.options.i18n.t('mustMatch'));
     ok = false;
   }
 
   return ok;
-}
+};
 
 /**
  * Submit validated form to Auth0 for password reset
@@ -268,6 +277,8 @@ ResetPanel.prototype.submit = function () {
   var callback = panel.options.popupCallback;
 
   widget._loadingPanel({ mode: 'reset' });
+
+  widget.emit('reset submit', widget.options);
 
   widget.$auth0.changePassword({
     connection: connection.name,
@@ -294,9 +305,11 @@ ResetPanel.prototype.submit = function () {
       email_input.val('');
       widget._signinPanel(panel.options);
       widget._showSuccess(widget.options.i18n.t('reset:successText'));
-
+      widget.emit('reset success');
       return 'function' === typeof callback ? callback.apply(widget, args) : null;
     }
+
+    widget.emit('reset error', err);
 
     widget.setPanel(panel);
 
@@ -316,4 +329,4 @@ ResetPanel.prototype.submit = function () {
 
   });
 
-}
+};

--- a/lib/mode-signin/index.js
+++ b/lib/mode-signin/index.js
@@ -10,6 +10,7 @@ var stop = require('../stop-event');
 var $ = require('../bonzo-augmented');
 var template = require('./signin.ejs');
 var create = require('../object-create');
+var ValidationError = require('../errors/ValidationError');
 var Emitter = require('events').EventEmitter;
 var buttonTmpl = require('../html/zocial-button.ejs');
 var loginActionsTmpl = require('./login_actions.ejs');
@@ -342,6 +343,7 @@ SigninPanel.prototype.onsubmit = function(e) {
   widget._focusError();
 
   if (email_empty) {
+    widget.emit('signin error', new ValidationError('email empty'));
     widget._focusError(email_input);
     ok = false;
   }
@@ -349,11 +351,17 @@ SigninPanel.prototype.onsubmit = function(e) {
   if (!widget._ignoreEmailValidations(email_input)) {
     if (!email_parsed && !email_empty) {
       ok = false || (validate_username && username_parsed);
-      if(!ok) widget._focusError(email_input, options.i18n.t('invalid'));
+
+      if (!ok) {
+        var error_message = validate_username ? 'username invalid' : 'email invalid';
+        widget.emit('signin error', new ValidationError(error_message));
+        widget._focusError(email_input, options.i18n.t('invalid'));
+      }
     }
   }
 
   if (password_empty && password_required && !password_disabled) {
+    widget.emit('signin error', new ValidationError('password empty'));
     widget._focusError(password_input);
     ok = false;
   }
@@ -382,6 +390,10 @@ SigninPanel.prototype.onsubmit = function(e) {
 
 SigninPanel.prototype.onsocialclick = function(e) {
     stop(e);
+    var target = e.currentTarget || e.delegateTarget || e.target || e;
+    var strategyName = typeof target === 'string' ? target : target.getAttribute('data-strategy');
+
+    this.widget.emit('signin submit', this.widget.options, { provider: strategyName });
     this.widget._signinSocial(e, null, null, this);
 };
 
@@ -517,5 +529,3 @@ SigninPanel.prototype.oncancel = function (e) {
 
   debug('sigin canceled');
 };
-
-

--- a/lib/mode-signup/index.js
+++ b/lib/mode-signup/index.js
@@ -14,6 +14,7 @@ var buttonTmpl = require('../html/zocial-button.ejs');
 var regex = require('../regex');
 var gravatar = require('../gravatar');
 var PasswordStrength = require('../password-strength');
+var ValidationError = require('../errors/ValidationError');
 var empty = regex.empty;
 var email_parser = regex.email_parser;
 var slice = Array.prototype.slice;
@@ -173,6 +174,10 @@ SignupPanel.prototype.bindAll = function() {
 
 SignupPanel.prototype.onzocialclick = function(e) {
   stop(e);
+  var target = e.currentTarget || e.delegateTarget || e.target || e;
+  var strategyName = typeof target === 'string' ? target : target.getAttribute('data-strategy');
+
+  this.widget.emit('signup submit', this.widget.options, { provider: strategyName });
   this.widget._signinSocial(e, null, null, this);
 };
 
@@ -259,7 +264,9 @@ SignupPanel.prototype.submit = function() {
 
   widget._loadingPanel({ mode: 'signup' });
 
-  debug('signin up');
+  debug('signup submit');
+  widget.emit('signup submit', widget.options);
+
   widget.$auth0.signup({
     connection: connection.name,
     username:   (options._isUsernameRequired()) ? username : email,
@@ -280,9 +287,15 @@ SignupPanel.prototype.submit = function() {
       return debug('this signup was triggered from another node instance', arguments);
     }
 
+    // Emit "signup success" for all non error cases.
+    if (!err) { widget.emit('signup success'); }
+
     if (!err && widget.options.loginAfterSignup) { return widget._signinWithAuth0(panel); }
     if (!err && 'function' === typeof callback) { return callback.apply(widget, args), widget.hide(); }
     if (!err) { return widget.hide(); }
+
+    debug('Error on signup: %o', err);
+    widget.emit('signup error', err);
 
     // display signup again
     widget.setPanel(panel);
@@ -359,11 +372,13 @@ SignupPanel.prototype.valid = function() {
   widget._focusError();
 
   if (email_empty) {
+    widget.emit('signup error', new ValidationError('email empty'));
     widget._focusError(email_input);
     ok = false;
   }
 
   if (!email_parsed && !email_empty) {
+    widget.emit('signup error', new ValidationError('email invalid'));
     widget._focusError(email_input, widget.options.i18n.t('invalid'));
     ok = false;
   }
@@ -374,16 +389,19 @@ SignupPanel.prototype.valid = function() {
     var username_parsed = username_parser.exec(username_input.val().toLowerCase());
 
     if (username_empty) {
+      widget.emit('signup error', new ValidationError('username empty'));
       widget._focusError(username_input);
       ok = false;
     }
     if (!username_parsed && !username_empty) {
+      widget.emit('signup error', new ValidationError('username invalid'));
       widget._focusError(username_input, widget.options.i18n.t('invalid'));
       ok = false;
     }
   }
 
   if (password_empty) {
+    widget.emit('signup error', new ValidationError('password empty'));
     widget._focusError(password_input);
     ok = false;
   }

--- a/support/development-demo/index.html
+++ b/support/development-demo/index.html
@@ -19,7 +19,7 @@
           <div class="navbar-header">
             <h1 class="navbar-brand">
               <a href="/">
-                <img src="//styleguide.auth0.com/img/auth0_logo.png"/>  
+                <img src="//styleguide.auth0.com/img/auth0_logo.png"/>
               </a>
             </h1>
           </div>
@@ -454,36 +454,19 @@
 
           function trackEvents(widget, namespace) {
             var name = namespace || 'widget';
-            widget.on('shown', function() {
-              console.log('%s shown', name);
+
+            ['signup', 'signin', 'reset', 'kerberos', 'loggedin'].forEach(function (mode) {
+              ['ready', 'error', 'success', 'submit'].forEach(function (ev) {
+                var event_name = mode + ' ' + ev;
+                widget.on(event_name, function() {
+                  console.log('Event: "' + event_name + '" fired!');
+                })
+              });
             });
-            widget.on('loading ready', function() {
-              console.log('%s loading ready', name);
-            });
-            widget.on('ready', function() {
-              console.log('%s ready', name);
-            });
-            widget.on('hidden', function() {
-              console.log('%s hidden', name);
-            });
-            widget.on('signin ready', function() {
-              console.log('%s signin ready', name);
-            });
-            widget.on('signin submit', function(options, context) {
-              console.log('%s signin submit. context: %s', name, context.email);
-            });
-            widget.on('signup ready', function() {
-              console.log('%s signup ready', name);
-            });
-            widget.on('reset ready', function() {
-              console.log('%s reset ready', name);
-            });
-            widget.on('loggedin ready', function() {
-              console.log('%s loggedin ready', name);
-            });
-            widget.on('kerberos ready', function() {
-              console.log('%s loggedin ready', name);
-            });
+
+            widget.on('error shown', function() {
+              console.log('Event: "error shown" fired!');
+            })
           }
       });
 

--- a/test/reset.tests.js
+++ b/test/reset.tests.js
@@ -223,4 +223,156 @@ describe('reset', function () {
     });
   });
 
+  describe('Events', function() {
+    it('should fire up an submit event on submit', function(done) {
+        var auth0 = this.widget;
+        var email = 'pepo@example.com';
+        var password = '12345';
+
+        this.client.changePassword = function() {};
+
+        auth0
+        .once('reset submit', function(opts) {
+          expect(opts).to.not.be(undefined);
+          done();
+        })
+        .once('reset ready', function() {
+          $('#a0-reset_easy_email').val(email);
+          $('#a0-reset_easy_password').val(password);
+          $('#a0-reset_easy_repeat_password').val(password);
+
+          bean.fire($('.a0-reset form')[0], 'submit');
+        })
+        .showReset(this.options);
+    });
+
+    it('should fire up an error event on password missmatch', function(done) {
+        var auth0 = this.widget;
+        var email = 'pepo@example.com';
+        var password = '12345';
+
+        this.client.changePassword = function() {};
+
+        auth0
+        .once('reset error', function(err) {
+          expect(err.message).to.be('password missmatch');
+          done();
+        })
+        .once('reset ready', function() {
+          $('#a0-reset_easy_email').val(email);
+          $('#a0-reset_easy_password').val(password);
+          $('#a0-reset_easy_repeat_password').val(password + 'invalid');
+
+          bean.fire($('.a0-reset form')[0], 'submit');
+        })
+        .showReset(this.options);
+    });
+
+    it('should fire up an error event on password empty', function(done) {
+        var auth0 = this.widget;
+        var email = 'pepo@example.com';
+        var password = '12345';
+
+        this.client.changePassword = function() {};
+
+        auth0
+        .once('reset error', function(err) {
+          expect(err.message).to.be('password empty');
+          done();
+        })
+        .once('reset ready', function() {
+          $('#a0-reset_easy_email').val(email);
+          $('#a0-reset_easy_repeat_password').val(password + 'invalid');
+
+          bean.fire($('.a0-reset form')[0], 'submit');
+        })
+        .showReset(this.options);
+    });
+
+    it('should fire up an error event on repeat password empty', function(done) {
+        var auth0 = this.widget;
+        var email = 'pepo@example.com';
+        var password = '12345';
+
+        this.client.changePassword = function() {};
+
+        auth0
+        .once('reset error', function(err) {
+          expect(err.message).to.be('repeat password empty');
+          done();
+        })
+        .once('reset ready', function() {
+          $('#a0-reset_easy_email').val(email);
+          $('#a0-reset_easy_password').val(password);
+
+          bean.fire($('.a0-reset form')[0], 'submit');
+        })
+        .showReset(this.options);
+    });
+
+    it('should fire up an error event on email invalid', function(done) {
+        var auth0 = this.widget;
+        var email = 'pepo!&&*example.com';
+        var password = '12345';
+
+        auth0
+        .once('reset error', function(err) {
+          expect(err.message).to.be('email invalid');
+          done();
+        })
+        .once('reset ready', function() {
+          $('#a0-reset_easy_email').val(email);
+          $('#a0-reset_easy_password').val(password);
+          $('#a0-reset_easy_repeat_password').val(password);
+
+          bean.fire($('.a0-reset form')[0], 'submit');
+        })
+        .showReset(this.options);
+    });
+
+    it('should fire up an error event on username empty', function (done) {
+      var auth0 = this.widget;
+      var email = 'pepo@example.com';
+      var password = '12345';
+
+      this.options._isUsernameRequired = function() { return true; };
+
+      auth0
+      .once('reset error', function(err) {
+        expect(err.message).to.be('username empty');
+        done();
+      })
+      .once('reset ready', function() {
+        $('#a0-reset_easy_password').val(password);
+        $('#a0-reset_easy_repeat_password').val(password);
+
+        bean.fire($('.a0-reset form')[0], 'submit');
+      })
+      .showReset(this.options);
+    });
+
+    it('should fire up an error event on username invalid', function (done) {
+      var auth0 = this.widget;
+      var username = '1.1.1.1';
+      var password = '12345';
+
+      this.options._isUsernameRequired = function() { return true; };
+
+      auth0
+      .once('reset error', function(err) {
+        expect(err.message).to.be('username invalid');
+        done();
+      })
+      .once('reset ready', function() {
+        $('#a0-reset_easy_email').val(username);
+        $('#a0-reset_easy_password').val(password);
+        $('#a0-reset_easy_repeat_password').val(password);
+
+        bean.fire($('.a0-reset form')[0], 'submit');
+      })
+      .showReset(this.options);
+    });
+
+  });
+
 });

--- a/test/signup.tests.js
+++ b/test/signup.tests.js
@@ -243,4 +243,140 @@ describe('sign up', function () {
     .showSignup(this.options);
   });
 
+  describe('signup events', function() {
+    it('should fire up submit event when the form is submitted', function (done) {
+      var auth0 = this.auth0;
+      auth0
+      .once('signup ready', function() {
+        $('#a0-signup_easy_email').val('tehsis@gmail.com');
+        $('#a0-signup_easy_password').val('123');
+
+        bean.fire($('.a0-signup form')[0], 'submit');
+      })
+      .once('signup submit', function(options) {
+        expect(options).not.to.be(undefined);
+        done();
+      })
+      .showSignup(this.options);
+  });
+
+    it('should fire up error event when email is invalid', function (done) {
+      var auth0 = this.auth0;
+      auth0
+      .once('signup ready', function() {
+        $('#a0-signup_easy_email').val('tehsis');
+        $('#a0-signup_easy_password').val('123');
+
+        bean.fire($('.a0-signup form')[0], 'submit');
+      })
+      .once('signup error', function(err) {
+        expect(err.message).to.be('email invalid');
+        done();
+      })
+      .showSignup(this.options);
+    });
+
+    it('should fire up error event when email is empty', function (done) {
+      var auth0 = this.auth0;
+      auth0
+      .once('signup ready', function() {
+        bean.fire($('.a0-signup form')[0], 'submit');
+      })
+      .once('signup error', function(err) {
+        expect(err.message).to.be('email empty');
+        done();
+      })
+      .showSignup(this.options);
+    });
+
+    it('should fire up error event when password is empty', function (done) {
+      var auth0 = this.auth0;
+      auth0
+      .once('signup ready', function() {
+        $('#a0-signup_easy_email').val('tehsis@gmail.com');
+
+        bean.fire($('.a0-signup form')[0], 'submit');
+      })
+      .once('signup error', function(err) {
+        expect(err.message).to.be('password empty');
+        done();
+      })
+      .showSignup(this.options);
+    });
+
+    it('should fire up error event when username is required and is empty', function (done) {
+      this.options._isUsernameRequired = function() { return true; };
+      var auth0 = this.auth0;
+      auth0
+      .once('signup ready', function() {
+        $('#a0-signup_easy_email').val('tehsis@gmail.com');
+        $('#a0-signup_easy_password').val('123');
+
+        bean.fire($('.a0-signup form')[0], 'submit');
+      })
+      .once('signup error', function(err) {
+        expect(err.message).to.be('username empty');
+        done();
+      })
+      .showSignup(this.options);
+    });
+
+    it('should fire up error event when username is required and is invalid', function (done) {
+      this.options._isUsernameRequired = function() { return true; };
+      var auth0 = this.auth0;
+      auth0
+      .once('signup ready', function() {
+        $('#a0-signup_easy_username').val('sdfasf@$$--');
+        $('#a0-signup_easy_email').val('tehsis@gmail.com');
+        $('#a0-signup_easy_password').val('123');
+
+        bean.fire($('.a0-signup form')[0], 'submit');
+      })
+      .once('signup error', function(err) {
+        expect(err.message).to.be('username invalid');
+        done();
+      })
+      .showSignup(this.options);
+    });
+
+    it('should fire up success event if there was no error', function (done) {
+      var auth0 = this.auth0;
+
+      var callback;
+
+      this.options.loginAfterSignup = false;
+
+      auth0.$auth0.signup = function(options, cb) {
+        callback = cb;
+        callback();
+      };
+
+      auth0
+      .once('signup ready', function() {
+        $('#a0-signup_easy_email').val('john@fabrikam.com');
+        $('#a0-signup_easy_password').val('123');
+
+        bean.fire($('.a0-signup form')[0], 'submit');
+      })
+      .once('signup success', function() {
+        expect(callback).to.not.throwException();
+        done();
+      })
+      .showSignup(this.options);
+    });
+
+    it('should fireup an emit event when signing up with social connection', function (done) {
+      this.auth0.$auth0.login = function () {};
+
+      this.auth0
+      .once('signup submit', function(opts) {
+        expect(opts).to.not.be(undefined);
+        done();
+      })
+      .once('signup ready', function() {
+        bean.fire($('.a0-signup [data-strategy="google-oauth2"]')[0], 'click');
+      })
+      .showSignup(this.options);
+    });
+  });
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -232,6 +232,31 @@ describe('Auth0Lock', function () {
     });
   });
 
+  it('should fireup loggedin submit on submit in loggedin mode', function (done) {
+    client.getSSOData = function (withAd, callback) {
+      callback(null, {
+        sso: true,
+        lastUsedUsername: 'john@gmail.com',
+        lastUsedConnection: { strategy: 'google-oauth2', name: 'google-oauth2' }
+      });
+    };
+
+    client.login = function () {};
+
+    widget
+    .once('loggedin submit', function(opts) {
+      expect(opts).to.not.be(undefined);
+      done();
+    })
+    .once('ready', function () {
+      bean.fire($('.a0-googleplus')[0], 'click');
+    })
+    .show({
+      callbackURL: callbackURL,
+      responseType: 'token'
+    });
+  });
+
   describe('When assetsUrl option is not specified', function () {
     beforeEach(function() {
       this.widget = new Auth0Lock(clientID, 'abc.contoso.com');
@@ -500,6 +525,76 @@ describe('Auth0Lock', function () {
       .show({ callbackURL: callbackURL, responseType: 'token', authParams: { state: 'foo' }});
     });
 
+    it('should emit signin error event when email is empty', function (done) {
+      widget
+      .once('ready', function () {
+        $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-password input').val('xyz');
+        $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-action button.a0-primary').trigger('click');
+      })
+      .on('signin error', function (err) {
+        expect(err.message).to.be('email empty');
+        done();
+      })
+      .show({ callbackURL: callbackURL, responseType: 'token', authParams: { state: 'foo' }});
+    });
+
+    it('should emit signin error event when email is invalid', function (done) {
+      widget
+      .once('ready', function () {
+        $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-email input').val('john.@#$@fabrikam.com');
+        $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-password input').val('xyz');
+        $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-action button.a0-primary').trigger('click');
+      })
+      .on('signin error', function (err) {
+        expect(err.message).to.be('email invalid');
+        done();
+      })
+      .show({ callbackURL: callbackURL, responseType: 'token', authParams: { state: 'foo' }});
+    });
+
+    it('should emit signin error event when password is empty', function (done) {
+      widget
+      .once('ready', function () {
+        $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-email input').val('john@fabrikam.com');
+        $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-action button.a0-primary').trigger('click');
+      })
+      .on('signin error', function (err) {
+        expect(err.message).to.be('password empty');
+        done();
+      })
+      .show({ callbackURL: callbackURL, responseType: 'token', authParams: { state: 'foo' }});
+    });
+
+    it('should emit submit envent when logging with social connections', function (done) {
+      client.login = function () {};
+
+      widget
+      .once('signin submit', function(opts) {
+        expect(opts).to.not.be(undefined);
+        done();
+      })
+      .once('ready', function () {
+        bean.fire($('#a0-lock .a0-notloggedin .a0-iconlist [data-strategy="google-oauth2"]')[0], 'click');
+      })
+      .show({
+        callbackURL: callbackURL,
+        responseType: 'token'
+      });
+    });
+
+    it('should emit signin error event when password is empty', function (done) {
+      widget
+      .once('ready', function () {
+        $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-email input').val('john@fabrikam.com');
+        $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-action button.a0-primary').trigger('click');
+      })
+      .on('signin error', function (err) {
+        expect(err.message).to.be('password empty');
+        done();
+      })
+      .show({ callbackURL: callbackURL, responseType: 'token', authParams: { state: 'foo' }});
+    });
+
     describe('when requires_username is enabled', function() {
 
       beforeEach(function() {
@@ -542,6 +637,26 @@ describe('Auth0Lock', function () {
           expect($('.a0-email .a0-error-input')).to.not.be.empty();
           expect($('.a0-email .a0-error-input .a0-error-message')).to.not.be.empty();
           expect($('.a0-error-message').text()).to.equal(auth0.options.i18n.t('invalid'));
+          done();
+        })
+        .showSignin(this.options);
+      });
+
+      it('should emit signin error event when username is invalid', function (done) {
+        var auth0 = widget;
+        var username = '1.1.1.1';
+        var password = '12345';
+
+        auth0
+        .once('signin ready', function() {
+          $('#a0-signin_easy_email').val(username);
+          $('#a0-signin_easy_password').val(password);
+          $('#a0-signin_easy_repeat_password').val(password);
+
+          bean.fire($('.a0-signin form')[0], 'submit');
+        })
+        .once('signin error', function(err) {
+          expect(err.message).to.be('username invalid');
           done();
         })
         .showSignin(this.options);


### PR DESCRIPTION
### Briefing

This PR completes the lifecycle of events for our modes: `signin`, `signup`, `reset`.

- Close auth0/lock#82

The states added are: `ready`, `submit`, `success` and `error`.

Which will generate events like

```js
lock.on('signup ready', function () {})
lock.on('signup submit', function () {})
lock.on('signup success', function () {})
lock.on('signup error', function () {})

// ... same for signin and reset
```
