### PR TITLE
Fix webpack bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ No special configuration is required if you are using Browserify to build your p
 
 ### Webpack
 
-If you are using Webpack, you will need to install loaders (`$ npm install --save brfs ejsify json-loader packageify transform-loader`) and then use them in your `webpack.config.js` file:
+If you are using Webpack, you will need to install loaders (`$ npm install --save json-loader transform-loader`) and then use them in your `webpack.config.js` file:
 
 ```js
 loaders: [{

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -9,7 +9,7 @@
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",
   "dependencies": {
-    "auth0-lock": "^8.2.0",
+    "auth0-lock": "^8.2.1",
     "jquery": "^2.1.4",
     "json-loader": "^0.5.2",
     "transform-loader": "^0.2.2",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -9,12 +9,9 @@
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",
   "dependencies": {
-    "auth0-lock": "^7.5.5",
-    "brfs": "^1.4.0",
-    "ejsify": "0.1.0",
+    "auth0-lock": "^8.2.0",
     "jquery": "^2.1.4",
     "json-loader": "^0.5.2",
-    "packageify": "^0.2.2",
     "transform-loader": "^0.2.2",
     "webpack": "^1.9.10"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "auth0-js": "~6.8.0",
     "bean": "~1.0.4",
-    "brfs": "0.0.8",
+    "brfs": "^1.4.0",
     "blueimp-md5": "^1.1.0",
     "bonzo": "^1.3.6",
     "debug": "^2.2.0",


### PR DESCRIPTION
- Upgraded brfs version, because it doesn't work with webpack (see #301). Since lock 8.2.0 it's included as a regular dependency and is the one that webpack picks up.
- Upgraded lock version in webpack example and updated instructions in README.