### PR TITLE
Add hash_parsed event

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Lock will emit events during its lifecycle.
 - `unrecoverable_error`: emitted when there is an unrecoverable error, for instance when no connection is available. Has the error as the only argument.
 - `authenticated`: emitted after a successful authentication. Has the authentication result as the only argument.
 - `authorization_error`: emitted when authorization fails. Has error as the only argument.
-- `hash_parsed`: every time a new Auth0Lock object is initialized in redirect mode (the fault), it will attempt to parse the hash part of the url looking for the result of a login attempt. After that this event will be emitted with `null` if it couldn't find anything in the hash. It will be emitted with the same argument as the `authenticated` event after a successful login or with the same argument as `authorization_error` if something went wrong. This event won't be emitted in popup mode because there is no need to parse the url's hash part.
+- `hash_parsed`: every time a new Auth0Lock object is initialized in redirect mode (the fault), it will attempt to parse the hash part of the url looking for the result of a login attempt. This is a _low level_ event for advanced use cases and _authenticated_ and _authorization_error_ should be preferred when possible. After that this event will be emitted with `null` if it couldn't find anything in the hash. It will be emitted with the same argument as the `authenticated` event after a successful login or with the same argument as `authorization_error` if something went wrong. This event won't be emitted in popup mode because there is no need to parse the url's hash part.
 
 ### Customization
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Lock will emit events during its lifecycle.
 - `unrecoverable_error`: emitted when there is an unrecoverable error, for instance when no connection is available. Has the error as the only argument.
 - `authenticated`: emitted after a successful authentication. Has the authentication result as the only argument.
 - `authorization_error`: emitted when authorization fails. Has error as the only argument.
+- `hash_parsed`: every time a new Auth0Lock object is initialized in redirect mode (the fault), it will attempt to parse the hash part of the url looking for the result of a login attempt. After that this event will be emitted with `null` if it couldn't find anything in the hash. It will be emitted with the same argument as the `authenticated` event after a successful login or with the same argument as `authorization_error` if something went wrong. This event won't be emitted in popup mode because there is no need to parse the url's hash part.
 
 ### Customization
 

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -34,6 +34,7 @@ export function handleAuthCallback() {
 
 function parseHash(m, hash) {
   const parsedHash = webApi.parseHash(l.id(m), hash);
+  l.emitHashParsedEvent(m, parsedHash);
 
   let error, result;
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -342,6 +342,10 @@ export function hasStopped(m) {
   return get(m, "stopped");
 }
 
+export function emitHashParsedEvent(m, parsedHash) {
+  emitEvent(m, "hash_parsed", parsedHash);
+}
+
 export function emitAuthenticatedEvent(m, result) {
   emitEvent(m, "authenticated", result);
 }


### PR DESCRIPTION
The event is fired after any lock attempt to parse the url's hash part. It is a low level event for cases where you need to know if there is a login result before initializing your application. It should not be used in conjunction with the `authenticated` and the `authorization_error` events