### PR TITLE
Remove react warning

### DIFF
--- a/src/ui/pane/quick_auth_pane.jsx
+++ b/src/ui/pane/quick_auth_pane.jsx
@@ -45,9 +45,9 @@ const QuickAuthPane = (props) => {
 
 QuickAuthPane.propTypes = {
   alternativeLabel: React.PropTypes.string,
-  alternativeClickHandler: (props, propName, component) => {
+  alternativeClickHandler: (props, propName, component, ...rest) => {
     if (props.alternativeLabel !== undefined) {
-      return React.PropTypes.func.isRequired(props, propName, component)
+      return React.PropTypes.func.isRequired(props, propName, component, ...rest);
     }
   },
   buttonLabel: React.PropTypes.string.isRequired,


### PR DESCRIPTION
tl;dr The code for PropType validation function will be removed from production builds of React, so we need to let React know that we are wrapping its PropType.

The details are in https://facebook.github.io/react/warnings/dont-call-proptypes.html.