### PR TITLE
Custom avatars

### DIFF
--- a/lib/avatar/index.js
+++ b/lib/avatar/index.js
@@ -1,0 +1,30 @@
+var md5 = require('../md5');
+var regex = require('../regex');
+var trim = require('trim');
+
+/**
+ * Returns a function which sets the header image using the supplied
+ * function to construct the URL for the avatar asociated with a
+ * given mail.
+ *
+ * @param {Function} urlFunc
+ *
+ * @static
+ * @public
+ */
+// TODO Change widget to header
+module.exports = function(urlFunc) {
+  return function (widget, mail) {
+    var parseResult = regex.email_parser.exec(mail.toLowerCase());
+
+    // valid email? Then construct a URL from it
+    if (parseResult) {
+      var parsedEmail = parseResult[0];
+
+      widget.setImage(urlFunc(trim(parsedEmail)));
+
+    } else {
+      widget.restoreImage();
+    }
+  };
+};

--- a/lib/mode-signin/index.js
+++ b/lib/mode-signin/index.js
@@ -14,7 +14,6 @@ var ValidationError = require('../errors/ValidationError');
 var Emitter = require('events').EventEmitter;
 var buttonTmpl = require('../html/zocial-button.ejs');
 var loginActionsTmpl = require('./login_actions.ejs');
-var gravatar = require('../gravatar');
 var trim = require('trim');
 
 /**
@@ -46,8 +45,8 @@ function SigninPanel(widget, options) {
   this.options = this.resolveOptions(options);
   this.el = null;
 
-  // debounce gravatar update method
-  this.gravatar = _.debounce(this.gravatar, 300);
+  // debounce avatar update method
+  this.fetchAvatar = _.debounce(this.options.fetchAvatar, 300);
 
   Emitter.call(this);
 }
@@ -246,8 +245,8 @@ SigninPanel.prototype.onemailinput = function (e) {
 
   var msg;
 
-  if ('username' !== this.options.usernameStyle && this.options.gravatar) {
-    this.gravatar(mailField.val());
+  if ('username' !== this.options.usernameStyle) {
+    this.avatar(mailField.val());
   }
 
   // TODO Refactor
@@ -319,16 +318,16 @@ SigninPanel.prototype.onemailinput = function (e) {
 };
 
 /**
- * Invoke gravatar update for `email`
+ * Invoke avatar update for `email`
  *
  * @param {String} email
  * @private
  */
 
-SigninPanel.prototype.gravatar = function(email) {
-  gravatar(this.widget, email);
+SigninPanel.prototype.avatar = function(email) {
+  this.fetchAvatar(this.widget, email);
   return this;
-}
+};
 
 /**
  * Validate form and continue with signin

--- a/lib/mode-signup/index.js
+++ b/lib/mode-signup/index.js
@@ -49,7 +49,7 @@ function SignupPanel(widget, options) {
   this.el = null;
 
   // debounce avatar update method
-  this.fetchAvatar = _.debounce(this.fetchAvatar, 300);
+  this.fetchAvatar = _.debounce(this.options.fetchAvatar, 300);
 
   Emitter.call(this);
 }
@@ -227,7 +227,7 @@ SignupPanel.prototype.onemailinput = function() {
   }
 
   if ('username' !== this.options.usernameStyle) {
-    this.fetchAvatar(email);
+    this.avatar(email);
   }
 };
 

--- a/lib/mode-signup/index.js
+++ b/lib/mode-signup/index.js
@@ -12,7 +12,6 @@ var bind = require('../bind');
 var template = require('./signup.ejs');
 var buttonTmpl = require('../html/zocial-button.ejs');
 var regex = require('../regex');
-var gravatar = require('../gravatar');
 var PasswordStrength = require('../password-strength');
 var ValidationError = require('../errors/ValidationError');
 var empty = regex.empty;
@@ -49,8 +48,8 @@ function SignupPanel(widget, options) {
   this.options = this.resolveOptions(options);
   this.el = null;
 
-  // debounce gravatar update method
-  this.gravatar = _.debounce(this.gravatar, 300);
+  // debounce avatar update method
+  this.fetchAvatar = _.debounce(this.fetchAvatar, 300);
 
   Emitter.call(this);
 }
@@ -88,6 +87,7 @@ SignupPanel.prototype.create = function(options) {
 
   this.el = $.create(widget.render(template, opts))[0];
   this.bindAll();
+
   return this.el;
 };
 
@@ -226,20 +226,20 @@ SignupPanel.prototype.onemailinput = function() {
     return;
   }
 
-  if ('username' !== this.options.usernameStyle && this.options.gravatar) {
-    this.gravatar(email);
+  if ('username' !== this.options.usernameStyle) {
+    this.fetchAvatar(email);
   }
 };
 
 /**
- * Invoke gravatar update for `email`
+ * Invoke avatar update for `email`
  *
  * @param {String} email
  * @private
  */
 
-SignupPanel.prototype.gravatar = function(email) {
-  gravatar(this.widget, email);
+SignupPanel.prototype.avatar = function(email) {
+  this.fetchAvatar(this.widget, email);
   return this;
 };
 

--- a/lib/options-manager/index.js
+++ b/lib/options-manager/index.js
@@ -9,6 +9,7 @@ var ocreate = require('../object-create');
 var regex = require('../regex');
 var i18n = require('../i18n');
 var bind = require('../bind');
+var gravatar = require('../gravatar');
 var _ = require('underscore');
 var okeys = _.keys;
 
@@ -81,6 +82,15 @@ function OptionsManager(widget, options) {
 
   // enable/disable gravatar image fetch
   this.gravatar = null != options.gravatar ? !!options.gravatar : true;
+
+  // Set custom avatar URL retrieval function - overrides gravatar if set
+  if ('function' === typeof options.fetchAvatar) {
+    this.fetchAvatar = options.customAvatarUrlFunc;
+  } else if (this.gravatar) {
+    this.fetchAvatar = gravatar;
+  } else {
+    this.fetchAvatar = function() { return null; };
+  }
 
   if ('function' === typeof options.popupCallback) {
     // XXX: the following to should already come with

--- a/test/custom_avatar.tests.js
+++ b/test/custom_avatar.tests.js
@@ -1,0 +1,119 @@
+/* global bean */
+
+var clientID  = '0HP71GSd6PuoRYJ3DXKdiXCUUdGmBbup';
+var domain    = 'mdocs.auth0.com';
+
+function type(input, value) {
+  input.val(value);
+  bean.fire(input[0], 'input');
+}
+
+function isVisible(element) {
+  return !element.hasClass('a0-hide');
+}
+
+describe('avatars', function () {
+  var email, avatar, icon, avatarImg;
+
+  describe('when using a custom avatar function', function() {
+    var expectedAvatarUrl = "http://lorempixel.com/200/200/";
+
+    beforeEach(function (done) {
+      this.widget = new Auth0Lock(clientID, domain);
+      this.options = {
+        rememberLastLogin: false,
+        integratedWindowsLogin: false,
+        fetchAvatar: function(widget, email) {
+          widget.setImage(expectedAvatarUrl);
+        }
+      };
+
+      done();
+    });
+
+    afterEach(function (done) {
+      this.options = null;
+      global.window.Auth0 = null;
+      this.widget.hide(done);
+    });
+
+    it('should call the custom avatar function', function() {
+
+      // Should never happen
+      this.widget.on('icon shown', function () {
+        expect(false).to.be.equal(true);
+      });
+
+      this.widget.on('avatar shown', function () {
+        expect(isVisible(avatar)).to.be.equal(true);
+        expect(isVisible(icon)).to.be.equal(false);
+        expect(avatarImg.attr('src')).to.be.equal(expectedAvatarUrl);
+        done();
+      });
+
+      this.widget.on('ready', function () {
+        email     = $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-email input');
+        avatar    = $('#a0-lock .a0-header .a0-icon-container .a0-avatar');
+        icon      = $('#a0-lock .a0-header .a0-icon-container .a0-image');
+        avatarImg = $('#a0-lock .a0-header .a0-icon-container .a0-avatar img');
+
+        expect(email).not.to.be.empty();
+        expect(avatar).not.to.be.empty();
+        expect(icon).not.to.be.empty();
+        expect(avatarImg).not.to.empty();
+
+        type(email, "some@email.com");
+      });
+
+      this.widget.show(this.options);
+    });
+  });
+
+  describe('when gravatar is disabled and no custom avatar function is supplied', function() {
+    var gravatarEmail = 'albertopose@gmail.com';
+
+    beforeEach(function (done) {
+      this.widget = new Auth0Lock(clientID, domain);
+      this.options = {
+        rememberLastLogin: false,
+        integratedWindowsLogin: false,
+        gravatar: false
+      };
+
+      done();
+    });
+
+    afterEach(function (done) {
+      this.options = null;
+      global.window.Auth0 = null;
+      this.widget.hide(done);
+    });
+
+    it('should display the icon', function() {
+      // Should never happen
+      this.widget.on('avatar shown', function () {
+        expect(false).to.be.equal(true);
+      });
+
+      this.widget.on('icon shown', function () {
+        expect(isVisible(avatar)).to.be.equal(false);
+        expect(isVisible(icon)).to.be.equal(true);
+        done();
+      });
+
+      this.widget.on('ready', function () {
+        email     = $('#a0-lock .a0-notloggedin .a0-emailPassword .a0-email input');
+        avatar    = $('#a0-lock .a0-header .a0-icon-container .a0-avatar');
+        icon      = $('#a0-lock .a0-header .a0-icon-container .a0-image');
+        avatarImg = $('#a0-lock .a0-header .a0-icon-container .a0-avatar img');
+
+        expect(email).not.to.be.empty();
+        expect(avatar).not.to.be.empty();
+        expect(icon).not.to.be.empty();
+        expect(avatarImg).not.to.empty();
+
+        type(email, gravatarEmail);
+      });
+    });
+  });
+});

--- a/test_harness.html
+++ b/test_harness.html
@@ -29,6 +29,7 @@
   <script src="/test/tests.js"></script>
   <script src="/test/options.tests.js"></script>
   <script src="/test/gravatar.tests.js"></script>
+  <script src="/test/custom_avatar.tests.js"></script>
   <script src="/test/password_strength.tests.js"></script>
 
   <!-- start -->


### PR DESCRIPTION
This PR adds a runtime option to supply custom logic for avatar URLs - useful for those users whose platforms include their own avatars.

In order to utilize the functionality, the lock widget can be instantiated using a 'fetchAvatar' function which receives the widget instance and the email field value. This function is expected to operate analogously to the gravatar function supplied with lock - that is, it is expected to call widget.setImage() with an appropriate URL.

Please let me know if you have any questions, corrections or suggestions which would help make this patch suitable for inclusion in mainline lock.