### PR TITLE
Delay event emission

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -294,9 +294,7 @@ export function runHook(m, str, ...args) {
 }
 
 export function emitEvent(m, str, ...args) {
-  try {
-    get(m, "emitEventFn")(str, ...args);
-  } catch (e) { }
+  setTimeout(() => get(m, "emitEventFn")(str, ...args), 0);
 }
 
 export function loginErrorMessage(m, error, type) {


### PR DESCRIPTION
Event listener invocations were surrounded in a try/catch block to prevent errors in them to interfere with Lock behavior. As a consequence of this, errors didn't show up in the console log.