### PR TITLE
Consider stage subdomain when building assets url

### DIFF
--- a/index.js
+++ b/index.js
@@ -868,6 +868,9 @@ Auth0Lock.prototype.getAssetsUrl = function (assetsUrl, domain) {
   if (this.isAuth0Domain('au')) {
     return 'https://cdn.au.auth0.com/';
   }
+  if (this.isAuth0Domain('stage')) {
+    return 'https://cdn.stage.auth0.com/';
+  }
   if (this.isAuth0Domain()) {
     return 'https://cdn.auth0.com/';
   }


### PR DESCRIPTION
A new `stage` environment has been added and Lock is failing to obtain the client settings from the CDN because the assetsUrl is incorrect.