### PR TITLE
Add close event for when the user clicks the X button

### DIFF
--- a/index.js
+++ b/index.js
@@ -1305,6 +1305,7 @@ Auth0Lock.prototype.getProfile = function (token, callback) {
 
 Auth0Lock.prototype.oncloseclick = function(e) {
   stop(e);
+  this.emit('close');
   this.hide();
 };
 


### PR DESCRIPTION
\### Briefing

It has come to our knowledge the need of users to establish when the lock was hidden by it's own action or by a close action.

This PR adds a `close` event triggered when the X is clicked by the users. It also completes some of the events added for auth0/lock#82 completing a lifecycle.

- Close auth0/lock#188