### PR TITLE
Improve webpack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you are targeting mobile audiences, it's recommended that you add:
 
 ### Browserify
 
-If you are using browserify to build your project, you will need to add the following transformations required by Auth0 Lock:
+If you are using Browserify to build your project, you will need to add the following transformations required by Auth0 Lock:
 
 ``` json
 {
@@ -69,6 +69,20 @@ If you are using browserify to build your project, you will need to add the foll
 }
 ```
 
+### webpack
+
+If you are using webpack, you will need the following loaders:
+
+```js
+[
+  {
+    test: /node_modules\/auth0-lock\/.*\.js$/,
+    loaders: 'transform?brfs!transform?packageify'
+  },
+  {test: /\.ejs$/, loader: 'transform?ejsify'},
+  {test: /\.json$/, loader: 'json'}
+]
+```
 
 ## Documentation
 You can find the full documentation for Lock on the [Auth0 docs site](https://auth0.com/docs/libraries/lock).

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -10,13 +10,14 @@ var config = {
   },
   module: {
     loaders: [{
-      test: /\.js$/,
+      test: /node_modules\/auth0-lock\/.*\.js$/,
       loaders: ['transform?brfs', 'transform?packageify']
     }, {
+      // ejs-compiled-loader will not work per bazilio91/ejs-compiled-loader#6.
       test: /\.ejs$/,
       loader: 'transform?ejsify'
     }, {
-      test: /.json$/,
+      test: /\.json$/,
       loader: 'json'
     }]
   }


### PR DESCRIPTION
I actually didn't find the webpack instructions because I assumed there weren't any after I scrolled past the Browserify section, and ended up wasting a little bit of time.

This improves the organization of that section of the README a bit and will hopefully prevent other people from making the same mistake in the future.

This also improves the webpack example a little bit by restricting the scope of the transforms to just the `auth0-lock` package.