### PR TITLE
Invoke callback with unrecoverable errors

### DIFF
--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -123,7 +123,10 @@ function autoLogInError(id, error) {
       const errorMessage = l.loginErrorMessage(m, error);
       return l.setSubmitting(setScreen(m, "login"), false, errorMessage);
     } else {
-      return l.setSubmitting(l.stop(m), false);
+      const stopError = new Error("Autologin failed and no the login screen is not allowed.");
+      stopError.code = "autologin_error";
+      stopError.origin = error;
+      return l.setSubmitting(l.stop(m, stopError), false);
     }
   });
 }

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -118,12 +118,12 @@ function processDatabaseOptions(opts) {
 
       const reservedNames = ["email", "username", "password"];
       if (typeof name != "string" || !name.match(/^[a-zA-Z0-9_]+$/) || reservedNames.indexOf(name) > -1) {
-        l.warn(opts, `A \`name\` property must be provided for every element of \`additionalSignUpFields\`. It must be a non-empty string consisting of letters, numbers and underscores. The following names are reserved, and therefore, cannot be used: ${reservedNames.join(", ")}.`);
+        l.warn(opts, `Ignoring an element of \`additionalSignUpFields\` because it does not contain valid \`name\` property. Every element of \`additionalSignUpFields\` must be an object with a \`name\` property that is a non-empty string consisting of letters, numbers and underscores. The following names are reserved, and therefore, cannot be used: ${reservedNames.join(", ")}.`);
         filter = false;
       }
 
       if (typeof placeholder != "string" || !placeholder) {
-        l.warn(opts, "A `placeholder` property must be provided for every element of `additionalSignUpFields`. It must be a non-empty string.");
+        l.warn(opts, "Ignoring an element of `additionalSignUpFields` because it does not contain a valid `placeholder` property. Every element of `additionalSignUpFields` must have a `placeholder` property that is a non-empty string.");
         filter = false;
       }
 
@@ -158,12 +158,9 @@ function processDatabaseOptions(opts) {
         options = undefined;
       }
 
-      if (options != undefined && !global.Array.isArray(options) && typeof options != "function") {
-        throw new Error("Elements of `additionalSignUpFields` with a \"select\" `type` must specify a `options` property that is an Array or a function.");
-      }
-
-      if (type === "select" && options === undefined) {
-        l.warn(opts, `When providing a \`type\` property in an element of \`additionalSignUpFields\` a valid \`options\` property must also be provided.`);
+      if ((options != undefined && !global.Array.isArray(options) && typeof options != "function")
+          || (type === "select" && options === undefined)) {
+        l.warn("Ignoring an element of `additionalSignUpFields` because it has a \"select\" `type` but does not specify an `options` property that is an Array or a function.");
         filter = false;
       }
 

--- a/src/core.js
+++ b/src/core.js
@@ -147,7 +147,7 @@ export default class Base extends EventEmitter {
 
   runHook(str, ...args) {
     if (typeof this.engine[str] != "function") return;
-    return this.engine[str](read(getEntity, "lock", this.id), ...args);
+    return this.engine[str](...args);
   }
 
 }

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -8,24 +8,17 @@ import { defaultProps } from '../ui/box/container';
 import { isFieldValid, showInvalidField } from '../field/index';
 
 export function setupLock(id, clientID, domain, options, logInCallback, hookRunner, emitEventFn) {
-  // TODO: run a hook before initialization, useful for when we want
-  // to provide some options by default.
-  const m = syncRemoteData(l.setup(id, clientID, domain, options, logInCallback, hookRunner, emitEventFn));
+  let m = syncRemoteData(l.setup(id, clientID, domain, options, logInCallback, hookRunner, emitEventFn));
   preload(l.ui.logo(m) || defaultProps.logo);
-
 
   webApi.setupClient(id, clientID, domain, l.withAuthOptions(m, {
     ...options,
     popupOptions: l.ui.popupOptions(m)
   }));
 
+  m = l.runHook(m, "didInitialize", options);
 
   swap(setEntity, "lock", id, m);
-
-  // TODO: this triggers a second call to swap, maybe it can be
-  // optimized. However, the Lock isn't rendering yet so it might not
-  // be really an issue.
-  l.runHook(m, "didInitialize", options);
 
   if (l.auth.redirect(m)) {
     const hash = webApi.parseHash(id);

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -323,7 +323,12 @@ export function loginErrorMessage(m, error) {
     || i18n.str(m, ["error", "login", "lock.fallback"]);
 }
 
-export function stop(m) {
+// TODO: rename to something less generic that is easier to grep
+export function stop(m, error) {
+  if (error) {
+    setTimeout(() => invokeLogInCallback(m, error), 0);
+  }
+
   return set(m, "stopped", true);
 }
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -295,7 +295,7 @@ export function hasConnection(m, name) {
 }
 
 export function runHook(m, str, ...args) {
-  get(m, "hookRunner")(str, ...args);
+  return get(m, "hookRunner")(str, m, ...args);
 }
 
 export function emitEvent(m, str, ...args) {

--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -29,8 +29,8 @@ function syncClientSettingsSuccess(m, result) {
     pickConnections(result, l.allowedConnections(m))
   );
 
-  // TODO: this shouldn't be like this
-  setTimeout(() => l.runHook(m, "didReceiveClientSettings"), 0);
+  m = l.runHook(m, "didReceiveClientSettings");
+
   return m;
 }
 

--- a/src/engine/automatic.js
+++ b/src/engine/automatic.js
@@ -144,7 +144,13 @@ class Automatic {
     const Screen = Automatic.SCREENS[getScreen(m)];
     if (Screen) return new Screen();
 
-    l.error(m, "At least one screen (\"login\", \"signUp\" or \"forgotPassword\") needs to be allowed.");
+    setTimeout(() => {
+      const stopError = new Error("Internal error");
+      stopError.code = "internal_error";
+      stopError.description = `Couldn't find a screen "${getScreen(m)}"`;
+      swap(updateEntity, "lock", l.id(m), l.stop, stopError);
+    }, 0);
+
     return new ErrorScreen();
   }
 

--- a/src/engine/automatic.js
+++ b/src/engine/automatic.js
@@ -86,8 +86,9 @@ class Automatic {
     const anyEnterpriseConnection = l.hasSomeConnections(m, "enterprise");
 
     if (!anyDBConnection && !anySocialConnection && !anyEnterpriseConnection) {
-      // TODO: improve message
-      throw new Error("At least one database, enterprise or social connection needs to be available.");
+      const error = new Error("At least one database, enterprise or social connection needs to be available.");
+      error.code = "no_connection";
+      m = l.stop(m, error);
     }
 
     if (defaultDatabaseConnectionName(m) && !defaultDatabaseConnection(m)) {

--- a/src/engine/automatic.js
+++ b/src/engine/automatic.js
@@ -77,7 +77,7 @@ class Automatic {
     if (typeof email === "string") model = setEmail(model, email);
     if (typeof username === "string") model = setUsername(model, username);
 
-    swap(updateEntity, "lock", l.id(model), _ => model);
+    return model;
   }
 
   didReceiveClientSettings(m) {
@@ -97,6 +97,8 @@ class Automatic {
     if (defaultEnterpriseConnectionName(m) && !defaultEnterpriseConnection(m)) {
       l.warn(m, `The provided default enterprise connection "${defaultEnterpriseConnectionName(m)}" is not enabled or does not allow email/password authentication.`);
     }
+
+    return m;
   }
 
   render(m) {

--- a/src/engine/automatic.js
+++ b/src/engine/automatic.js
@@ -105,16 +105,11 @@ class Automatic {
   render(m) {
     // TODO: remove the detail about the loading pane being pinned,
     // sticky screens should be handled at the box module.
-    if ((!isDone(m) && !hasError(m, ["sso"])) || m.get("isLoadingPanePinned")) {
+    if (!isDone(m) || m.get("isLoadingPanePinned")) {
       return new LoadingScreen();
     }
 
-    const anyDBConnection = l.hasSomeConnections(m, "database");
-    const anySocialConnection = l.hasSomeConnections(m, "social");
-    const anyEnterpriseConnection = l.hasSomeConnections(m, "enterprise");
-    const noConnection = !anyDBConnection && !anySocialConnection && !anyEnterpriseConnection;
-
-    if (l.hasStopped(m) || hasError(m, ["sso"]) || noConnection) {
+    if (l.hasStopped(m)) {
       return new ErrorScreen();
     }
 

--- a/src/engine/automatic.js
+++ b/src/engine/automatic.js
@@ -9,6 +9,7 @@ import {
   defaultDatabaseConnection,
   defaultDatabaseConnectionName,
   getScreen,
+  hasInitialScreen,
   hasScreen,
   initDatabase
 } from '../connection/database/index';
@@ -88,6 +89,14 @@ class Automatic {
     if (!anyDBConnection && !anySocialConnection && !anyEnterpriseConnection) {
       const error = new Error("At least one database, enterprise or social connection needs to be available.");
       error.code = "no_connection";
+      m = l.stop(m, error);
+    } else if (!anyDBConnection && hasInitialScreen(m, "forgotPassword")) {
+      const error = new Error("The `initialScreen` option was set to \"forgotPassword\" but no database connection is available.");
+      error.code = "unavailable_initial_screen";
+      m = l.stop(m, error);
+    } else if (!anyDBConnection && !anySocialConnection && hasInitialScreen(m, "signUp")) {
+      const error = new Error("The `initialScreen` option was set to \"signUp\" but no database or social connection is available.");
+      error.code = "unavailable_initial_screen";
       m = l.stop(m, error);
     }
 

--- a/src/sync.js
+++ b/src/sync.js
@@ -1,6 +1,7 @@
 import { Map } from 'immutable';
 import { dataFns } from './utils/data_utils';
 const { get, set } = dataFns(["sync"]);
+import * as l from './core/index';
 
 import { getEntity, observe, read, swap, updateEntity } from './store/index';
 
@@ -58,7 +59,7 @@ const process = (m, id) => {
           swap(updateEntity, "lock", id, m => {
             const recoverResult = getProp(m, k, "recoverResult");
             if (error && recoverResult === undefined) {
-              return setStatus(m, k, "error");
+              return handleError(m, k, error);
             } else {
               m = setStatus(m, k, "ok");
               return getProp(m, k, "successFn")(m, error ? recoverResult : result);
@@ -98,4 +99,15 @@ export function hasError(m, excludeKeys = []) {
 
 function isLoading(m, key) {
   return ["loading", "pending", "waiting"].indexOf(getStatus(m, key)) > -1;
+}
+
+function handleError(m, key, error) {
+  let result = setStatus(m, key, "error");
+
+  // TODO: this should be configurable for each sync
+  if (key !== "sso") {
+    result = l.stop(result);
+  }
+
+  return result;
 }

--- a/src/sync.js
+++ b/src/sync.js
@@ -106,7 +106,10 @@ function handleError(m, key, error) {
 
   // TODO: this should be configurable for each sync
   if (key !== "sso") {
-    result = l.stop(result);
+    const stopError = new Error("An error ocurred when fetching data.");
+    stopError.code = "sync";
+    stopError.origin = error;
+    result = l.stop(result, stopError);
   }
 
   return result;


### PR DESCRIPTION
The callback will be invoked when:
- A sync fails, except if it is for SSO data.
- Automatic login fails and the login screen is not allowed.
- No connection is available (because no connection is enabled in the dashboard or none of the `allowedConnections` is found).
- Can't found a screen to render (internal error).
- The `initialScreen` is not available for the enabled connections.

The way hooks are implemented has been changed to avoid to swap the state twice in a row.