### PR TITLE
Electron support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1429,6 +1429,10 @@ Auth0Lock.prototype._clearPreviousPanel = function () {
   this._setPreviousPanel(null);
 };
 
+Auth0Lock._setOpenWindowFn = function(f) {
+  Auth0.prototype.openWindow = f;
+};
+
 /**
  * Private helpers
  */

--- a/lib/header/lock-header.ejs
+++ b/lib/header/lock-header.ejs
@@ -6,7 +6,7 @@
       </div>
 
       <div class="a0-avatar <%= !options.icon ? '' : 'a0-hide' %>">
-          <img class="a0-avatar-guest" src="//cdn.auth0.com/styleguide/1.0.0/img/badge.png">
+          <img class="a0-avatar-guest" src="<%= defaultIcon %>">
       </div>
 
       <div class="a0-bg-solid-color" style="background-color: <%= options.primaryColor %>"></div>
@@ -18,7 +18,7 @@
       </div>
 
       <div class="a0-avatar <%= !options.icon ? '' : 'a0-hide' %>">
-          <img class="a0-avatar-guest" src="//cdn.auth0.com/styleguide/1.0.0/img/badge.png">
+          <img class="a0-avatar-guest" src="<%= defaultIcon %>">
       </div>
 
       <h1><%= options.i18n.t('signin:title') %></h1>

--- a/lib/options-manager/index.js
+++ b/lib/options-manager/index.js
@@ -132,6 +132,11 @@ function OptionsManager(widget, options) {
     return !!el.style.length && (global.document.documentMode === undefined || global.document.documentMode > 9);
   })();
 
+  this.defaultIcon = "//cdn.auth0.com/styleguide/1.0.0/img/badge.png";
+  if (window.location.protocol && window.location.protocol === "file:") {
+    this.defaultIcon = "http:" + this.defaultIcon;
+  }
+
   // Delay options requiring $client configuration
   this.$widget.getClientConfiguration(bind(this._onclientloaded, this));
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",
   "dependencies": {
-    "auth0-js": "~6.7.4",
+    "auth0-js": "~6.8.0",
     "bean": "~1.0.4",
     "blueimp-md5": "^1.1.0",
     "bonzo": "^1.3.6",


### PR DESCRIPTION
Adds support for electron:
- Allows to override `Auth0.prototype.openWindow` (see the details in the PR linked above)
- Loads the default icon correctly when `window.location.protocol` is `"file:"`, which is the case for Electron.