### PR TITLE
Don't show last login for unknown connections

### DIFF
--- a/lib/options-manager/index.js
+++ b/lib/options-manager/index.js
@@ -552,6 +552,11 @@ OptionsManager.prototype._shouldShowLastLogin = function() {
     return false;
   }
 
+  // Don't show last login if we don't know the strategy
+  if (connectionStrategy && !this.$strategies[connectionStrategy]) {
+    return false;
+  }
+
   var shouldShow = $ssoData
     && $ssoData.sso
     && $ssoData.lastUsedConnection


### PR DESCRIPTION
When the connection is unknown and SSO is enabled `LoggednPanel` is displayed without any buttons, as reported in #244.