### PR TITLE
Proposal: Distribute bundle on npm as well

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,8 +15,5 @@ results
 npm-debug.log
 node_modules
 
-#do not include bundle
-build
-
 # other paths to ignore
 bin

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "auth0-lock",
   "version": "7.9.5",
   "description": "Auth0 Lock",
+  "browser": "build/auth0-lock.js",
   "main": "./index.js",
   "keywords": [
     "auth0",


### PR DESCRIPTION
Don't merge this as is - I just wanted to drop this PR as an example of the non-documentation changes involved.

It doesn't seem like there's a meaningful reason to distribute this on NPM as source rather than as a built bundle.

- There don't seem to be any hooks other than the main import, so I'm not doing any partial imports anyway
- It significantly complicates building by requiring users to add extra transforms for Browserify and extra loaders for webpack
- Potential additional minification benefits are not material; besides, at > 0.5 MB, anybody who really cares is going to be using code splitting on this package anyway

If you distribute this as the bundle, then Browserify and webpack users can drop all the extra build steps.

Full disclosure, on webpack doing this will result in the following unavoidable warning:
```
WARNING in ./~/auth0-lock/build/auth0-lock.js
Critical dependencies:
1:113-120 This seems to be a pre-built javascript file. Though this is possible, it's not recommended. Try to require the original source to get better results.
 @ ./~/auth0-lock/build/auth0-lock.js 1:113-120
```

This is less of an issue to me than adding a bunch of extra loaders that don't tie into my app at all.

Also, for actual distribution you'd probably want a NPM-specific bundle that doesn't bundle in e.g. auth0.js and your other dependencies.