### PR TITLE
Remove JSONP authentication suppport

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Authentication options are grouped in the `auth` property of the `options` objec
 ```js
 var options = {
   auth: {
-   jsonp: false,
    params: {param1: "value1"},
    redirect: true,
    redirectUrl: "some url",
@@ -150,7 +149,6 @@ var options = {
 };
 ```
 
-- **jsonp {Boolean}**: Use JSONP requests when calling Auth0's API. This setup is useful when no CORS allowed. Defaults to `false`.
 - **params {Object}**: Specifies extra parameters that will be sent when starting a login. Defaults to `{}`.
 - **redirect {Boolean}**: When set to `true`, the default, _redirect mode_ will be used. Otherwise, _popup mode_ is chosen. See [below](#popup-mode) for more details.
 - **redirectUrl {String}**: The url Auth0 will redirect back after authentication. Defaults to the empty string `""` (no redirect URL).

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -143,7 +143,6 @@ const { get: getAuthAttribute } = dataFns(["core", "auth"]);
 
 export const auth = {
   params: lock => getAuthAttribute(lock, "params"),
-  jsonp: lock => getAuthAttribute(lock, "jsonp"),
   redirect: lock => getAuthAttribute(lock, "redirect"),
   redirectUrl: lock => getAuthAttribute(lock, "redirectUrl"),
   responseType: lock => getAuthAttribute(lock, "responseType"),
@@ -155,7 +154,6 @@ function extractAuthOptions(options) {
   // TODO: shouldn't all options be namespased in authentication?
   let {
     params,
-    jsonp,
     redirect,
     redirectUrl,
     responseType,
@@ -173,7 +171,6 @@ function extractAuthOptions(options) {
   }
 
   return Immutable.fromJS({
-    jsonp,
     params,
     redirect,
     redirectUrl,

--- a/src/core/web_api.js
+++ b/src/core/web_api.js
@@ -12,7 +12,7 @@ class Auth0WebAPI {
       clientID: clientID,
       domain: domain,
       sendSDKClientInfo: true,
-      forceJSONP: opts.jsonp,
+      forceJSONP: false,
       callbackURL: opts.redirectUrl,
       callbackOnLocationHash: opts.responseType === "token"
     });


### PR DESCRIPTION
JSONP was used in some old IE versions that we no longer support