### PR TITLE
Add getClient method and remove parseHash

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -4,6 +4,7 @@ import { remove, render } from './ui/box';
 import webAPI from './core/web_api';
 import {
   closeLock,
+  createClient,
   handleAuthCallback,
   openLock,
   removeLock,
@@ -130,6 +131,10 @@ export default class Base extends EventEmitter {
 
   getProfile(token, cb) {
     return webAPI.getProfile(this.id, token, cb);
+  }
+
+  getClient(opts) {
+    return createClient(this.id, opts);
   }
 
   parseHash(hash = undefined) {

--- a/src/core.js
+++ b/src/core.js
@@ -137,10 +137,6 @@ export default class Base extends EventEmitter {
     return createClient(this.id, opts);
   }
 
-  parseHash(hash = undefined) {
-    return webAPI.parseHash(this.id, hash);
-  }
-
   logout(query = {}) {
     webAPI.signOut(this.id, query);
   }

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -1,3 +1,4 @@
+import Auth0 from 'auth0-js';
 import Immutable, { Map } from 'immutable';
 import webApi from './web_api';
 import { getCollection, getEntity, read, removeEntity, swap, setEntity, updateEntity } from '../store/index';
@@ -57,6 +58,17 @@ function parseHash(m, hash) {
   }
 
   return !!(error || result);
+}
+
+export function createClient(id, opts) {
+  const m = read(getEntity, "lock", id);
+  return new Auth0({
+    clientID: l.clientID(m),
+    domain: l.domain(m),
+    callbackURL: l.auth.redirectUrl(m),
+    callbackOnLocationHash: l.auth.responseType(m) === "token",
+    ...opts
+  });
 }
 
 export function openLock(id) {


### PR DESCRIPTION
The `getClient` method is added to support some uncommon but valid use cases.