### PR TITLE
Add reference sigin:userBlockedErrorText translation

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -29,6 +29,7 @@
     "wrongEmailPasswordErrorText":      "Wrong email or password.",
     "passwordChangeRequiredErrorText":  "You need to update your password because this is the first time you are signing in, or because your password has expired.",
     "unauthorizedErrorText":            "Access denied.",
+    "userBlockedErrorText":             "",
     "or":                               "... or log in using",
     "loadingMessage":                   "Logging In with {connection}...",
     "popupCredentials":                 "Enter your credentials in the pop-up window",


### PR DESCRIPTION
Commit b94f24ad047e4485ed1decbcf2c6a4f762281aec introduced a new translation `sigin:userBlockedErrorText` and by convention we add it to the reference `en` dictionary. It was intentionally left blank to show the message returned by the API by default.