### PR TITLE
Improve error handling when logging in automatically

### DIFF
--- a/index.js
+++ b/index.js
@@ -585,7 +585,7 @@ Auth0Lock.prototype.display = function(options, callback) {
       }
 
       // otherwise, just show signin
-      this._signinPanel(this.options, callback);
+      this._signinPanel();
     }
 
     if ('signup' === this.options.mode) {

--- a/index.js
+++ b/index.js
@@ -673,7 +673,7 @@ Auth0Lock.prototype.initialize = function(done) {
  */
 
 Auth0Lock.prototype._signinPanel = function (options) {
-  var panel = SigninPanel(this, { options: options || {} });
+  var panel = SigninPanel(this, options || {});
 
   // XXX: future Panel API placeholder
   // panel.on('submit', this.setLoadingMode);
@@ -813,6 +813,9 @@ Auth0Lock.prototype._kerberosPanel = function (options) {
 Auth0Lock.prototype.setPanel = function(panel, name) {
   var el = 'function' === typeof panel.render ? panel.render() : panel;
   var pname = 'function' === typeof panel.render ? panel.name : (name || 'signin');
+
+  // Remember current panel
+  this.$panel = panel;
 
   //Removes error messages on new views.
   this._showError();
@@ -1159,6 +1162,11 @@ Auth0Lock.prototype._signinWithAuth0 = function (panel, connection) {
       // password_input.get(0).setSelectionRange(0, password_input.val().length);
     }
   });
+};
+
+Auth0Lock.prototype._autoSignin = function(email, password) {
+  this._signinPanel({initialEmail: email, initialPassword: password});
+  this._signinWithAuth0(this.$panel);
 };
 
 /**

--- a/lib/mode-kerberos/index.js
+++ b/lib/mode-kerberos/index.js
@@ -149,6 +149,6 @@ KerberosPanel.prototype.bindAll = function() {
     // no need to check other panels since
     // no reset nor signup modes allow for
     // return user experience...
-    widget._signinPanel(self.options);
+    widget._signinPanel();
   });
 }

--- a/lib/mode-loggedin/index.js
+++ b/lib/mode-loggedin/index.js
@@ -162,7 +162,7 @@ LoggedinPanel.prototype.bindAll = function() {
     // no reset nor signup modes allow for
     // return user experience...
     gravatar(widget, '');
-    widget._signinPanel(self.options);
+    widget._signinPanel();
   });
 
 };

--- a/lib/mode-reset/index.js
+++ b/lib/mode-reset/index.js
@@ -303,7 +303,7 @@ ResetPanel.prototype.submit = function () {
 
     if (!err) {
       email_input.val('');
-      widget._signinPanel(panel.options);
+      widget._signinPanel();
       widget._showSuccess(widget.options.i18n.t('reset:successText'));
       widget.emit('reset success');
       return 'function' === typeof callback ? callback.apply(widget, args) : null;

--- a/lib/mode-signin/index.js
+++ b/lib/mode-signin/index.js
@@ -199,6 +199,14 @@ SigninPanel.prototype.bindAll = function() {
 
   this.query('input').val('');
 
+  if (this.options.initialEmail) {
+    this.query('.a0-email input').val(this.options.initialEmail);
+  }
+
+  if (this.options.initialPassword) {
+    this.query('.a0-password input').val(this.options.initialPassword);
+  }
+
   // show email, password, separator and button if there are enterprise/db connections
   var anyEnterpriseOrDbConnection = options._isThereAnyEnterpriseOrDbConnection();
   var anySocialConnection = options._isThereAnySocialConnection();

--- a/lib/mode-signup/index.js
+++ b/lib/mode-signup/index.js
@@ -305,7 +305,7 @@ SignupPanel.prototype.submit = function() {
     if (!err && widget.options.loginAfterSignup) {
       widget.$auth0._current_popup = panel.lock_safe_popup;
       panel.lock_safe_popup = null;
-      return widget._signinWithAuth0(panel);
+      return widget._autoSignin(email, password);
     }
 
     if (panel.lock_safe_popup) {


### PR DESCRIPTION
If something goes wrong during the login, the _sing in_ panel should be displayed instead of the _sign up panel_. See #257. 