### PR TITLE
Use onInput instead of onChange in EmailField

### DIFF
--- a/src/ui/input/email_input.jsx
+++ b/src/ui/input/email_input.jsx
@@ -29,7 +29,7 @@ export default class EmailInput extends React.Component {
           placeholder="yours@example.com"
           autoComplete="off"
           autoCapitalize="off"
-          onChange={::this.handleOnChange}
+          onInput={::this.handleOnChange}
           onFocus={::this.handleFocus}
           onBlur={::this.handleBlur}
           {...props}/>

--- a/test/helper/ui.js
+++ b/test/helper/ui.js
@@ -157,7 +157,8 @@ const check = (lock, query) => {
 const checkFn = query => lock => check(lock, query);
 export const clickTermsCheckbox = checkFn(".auth0-lock-sign-up-terms-agreement label input[type='checkbox']");
 const fillInput = (lock, name, str) => {
-  Simulate.change(qInput(lock, name, true), {target: {value: str}});
+  var method = name === "email" ? "input" : "change";
+  Simulate[method](qInput(lock, name, true), {target: {value: str}});
 };
 const fillInputFn = name => (lock, str) => fillInput(lock, name, str);
 


### PR DESCRIPTION
When using `onChange` some events are skipped in IE11.