### PR TITLE
Add events

### DIFF
--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -154,7 +154,7 @@ function processDatabaseOptions(opts) {
 
       if ((options != undefined && !global.Array.isArray(options) && typeof options != "function")
           || (type === "select" && options === undefined)) {
-        l.warn("Ignoring an element of `additionalSignUpFields` because it has a \"select\" `type` but does not specify an `options` property that is an Array or a function.");
+        l.warn(opts, "Ignoring an element of `additionalSignUpFields` because it has a \"select\" `type` but does not specify an `options` property that is an Array or a function.");
         filter = false;
       }
 

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -9,14 +9,8 @@ import trim from 'trim';
 const { get, initNS, tget, tset } = dataFns(["database"]);
 
 export function initDatabase(m, options) {
-  try {
-    m = initNS(m, Immutable.fromJS(processDatabaseOptions(options)));
-    m = resolveAdditionalSignUpFields(m);
-  } catch (e) {
-    l.error(options, e.message);
-    m = l.stop(m);
-  }
-
+  m = initNS(m, Immutable.fromJS(processDatabaseOptions(options)));
+  m = resolveAdditionalSignUpFields(m);
   return m;
 }
 

--- a/src/core.js
+++ b/src/core.js
@@ -19,7 +19,7 @@ import { go } from './sync';
 
 export default class Base extends EventEmitter {
 
-  constructor(clientID, domain, options = {}, logInCallback = () => {}, engine) {
+  constructor(clientID, domain, options = {}, engine) {
     if (typeof clientID != "string") {
       throw new Error("A `clientID` string must be provided as first argument.");
     }
@@ -28,10 +28,6 @@ export default class Base extends EventEmitter {
     }
     if (typeof options != "object") {
       throw new Error("When provided, the third argument must be an `options` object.");
-    }
-    if (typeof logInCallback != "function") {
-      // TODO: should this argument be mandatory?
-      throw new Error("When provided, the fourth argument must be a function.");
     }
 
     super();
@@ -43,7 +39,7 @@ export default class Base extends EventEmitter {
 
     go(this.id);
 
-    setupLock(this.id, clientID, domain, options, logInCallback, hookRunner, emitEventFn);
+    setupLock(this.id, clientID, domain, options, hookRunner, emitEventFn);
 
     observe("render", this.id, m => {
       const partialApplyId = (screen, handlerName) => {

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -61,7 +61,7 @@ export function openLock(id) {
 export function closeLock(id, force = false, callback = () => {}) {
   // Do nothing when the Lock can't be closed, unless closing is forced.
   let m = read(getEntity, "lock", id);
-  if (!l.ui.closable(m) && !force) {
+  if (!l.ui.closable(m) && !force || !l.rendering(m)) {
     return;
   }
 

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -34,17 +34,16 @@ export function setupLock(id, clientID, domain, options, hookRunner, emitEventFn
       } else {
         result = hash;
       }
+
+      setTimeout(() => {
+        if (error) {
+          l.emitEvent(m, "redirect_error", error);
+        } else {
+          l.emitAuthenticatedEvent(m, result);
+        }
+      }, 0);
     }
 
-    setTimeout(() => {
-      if (result && !error) {
-        l.emitAuthenticatedEvent(m, result);
-      } else {
-        if (!l.hasStopped(m)) {
-          l.emitEvent(m, "ready", error);
-        }
-      }
-    }, 0);
   }
 
 }

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -36,7 +36,15 @@ export function setupLock(id, clientID, domain, options, logInCallback, hookRunn
       }
     }
 
-    setTimeout(() => l.invokeLogInCallback(m, error, result), 0);
+    setTimeout(() => {
+      if (result && !error) {
+        l.invokeLogInCallback(m, null, result);
+      } else {
+        if (!l.hasStopped(m)) {
+          l.emitEvent(m, "ready", error);
+        }
+      }
+    }, 0);
   }
 
 }

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -42,14 +42,16 @@ export function setupLock(id, clientID, domain, options, logInCallback, hookRunn
 }
 
 export function openLock(id) {
-  const lock = read(getEntity, "lock", id);
-  if (!lock) {
+  const m = read(getEntity, "lock", id);
+  if (!m) {
     throw new Error("The Lock can't be opened again after it has been destroyed");
   }
 
-  if (l.rendering(lock)) {
+  if (l.rendering(m)) {
     return false;
   }
+
+  l.emitEvent(m, "show");
 
   swap(updateEntity, "lock", id, l.render);
 

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -21,31 +21,31 @@ export function setupLock(id, clientID, domain, options, hookRunner, emitEventFn
   swap(setEntity, "lock", id, m);
 
   if (l.auth.redirect(m)) {
-    const hash = webApi.parseHash(id);
-    // TODO: this leaves the hash symbol (#) in the URL, maybe we can
-    // use the history API instead to remove it.
-    global.location.hash = "";
+    setTimeout(() => parseHash(m), 0);
+  }
+}
 
-    let error, result;
+function parseHash(m) {
+  const hash = webApi.parseHash(l.id(m));
+  // TODO: this leaves the hash symbol (#) in the URL, maybe we can
+  // use the history API instead to remove it.
+  global.location.hash = "";
 
-    if (hash) {
-      if (hash.error) {
-        error = hash;
-      } else {
-        result = hash;
-      }
+  let error, result;
 
-      setTimeout(() => {
-        if (error) {
-          l.emitEvent(m, "redirect_error", error);
-        } else {
-          l.emitAuthenticatedEvent(m, result);
-        }
-      }, 0);
+  if (hash) {
+    if (hash.error) {
+      error = hash;
+    } else {
+      result = hash;
     }
 
+    if (error) {
+      l.emitEvent(m, "redirect_error", error);
+    } else {
+      l.emitAuthenticatedEvent(m, result);
+    }
   }
-
 }
 
 export function openLock(id) {

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -60,23 +60,26 @@ export function openLock(id) {
 
 export function closeLock(id, force = false, callback = () => {}) {
   // Do nothing when the Lock can't be closed, unless closing is forced.
-  let lock = read(getEntity, "lock", id);
-  if (!l.ui.closable(lock) && !force) {
+  let m = read(getEntity, "lock", id);
+  if (!l.ui.closable(m) && !force) {
     return;
   }
 
+  l.emitEvent(m, "hide")
+
   // If it is a modal, stop rendering an reset after a second,
   // otherwise just reset.
-  if (l.ui.appendContainer(lock)) {
+  if (l.ui.appendContainer(m)) {
     swap(updateEntity, "lock", id, l.stopRendering);
 
     setTimeout(() => {
       swap(updateEntity, "lock", id, l.reset);
-      callback(read(getEntity, "lock", id));
+      m = read(getEntity, "lock", id);
+      callback(m);
     }, 1000);
   } else {
     swap(updateEntity, "lock", id, l.reset);
-    callback(lock);
+    callback(m);
   }
 }
 

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -38,7 +38,7 @@ export function setupLock(id, clientID, domain, options, logInCallback, hookRunn
 
     setTimeout(() => {
       if (result && !error) {
-        l.invokeLogInCallback(m, null, result);
+        l.invokeLogInCallback(m, result);
       } else {
         if (!l.hasStopped(m)) {
           l.emitEvent(m, "ready", error);
@@ -151,9 +151,9 @@ export function logInSuccess(id, ...args) {
       return l.setLoggedIn(m, true);
     });
 
-    l.invokeLogInCallback(m, null, ...args);
+    l.invokeLogInCallback(m, ...args);
   } else {
-    closeLock(id, false, m1 => l.invokeLogInCallback(m1, null, ...args));
+    closeLock(id, false, m1 => l.invokeLogInCallback(m1, ...args));
   }
 }
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -18,7 +18,7 @@ const {
   tremove
 } = dataFns(["core"]);
 
-export function setup(id, clientID, domain, options, logInCallback, hookRunner, emitEventFn) {
+export function setup(id, clientID, domain, options, hookRunner, emitEventFn) {
   let m = init(id, Immutable.fromJS({
     assetsUrl: extractAssetsUrlOption(options, domain),
     auth: extractAuthOptions(options),
@@ -26,7 +26,6 @@ export function setup(id, clientID, domain, options, logInCallback, hookRunner, 
     domain: domain,
     emitEventFn: emitEventFn,
     hookRunner: hookRunner,
-    logInCallback: logInCallback,
     allowedConnections: Immutable.fromJS(options.allowedConnections || []),
     ui: extractUIOptions(id, options)
   }));
@@ -211,10 +210,6 @@ function extractAssetsUrlOption(opts, domain) {
   }
 }
 
-export function invokeLogInCallback(m, ...args) {
-  get(m, "logInCallback").apply(undefined, args);
-}
-
 export function render(m) {
   return tset(m, "render", true);
 }
@@ -347,4 +342,8 @@ export function stop(m, error) {
 
 export function hasStopped(m) {
   return get(m, "stopped");
+}
+
+export function emitAuthenticatedEvent(m, result) {
+  emitEvent(m, "authenticated", result);
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -339,7 +339,7 @@ export function loginErrorMessage(m, error, type) {
 // TODO: rename to something less generic that is easier to grep
 export function stop(m, error) {
   if (error) {
-    setTimeout(() => invokeLogInCallback(m, error), 0);
+    setTimeout(() => emitEvent(m, "error", error), 17);
   }
 
   return set(m, "stopped", true);

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -299,7 +299,9 @@ export function runHook(m, str, ...args) {
 }
 
 export function emitEvent(m, str, ...args) {
-  get(m, "emitEventFn")(str, ...args);
+  try {
+    get(m, "emitEventFn")(str, ...args);
+  } catch (e) { }
 }
 
 export function loginErrorMessage(m, error, type) {

--- a/src/field/index.js
+++ b/src/field/index.js
@@ -2,6 +2,7 @@ import { Map } from 'immutable';
 import trim from 'trim';
 import * as cc from './country_codes';
 import OptionSelectionPane from './option_selection_pane';
+import * as l from '../core/index';
 
 export function setField(m, field, value, validator = str => trim(str).length > 0, ...args) {
   const prevValue = m.getIn(["field", field, "value"]);
@@ -30,8 +31,16 @@ export function registerOptionField(m, field, options, initialValue) {
     }
   });
 
-  // TODO: improve message? emit warning right here? warning for prefilled field ignored?
-  if (!valid || !options.size) throw new Error(`The options provided for the "${field}" field are invalid, they must have the following format: {label: "non-empty string", value: "non-empty string"} and there has to be at least one option.`);
+  if (!valid || !options.size) {
+    const stopError = new Error(`The options provided for the "${field}" field are invalid, they must have the following format: {label: "non-empty string", value: "non-empty string"} and there has to be at least one option.`);
+    stopError.code = "invalid_select_field";
+    // TODO: in the future we might want to return the result of the
+    // operation along with the model insteand of stopping the
+    // rendering, like [false, m] in the case of failure and [true, m]
+    // in the case of success.
+    return l.stop(m, stopError);
+  }
+
   if (!initialOption) initialOption = Map({});
 
   return m.mergeIn(["field", field], initialOption, Map({

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,8 @@ if (style.styleSheet) {
 
 export default class Auth0Lock extends Core {
 
-  constructor(clientID, domain, options, logInCallback) {
-    super(clientID, domain, options, logInCallback, automatic);
+  constructor(clientID, domain, options) {
+    super(clientID, domain, options, automatic);
   }
 
 }

--- a/src/passwordless.js
+++ b/src/passwordless.js
@@ -3,8 +3,8 @@ import passwordless from './engine/passwordless';
 
 export default class Auth0LockPasswordless extends Core {
 
-  constructor(clientID, domain, options, logInCallback) {
-    super(clientID, domain, options, logInCallback, passwordless);
+  constructor(clientID, domain, options) {
+    super(clientID, domain, options, passwordless);
   }
 
 }


### PR DESCRIPTION
This adds the following events:
- `show`: emitted when Lock is shown. Has no arguments.
- `hide`: emitted when Lock is hidden. Has no arguments.
- `error`: emitted when there is an unrecoverable error, for instance no connection is available. Has an `Error` instance as the only argument.
- `authenticated`: emitted after a successful authentication. Has the authentication result provided by auth0.js as the only argument.
- `redirect_error`: emitted when the authentication fails after redirecting to Auth0, for instance a rule error. Has the error provided by auth0.js as the only argument.

It also removes the callback argument from the constructor. The `authenticated` and `redirect_error` must be used instead.

 **Before**
```js
var lock = new Auth0Lock(cid. domain, opts, function (error, result) {
  // This was invoked every time the page loads and possibly a second
  // time when an unrecoverable error happened in redirect mode.
  // Handling all possible cases was problematic. You had to check if
  // if there was a error, what kind of error, if there was a result or
  // if there wasn't any error nor result.
  // In popup mode it was invoked every time an authentication attempt
  // was made or an unrecoverable error happened. 
});
```

**Now**
```js
var lock = new Auth0Lock(cid. domain, opts);

lock.on("authenticated", function(result) {
  // successful login
});

lock.on("redirect_error", function(error) {
  alert("something wen't wrong: " error.error_description);
});
```