### PR TITLE
Use cacheable loaders in webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ If you are using webpack, you will need the following loaders:
 [
   {
     test: /node_modules\/auth0-lock\/.*\.js$/,
-    loaders: 'transform?brfs!transform?packageify'
+    loaders: 'transform/cacheable?brfs!transform/cacheable?packageify'
   },
-  {test: /\.ejs$/, loader: 'transform?ejsify'},
+  {test: /\.ejs$/, loader: 'ejs-compiled'},
   {test: /\.json$/, loader: 'json'}
 ]
 ```

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "auth0-lock": "^7.5.5",
     "brfs": "^1.4.0",
-    "ejsify": "^1.0.0",
+    "ejs-compiled-loader": "^2.0.4",
     "jquery": "^2.1.4",
     "json-loader": "^0.5.2",
     "packageify": "^0.2.2",

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -11,11 +11,10 @@ var config = {
   module: {
     loaders: [{
       test: /node_modules\/auth0-lock\/.*\.js$/,
-      loaders: ['transform?brfs', 'transform?packageify']
+      loaders: ['transform/cacheable?brfs', 'transform/cacheable?packageify']
     }, {
-      // ejs-compiled-loader will not work per bazilio91/ejs-compiled-loader#6.
       test: /\.ejs$/,
-      loader: 'transform?ejsify'
+      loader: 'ejs-compiled',
     }, {
       test: /\.json$/,
       loader: 'json'


### PR DESCRIPTION
This speeds up incremental builds in webpack for users a bit; previously the files were not cacheable, and had to be re-built by webpack on incremental builds even if they didn't change.