### PR TITLE
V8 deploy script fix + backports

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,8 +1,7 @@
 ui: mocha-bdd
 tunnel:
   type: ngrok
-  authtoken: 5P5swTMSDDRlnMBkBWJt
-  proto: https
+  authtoken: LsVZFxFqgxA4h7ibWV9V_iuA9afbQwaSnGqH9dApL
 scripts:
   - "/node_modules/jquery/dist/jquery.min.js"
   - "/node_modules/expect.js/expect.js"

--- a/bin/deploy
+++ b/bin/deploy
@@ -36,7 +36,7 @@ if [ ! -z "$NPM_EXISTS" ]; then
     echo "There is already a version $VERSION in npm. Skiping npm publish."
 else
     echo "Deploying $VERSION to npm"
-    npm publish
+    npm publish --tag support
 fi
 
 CDN_EXISTS=$(curl -s -o /dev/null -w "%{http_code}" https://cdn.auth0.com/js/lock-$VERSION.min.js | grep 200 || true)

--- a/index.js
+++ b/index.js
@@ -115,6 +115,13 @@ function Auth0Lock (clientID, domain, options) {
 Auth0Lock.version = require('package.version');
 
 /**
+ * Configure telemetry
+ */
+Auth0.clientInfo.lib_version = Auth0.clientInfo.version;
+Auth0.clientInfo.name = "lock.js";
+Auth0.clientInfo.version = Auth0Lock.version;
+
+/**
  * Inherit from `EventEmitter`
  */
 

--- a/lib/html/lock-footer.ejs
+++ b/lib/html/lock-footer.ejs
@@ -1,5 +1,5 @@
 <div class='a0-footer'>
-    <a href="http://auth0.com" target="_new" class="a0-logo">
+    <a href="http://auth0.com/?utm_source=lock&utm_campaign=badge&utm_medium=widget" target="_new" class="a0-logo">
         <i class="a0-icon-badge"></i>
     </a>
 </div>

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
     "through": "^2.3.4",
     "uglify-js": "~2.4.15",
     "unreleased": "^0.0.5",
-    "zuul": "3.8.0",
-    "zuul-ngrok": "3.0.0"
+    "zuul": "3.10.1",
+    "zuul-ngrok": "gnandretta/zuul-ngrok#upgrade-ngrok"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
- Use the "support" tag when publishing the npm module, otherwise it will be installed with `npm install auth0-lock` because it will be the latest. We want the last release in the 9 branch to be installed by default.
- Upgrade to ngrok 2 so test can keep running.
- Update telemetry info.
- Add campaign params to badge link.