### PR TITLE
Change socialButtonStyle option default

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,9 @@ var options = {
 
 #### Social options
 
-- **socialButtonStyle {String}**: Determines the size of the buttons for the social providers. It defaults to `"big"` when there are at most tree social providers enabled, otherwise it defaults to `"small"`.
+- **socialButtonStyle {String}**: Determines the size of the buttons for the social providers. Possible values are `"big"` and `"small"`. The default style depends on the connections that are available:
+  - If only social connections are available, it will default to `"big"` when there are 5 connections at most, and default to `"small"` otherwise.
+  - If connections from types other than social are also available, it will default to `"big"` when there are 3 social connections at most, and default to `"small"` otherwise.
 
 #### Database options
 

--- a/src/connection/social/index.js
+++ b/src/connection/social/index.js
@@ -60,9 +60,7 @@ function processSocialOptions(options) {
   const { socialButtonStyle } = options;
 
   // TODO: emit warnings
-  if (typeof socialButtonStyle === "number"
-      || socialButtonStyle === "big"
-      || socialButtonStyle === "small") {
+  if (["big", "small"].indexOf(socialButtonStyle) > -1) {
     result.socialButtonStyle = socialButtonStyle;
   }
 
@@ -74,8 +72,6 @@ export function socialConnections(m) {
 }
 
 export function useBigButtons(m) {
-  const x = get(m, "socialButtonStyle", 3);
-  return typeof x === "number"
-    ? socialConnections(m).count() <= x
-    : x === "big";
+  const limit = l.hasOnlyConnections(m, "social") ? 5 : 3;
+  return get(m, "socialButtonStyle", socialConnections(m).count() <= limit);
 }


### PR DESCRIPTION
- If only social connections are available, fallback to small buttons when there are more than five.
- If other connections are available, fallback to small buttons when there are more than three.
