### PR TITLE
Invoke auth callback only on success

### DIFF
--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -133,13 +133,9 @@ function autoLogInSuccess(id, ...args) {
 function autoLogInError(id, error) {
   const lock = read(getEntity, "lock", id);
   const errorMessage = l.loginErrorMessage(lock, error);
-  swap(updateEntity, "lock", id, m => {
-    swap(updateEntity, "lock", id, m => (
-      l.setSubmitting(setScreen(m, "login"), false, errorMessage)
-    ));
-  });
-
-  l.invokeLogInCallback(lock, error);
+  swap(updateEntity, "lock", id, m => (
+    l.setSubmitting(setScreen(m, "login"), false, errorMessage)
+  ));
 }
 
 export function resetPassword(id) {

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -123,7 +123,7 @@ function autoLogInSuccess(id, ...args) {
   const autoclose = l.ui.autoclose(lock);
 
   if (!autoclose) {
-    swap(updateEntity, "lock", id, lock => l.setSignedIn(l.setSubmitting(lock, false), true));
+    swap(updateEntity, "lock", id, lock => l.setLoggedIn(l.setSubmitting(lock, false), true));
     l.invokeLogInCallback(lock, null, ...args);
   } else {
     closeLock(id, false, lock => l.invokeLogInCallback(lock, null, ...args));

--- a/src/connection/enterprise/actions.js
+++ b/src/connection/enterprise/actions.js
@@ -1,16 +1,13 @@
 import { getEntity, read, swap, updateEntity } from '../../store/index';
 import {
   enterpriseConnection,
-  findADConnectionWithoutDomain,
   isHRDActive,
   matchConnection,
   toggleHRD
 } from '../enterprise';
-import * as l from '../../core/index';
 import * as c from '../../field/index';
 import { setUsername } from '../../field/username';
 import { emailLocalPart } from '../../field/email';
-import webApi from '../../core/web_api';
 import { logIn as coreLogIn } from '../../core/actions';
 
 export function startHRD(id) {
@@ -51,53 +48,10 @@ function logInActiveFlow(id) {
 }
 
 function logInSSO(id, connection) {
-  swap(updateEntity, "lock", id, lock => {
-    if (c.isFieldValid(lock, "email")) {
-      return l.setSubmitting(lock, true);
-    } else {
-      lock = c.setFieldShowInvalid(lock, "email", !c.isFieldValid(lock, "email"));
-      return lock;
-    }
+  const m = read(getEntity, "lock", id);
+
+  coreLogIn(id, ["email"], {
+    connection: connection.get("name"),
+    login_hint: c.getFieldValue(m, "email")
   });
-
-  const lock = read(getEntity, "lock", id);
-
-  if (l.submitting(lock)) {
-    const options = {
-      connection: connection.get("name"),
-      login_hint: c.email(lock)
-    };
-
-    webApi.logIn(
-      id,
-      options,
-      (error, ...args) => {
-        if (error) {
-          setTimeout(() => logInError(id, error), 250);
-        } else {
-          logInSuccess(id, ...args);
-        }
-      }
-    );
-  }
-}
-
-function logInSuccess(id, ...args) {
-  const lock = read(getEntity, "lock", id);
-  const autoclose = l.ui.autoclose(lock);
-
-  if (!autoclose) {
-    swap(updateEntity, "lock", id, lock => l.setSignedIn(l.setSubmitting(lock, false), true));
-    l.invokeLogInCallback(lock, null, ...args);
-  } else {
-    closeLock(id, false, lock => l.invokeLogInCallback(lock, null, ...args));
-  }
-}
-
-function logInError(id, error) {
-  const lock = read(getEntity, "lock", id);
-  const errorMessage = l.loginErrorMessage(lock, error);
-
-  swap(updateEntity, "lock", id, l.setSubmitting, false, errorMessage);
-  l.invokeLogInCallback(lock, error);
 }

--- a/src/connection/passwordless/actions.js
+++ b/src/connection/passwordless/actions.js
@@ -165,7 +165,7 @@ function logInSuccess(id, ...args) {
   const autoclose = l.ui.autoclose(lock);
 
   if (!autoclose) {
-    swap(updateEntity, "lock", id, lock => l.setSignedIn(l.setSubmitting(lock, false), true));
+    swap(updateEntity, "lock", id, lock => l.setLoggedIn(l.setSubmitting(lock, false), true));
     l.invokeLogInCallback(lock, null, ...args);
   } else {
     closeLock(id, false, lock => l.invokeLogInCallback(lock, null, ...args));

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -153,7 +153,7 @@ function logInSuccess(id, ...args) {
   const autoclose = l.ui.autoclose(lock);
 
   if (!autoclose) {
-    swap(updateEntity, "lock", id, lock => l.setSignedIn(l.setSubmitting(lock, false), true));
+    swap(updateEntity, "lock", id, lock => l.setLoggedIn(l.setSubmitting(lock, false), true));
     l.invokeLogInCallback(lock, null, ...args);
   } else {
     closeLock(id, false, lock => l.invokeLogInCallback(lock, null, ...args));

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -109,18 +109,6 @@ function emitEvent(id, str, ...args) {
   l.emitEvent(read(getEntity, "lock", id), str, ...args);
 }
 
-export function startSubmit(id, fields = []) {
-  swap(updateEntity, "lock", id, m => {
-    const allFieldsValid = fields.reduce((r, x) => r && isFieldValid(m, x), true);
-    return allFieldsValid
-      ? l.setSubmitting(m, true)
-      : fields.reduce((r, x) => showInvalidField(r, x), m);
-  });
-
-  const m = read(getEntity, "lock", id);
-  return [l.submitting(m), m];
-}
-
 export function validateAndSubmit(id, fields = [], f) {
   swap(updateEntity, "lock", id, m => {
     const allFieldsValid = fields.reduce((r, x) => r && isFieldValid(m, x), true);

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -164,9 +164,9 @@ function logInSuccess(id, ...args) {
 }
 
 function logInError(id, error) {
-  const lock = read(getEntity, "lock", id);
-  const errorMessage = l.loginErrorMessage(lock, error);
+  const m = read(getEntity, "lock", id);
+  const errorMessage = l.loginErrorMessage(m, error);
 
   swap(updateEntity, "lock", id, l.setSubmitting, false, errorMessage);
-  l.invokeLogInCallback(lock, error);
+  l.invokeLogInCallback(m, error);
 }

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -168,5 +168,4 @@ function logInError(id, error) {
   const errorMessage = l.loginErrorMessage(m, error);
 
   swap(updateEntity, "lock", id, l.setSubmitting, false, errorMessage);
-  l.invokeLogInCallback(m, error);
 }

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -149,14 +149,17 @@ export function logIn(id, fields, params = {}) {
 
 
 function logInSuccess(id, ...args) {
-  const lock = read(getEntity, "lock", id);
-  const autoclose = l.ui.autoclose(lock);
+  const m = read(getEntity, "lock", id);
 
-  if (!autoclose) {
-    swap(updateEntity, "lock", id, lock => l.setLoggedIn(l.setSubmitting(lock, false), true));
-    l.invokeLogInCallback(lock, null, ...args);
+  if (!l.ui.autoclose(m)) {
+    swap(updateEntity, "lock", id, m => {
+      m = l.setSubmitting(m, false);
+      return l.setLoggedIn(m, true);
+    });
+
+    l.invokeLogInCallback(m, null, ...args);
   } else {
-    closeLock(id, false, lock => l.invokeLogInCallback(lock, null, ...args));
+    closeLock(id, false, m1 => l.invokeLogInCallback(m1, null, ...args));
   }
 }
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -222,12 +222,12 @@ export function render(m) {
 
 export { reset };
 
-export function setSignedIn(m, value) {
-  return tset(m, "signedIn", value);
+export function setLoggedIn(m, value) {
+  return tset(m, "loggedIn", value);
 }
 
-export function signedIn(m) {
-  return tget(m, "signedIn", false);
+export function loggedIn(m) {
+  return tget(m, "loggedIn", false);
 }
 
 export function warn(x, str) {

--- a/src/core/signed_in_confirmation.jsx
+++ b/src/core/signed_in_confirmation.jsx
@@ -39,5 +39,5 @@ export function renderSignedInConfirmation(lock, props = {}) {
   props.key = "auxiliarypane";
   props.lock = lock;
 
-  return l.signedIn(lock) ? <SignedInConfirmation {...props} /> : null;
+  return l.loggedIn(lock) ? <SignedInConfirmation {...props} /> : null;
 }

--- a/src/field/index.js
+++ b/src/field/index.js
@@ -63,9 +63,8 @@ export function showInvalidField(m, field) {
   return m.setIn(["field", field, "showInvalid"], !isFieldValid(m, field));
 }
 
-// TODO: replace invocation of this function for invocation of the
-// `showInvalidField`. This is always called with !isFieldValid(field)
-// as the value argument, so there.
+// TODO: only used in passwordless, when we update it to use
+// validateAndSubmit this won't be needed anymore.
 export function setFieldShowInvalid(m, field, value) {
   return m.setIn(["field", field, "showInvalid"], value);
 }


### PR DESCRIPTION
- No longer invoke the auth callback if the error is already handled by Lock (like invalid user/pass)
- Removed form submission/login logic duplication across different connection types.
- Renamed some functions names that used "sign in" instead of "log in" for consistency.