### PR TITLE
Improved webpack example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,20 @@ If you are using Webpack, you will need to install loaders (`$ npm install --sav
 
 ```js
 loaders: [{
-  test: /node_modules\/auth0-lock\/.*\.js$/,
+  test: /\.js$/,
   loaders: [
     'transform-loader/cacheable?brfs',
     'transform-loader/cacheable?packageify'
-  ]
+  ],
+  include: 'node_modules/auth0-lock'
 }, {
-  test: /node_modules\/auth0-lock\/.*\.ejs$/,
-  loader: 'transform-loader/cacheable?ejsify'
+  test: /\.ejs$/,
+  loader: 'transform-loader/cacheable?ejsify',
+  include: 'node_modules/auth0-lock'
 }, {
   test: /\.json$/,
-  loader: 'json-loader'
+  loader: 'json-loader',
+  include: ['node_modules/auth0-js', 'node_modules/auth0-lock']
 }]
 ```
 

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -1,5 +1,11 @@
 'use strict';
-var buildPath = require('path').resolve(__dirname, 'public', 'build');
+
+var path = require('path');
+
+var buildPath = path.resolve(__dirname, 'public', 'build');
+var vendorPath = function(relativePath) {
+  return path.join(path.join(__dirname, 'node_modules'), relativePath);
+};
 
 var config = {
   context: __dirname,
@@ -10,16 +16,19 @@ var config = {
   },
   module: {
     loaders: [{
-      test: /node_modules\/auth0-lock\/.*\.js$/,
+      test: /\.js$/,
+      include: vendorPath('auth0-lock'),
       loaders: [
         'transform-loader/cacheable?brfs',
         'transform-loader/cacheable?packageify'
       ]
     }, {
-      test: /node_modules\/auth0-lock\/.*\.ejs$/,
+      test: /\.ejs$/,
+      include: vendorPath('auth0-lock'),
       loader: 'transform-loader/cacheable?ejsify'
     }, {
       test: /\.json$/,
+      include: [vendorPath('auth0-js'), vendorPath('auth0-lock')],
       loader: 'json-loader'
     }]
   }


### PR DESCRIPTION
* Make it work on Windows by changing matching rules to use a broader
   regex but narrower include path(s).
* Scope JSON loader to auth0 packages only so impact is minimal when
   there is other JSON files in a project which should not be processed.
* Bumped auth0-lock dependency to 8.x line to be more up-to-date.