### PR TITLE
Remove cache for container elements

### DIFF
--- a/src/ui/box.js
+++ b/src/ui/box.js
@@ -5,22 +5,14 @@ import Container from './box/container';
 
 class ContainerManager {
 
-  constructor() {
-    this.cache = {};
-  }
-
   ensure(id, shouldAppend) {
-    let container = this.cache[id];
-
-    if (!container) {
-      container = this.cache[id] = global.document.getElementById(id);
-    }
+    let container = global.document.getElementById(id);
 
     if (!container && shouldAppend) {
       container = global.document.createElement('div');
       container.id = id;
       container.className = "auth0-lock-container";
-      this.cache[id] = global.document.body.appendChild(container);
+      global.document.body.appendChild(container);
     }
 
     if (!container) {


### PR DESCRIPTION
Otherwise when a container is removed we are not able to render in another container element with the same id.