### PR TITLE
Add hint support in additional field validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,10 @@ var options = {
     icon: "https://example.com/assests/address_icon.png",
     prefill: "street 123",
     validator: function(address) {
-      return address.length > 10;
+      return {
+         valid: address.length >= 10,
+         hint: "Must have 10 or more chars" // optional
+      };
     }
   }]
 }

--- a/src/field/custom_input.jsx
+++ b/src/field/custom_input.jsx
@@ -1,5 +1,11 @@
+import React from 'react';
 import { changeField, startOptionSelection } from './actions';
-import { getFieldLabel, getFieldValue, isFieldVisiblyInvalid } from './index';
+import {
+  getFieldInvalidHint,
+  getFieldLabel,
+  getFieldValue,
+  isFieldVisiblyInvalid
+} from './index';
 import TextInput from '../ui/input/text_input';
 import SelectInput from '../ui/input/select_input';
 import * as l from '../core/index';
@@ -24,6 +30,7 @@ const CustomInput = ({iconUrl, model, name, options, placeholder, type, validato
     default:
       return (
         <TextInput
+          invalidHint={getFieldInvalidHint(model, name)}
           onChange={e => changeField(l.id(model), name, e.target.value, validator)}
           value={getFieldValue(model, name)}
           {...props}

--- a/src/field/index.js
+++ b/src/field/index.js
@@ -6,13 +6,21 @@ import * as l from '../core/index';
 export function setField(m, field, value, validator = str => trim(str).length > 0, ...args) {
   const prevValue = m.getIn(["field", field, "value"]);
   const prevShowInvalid = m.getIn(["field", field, "showInvalid"], false);
-  const valid = validator === null || !!validator(value, ...args);
+  const validation = validate(validator, value, ...args);
 
-  return m.mergeIn(["field", field], Map({
+  return m.mergeIn(["field", field], validation, Map({
     value: value,
-    valid: valid,
     showInvalid: prevShowInvalid && prevValue === value
   }));
+}
+
+function validate(validator, value, ...args) {
+  if (typeof validator != "function") return Map({valid: true});
+
+  const validation = validator(value, ...args);
+  return validation && typeof validation === "object"
+    ? Map({valid: validation.valid, invalidHint: validation.hint})
+    : Map({valid: !!validation});
 }
 
 // TODO: this should handle icons, and everything.
@@ -58,6 +66,10 @@ export function setOptionField(m, field, option) {
 
 export function isFieldValid(m, field) {
   return m.getIn(["field", field, "valid"]);
+}
+
+export function getFieldInvalidHint(m, field) {
+  return m.getIn(["field", field, "invalidHint"], "");
 }
 
 export function isFieldVisiblyInvalid(m, field) {

--- a/src/field/username/username_pane.jsx
+++ b/src/field/username/username_pane.jsx
@@ -37,12 +37,10 @@ export default class UsernamePane extends React.Component {
     return (
       <UsernameInput
         value={value}
-        avatar={l.ui.avatar(lock)}
         invalidHint={i18n.str(invalidHintKey(value))}
         isValid={!c.isFieldVisiblyInvalid(lock, "username")}
         onChange={::this.handleChange}
         placeholder={placeholder}
-        disabled={l.submitting(lock)}
       />
     );
   }

--- a/src/ui/input/text_input.jsx
+++ b/src/ui/input/text_input.jsx
@@ -13,7 +13,15 @@ export default class TextInput extends React.Component {
   }
 
   render() {
-    const { iconUrl, isValid, name, onChange, value, ...props } = this.props;
+    const {
+      iconUrl,
+      invalidHint,
+      isValid,
+      name,
+      onChange,
+      value,
+      ...props
+    } = this.props;
     let { icon } = this.props;
     const { focused } = this.state;
 
@@ -22,7 +30,13 @@ export default class TextInput extends React.Component {
     }
 
     return (
-      <InputWrap focused={focused} isValid={isValid} name={name} icon={icon}>
+      <InputWrap
+        focused={focused}
+        invalidHint={invalidHint}
+        isValid={isValid}
+        name={name}
+        icon={icon}
+      >
         <input
           ref="input"
           type="text"


### PR DESCRIPTION
The _validator_ function instead of returning a **bool** now returns an **object** with a required `valid` property and an optional `hint` property. The `valid` property is a bool which indicates whether or not the field is valid. The `hint` property is a string that will be displayed in the error hint.

```js
validator: function(code) {
  return {
    valid: code.length === 3, // required
    hint: "Must have 3 chars" // optional
  };
}
```

<img width="465" alt="screen shot 2016-07-01 at 3 53 57 pm" src="https://cloud.githubusercontent.com/assets/120195/16531699/0d6ffaa8-3fa4-11e6-8985-2c172dc87f94.png">

