### PR TITLE
Fix webpack example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,17 +71,19 @@ If you are using Browserify to build your project, you will need to add the foll
 
 ### webpack
 
-If you are using webpack, you will need the following loaders:
+If you are using webpack, you will need to install loaders (`$ npm install --save brfs ejs-compiled-loader json-loader packageify transform-loader`) and then use them in your `webpack.config.js` file:
 
 ```js
-[
-  {
-    test: /node_modules\/auth0-lock\/.*\.js$/,
-    loaders: 'transform/cacheable?brfs!transform/cacheable?packageify'
-  },
-  {test: /\.ejs$/, loader: 'ejs-compiled'},
-  {test: /\.json$/, loader: 'json'}
-]
+loaders: [{
+  test: /node_modules\/auth0-lock\/.*\.js$/,
+  loaders: ['transform-loader/cacheable?brfs', 'transform-loader/cacheable?packageify']
+}, {
+  test: /\.ejs$/,
+  loader: 'ejs-compiled-loader',
+}, {
+  test: /\.json$/,
+  loader: 'json-loader'
+}]
 ```
 
 ## Documentation

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -11,13 +11,13 @@ var config = {
   module: {
     loaders: [{
       test: /node_modules\/auth0-lock\/.*\.js$/,
-      loaders: ['transform/cacheable?brfs', 'transform/cacheable?packageify']
+      loaders: ['transform-loader/cacheable?brfs', 'transform-loader/cacheable?packageify']
     }, {
       test: /\.ejs$/,
-      loader: 'ejs-compiled',
+      loader: 'ejs-compiled-loader',
     }, {
       test: /\.json$/,
-      loader: 'json'
+      loader: 'json-loader'
     }]
   }
 };


### PR DESCRIPTION
This is a minor fix to the webpack example (and the corresponding doc in the project readme) that makes it more copy-pastable into peoples' existing projects.

For example, the previous example would not work if a project also had [json](https://www.npmjs.com/package/json) in their `node_modules` directory (which is a different module than [json-loader](https://www.npmjs.com/package/json-loader)).

This is a great project, thanks for making it available! :smile: 