### PR TITLE
Ignore unknown connections

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -218,10 +218,11 @@ export function allowedConnections(m) {
 }
 
 export function connections(m, type = undefined, ...strategies) {
-  // TODO: is this considering "unknown" connections? it should not
-
   if (arguments.length === 1) {
-    return get(m, "connections", Map()).valueSeq().flatten(true);
+    return get(m, "connections", Map())
+      .filter((v, k) => k !== "unknown")
+      .valueSeq()
+      .flatten(true);
   }
 
   const xs = get(m, ["connections", type], List());

--- a/test/layout.ui.test.js
+++ b/test/layout.ui.test.js
@@ -520,3 +520,7 @@ describe("layout", function() {
   });
 
 });
+
+// TODO: besides of diplaying diffrent lock by customizing the allowed
+// connections we should consider when those connections come from the
+// client settings given the code paths are different.


### PR DESCRIPTION
Otherwise `hasOneConnection` and `hasOnlyConnections` that depend on the number of available connections will return invalid results because unknown connections are counted. This caused the display of a submit button with only social buttons when social and unknown connections were the only types available.