### PR TITLE
Add support for custom error messages from rules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -307,7 +307,7 @@ module.exports = function (grunt) {
   grunt.registerTask('demo',          ['less:demo', 'connect:demo', 'build', 'watch']);
   grunt.registerTask('demo-https',    ['less:demo', 'connect:demo-https', 'build', 'watch']);
 
-  grunt.registerTask('dev',           ['connect:test', 'build', 'watch']);
+  grunt.registerTask('dev',           ['less:demo', 'connect:test', 'build', 'watch']);
   grunt.registerTask('integration',   ['exec:test-inception', 'exec:test-integration']);
   grunt.registerTask('phantom',       ['build', 'exec:test-inception', 'exec:test-phantom']);
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -27,6 +27,7 @@
     "returnUserLabel":             "Last time you signed in using...",
     "domainUserLabel":             "You are connected from your corporate network...",
     "wrongEmailPasswordErrorText": "Wrong email or password.",
+    "unauthorizedErrorText":       "Access denied.",
     "or":                          "... or log in using",
     "loadingMessage":              "Logging In with {connection}...",
     "popupCredentials":            "Enter your credentials in the pop-up window",

--- a/index.js
+++ b/index.js
@@ -1242,6 +1242,12 @@ Auth0Lock.prototype._signinPopupNoRedirect = function (connectionName, popupCall
       self._showError(self.options.i18n.t('networkError'));
     } else if (err.status !== 401) {
       self._showError(self.options.i18n.t('signin:serverErrorText'));
+    } else if ('unauthorized' === err.code) {
+      // err.status => 401 && unauthorized from a rule
+      var message = (err.details && err.details.error_description) || '';
+      self._showError(message);
+      self._focusError(email_input);
+      self._focusError(password_input);
     } else {
       self._showError(self.options.i18n.t('signin:wrongEmailPasswordErrorText'));
       self._focusError(email_input);

--- a/index.js
+++ b/index.js
@@ -1240,18 +1240,16 @@ Auth0Lock.prototype._signinPopupNoRedirect = function (connectionName, popupCall
       self._showError(self.options.i18n.t('signin:userConsentFailed'));
     } else if (err.status === 0) {
       self._showError(self.options.i18n.t('networkError'));
-    } else if ('unauthorized' === err.code) {
-      // From rules, we sometimes get the err.status = 401... but sometimes we don't
-      // That is an auth0-server error. So, for now, we consuder err.code == 'unauthorized'
-      // Enough to asume we had an error
-      var message = (err.details && err.details.error_description) || '';
-      self._showError(message);
-      self._focusError(email_input);
-      self._focusError(password_input);
     } else if (err.status !== 401) {
       self._showError(self.options.i18n.t('signin:serverErrorText'));
+    } else if ('unauthorized' === err.code) {
+      var message = self.options.i18n.t('signin:unauthorizedErrorText');
+      self._showError((err.details && err.details.error_description) || message);
+      self._focusError(email_input);
+      self._focusError(password_input);
     } else {
-      self._showError(self.options.i18n.t('signin:wrongEmailPasswordErrorText'));
+      var message = self.options.i18n.t('signin:wrongEmailPasswordErrorText');
+      self._showError(message);
       self._focusError(email_input);
       self._focusError(password_input);
     }

--- a/index.js
+++ b/index.js
@@ -1240,14 +1240,16 @@ Auth0Lock.prototype._signinPopupNoRedirect = function (connectionName, popupCall
       self._showError(self.options.i18n.t('signin:userConsentFailed'));
     } else if (err.status === 0) {
       self._showError(self.options.i18n.t('networkError'));
-    } else if (err.status !== 401) {
-      self._showError(self.options.i18n.t('signin:serverErrorText'));
     } else if ('unauthorized' === err.code) {
-      // err.status => 401 && unauthorized from a rule
+      // From rules, we sometimes get the err.status = 401... but sometimes we don't
+      // That is an auth0-server error. So, for now, we consuder err.code == 'unauthorized'
+      // Enough to asume we had an error
       var message = (err.details && err.details.error_description) || '';
       self._showError(message);
       self._focusError(email_input);
       self._focusError(password_input);
+    } else if (err.status !== 401) {
+      self._showError(self.options.i18n.t('signin:serverErrorText'));
     } else {
       self._showError(self.options.i18n.t('signin:wrongEmailPasswordErrorText'));
       self._focusError(email_input);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",
   "dependencies": {
-    "auth0-js": "~6.4.2",
+    "auth0-js": "~6.6.0",
     "bean": "~1.0.4",
     "blueimp-md5": "^1.1.0",
     "bonzo": "^1.3.6",

--- a/support/development-demo/index.html
+++ b/support/development-demo/index.html
@@ -132,8 +132,8 @@
               domain: 'mdocs.auth0.com'
             },
             ruleFail: {
-              clientID: 'jUfYTdrYO6whDXiqqnM2EuB479Y6UNEO',
-              domain: 'douce1.myauth0.com'
+              clientID: 'AEh581bPJXrb3yYJwwAYxTJxiPCrfBEN',
+              domain: 'douce.auth0.com'
             },
             free: {
               clientID: 'zq4ImejULuvrPaazzFhttRgRUhCg4X3o',
@@ -426,7 +426,7 @@
             trackEvents(widget);
             widget.show({
               sso: false,
-              connections: ['always-fail-test']
+              connections: ['ExistentDatabase']
             }, function (err, profile, id_token) {
               debugger;
             });

--- a/support/development-demo/index.html
+++ b/support/development-demo/index.html
@@ -425,9 +425,10 @@
 
             trackEvents(widget);
             widget.show({
-              sso: false,
+              // sso: false,
+              // connections: ['twitter']
               connections: ['ExistentDatabase']
-            }, function (err, profile, id_token) {
+            }, function (err) {
               debugger;
             });
           });

--- a/support/development-demo/index.html
+++ b/support/development-demo/index.html
@@ -93,6 +93,7 @@
               <li><a id="login-button-inside-container"><i></i>Login (inside a DIV)</a></li>
               <li><a id="login-button-all"><i></i>Login (all languages)</a></li>
               <li><a id="signup-button-footer-text"><i></i>Show SignUp (footer text)</a></li>
+              <li><a id="login-rule-fail-message"><i></i>Login fail with rule message</a></li>
             </ul>
           </div>
         </div>
@@ -129,6 +130,10 @@
             mdocs: {
               clientID: 'yKJO1ckwuY1X8gPEhTRfhJXyObfiLxih',
               domain: 'mdocs.auth0.com'
+            },
+            ruleFail: {
+              clientID: 'jUfYTdrYO6whDXiqqnM2EuB479Y6UNEO',
+              domain: 'douce1.myauth0.com'
             },
             free: {
               clientID: 'zq4ImejULuvrPaazzFhttRgRUhCg4X3o',
@@ -409,6 +414,21 @@
               callbackURL: window.location.href,
               responseType: 'token',
               dict: dict
+            });
+          });
+
+          $('#login-rule-fail-message').on('click', function() {
+            var cid = credentials.ruleFail.clientID;
+            var domain = credentials.ruleFail.domain;
+
+            var widget = new Auth0Lock(cid, domain);
+
+            trackEvents(widget);
+            widget.show({
+              sso: false,
+              connections: ['always-fail-test']
+            }, function (err, profile, id_token) {
+              debugger;
             });
           });
 

--- a/support/development-demo/index.html
+++ b/support/development-demo/index.html
@@ -132,8 +132,8 @@
               domain: 'mdocs.auth0.com'
             },
             ruleFail: {
-              clientID: 'AEh581bPJXrb3yYJwwAYxTJxiPCrfBEN',
-              domain: 'douce.auth0.com'
+              clientID: 'bS4Htp89Y8vyYREFqqo980Bj4OlWKP2T',
+              domain: 'auth0-tests-lock.auth0.com'
             },
             free: {
               clientID: 'zq4ImejULuvrPaazzFhttRgRUhCg4X3o',
@@ -425,11 +425,10 @@
 
             trackEvents(widget);
             widget.show({
-              // sso: false,
               // connections: ['twitter']
-              connections: ['ExistentDatabase']
-            }, function (err) {
-              debugger;
+              connections: ['acme']
+            }, function (err, profile, id_token) {
+
             });
           });
 


### PR DESCRIPTION
- Add a new dict option `signin:unauthorizedErrorText` defaulting to `Access denied.`. Thanks @pose
- Verified custom error messages from Database connections
- Verified custom error messages from Social connections. Thanks @siacomuzzi for the server implementation