### PR TITLE
Stop crashing when providing an unknown dict

### DIFF
--- a/lib/i18n/index.js
+++ b/lib/i18n/index.js
@@ -22,14 +22,13 @@ module.exports.dicts = dicts;
  */
 
 module.exports.getDict = function (lang) {
-
   if (!lang) {
     return new Dictionary(default_dict);
   }
 
   if ('string' === typeof lang) {
     var dict = dicts[lang] || dicts[lang.split('-')[0]];
-    return new Dictionary(dict);
+    return new Dictionary(dict || default_dict);
   }
 
   return new Dictionary(lang);


### PR DESCRIPTION
When a dict option was provided with a language that wasn't supported, the dictionary was `undefined` and the Lock crashed before opening.

This change falls back to the default dictionary when the dictionary for the specified language can't be found.