### PR TITLE
added Powered By Auth0 text on badge for free accounts

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -24,7 +24,7 @@
     -webkit-box-sizing initial
     -moz-box-sizing initial
     box-sizing initial
-  
+
   svg
     background-color transparent
 
@@ -779,6 +779,11 @@
 
     .auth0-lock-badge
       display inline-block
+      color rgba(white,.7)
+      font-size 14px
+      font-family "Avenir"
+      span
+        padding 0 6px
       svg
         vertical-align middle
 

--- a/src/ui/box/container.jsx
+++ b/src/ui/box/container.jsx
@@ -7,7 +7,7 @@ const badgeSvg = '<svg width="18px" height="21px" viewBox="0 0 18 21" version="1
 const BottomBadge = ({link}) => (
   <span className="auth0-lock-badge-bottom">
     <a href={link} target="_blank" className="auth0-lock-badge">
-      <span dangerouslySetInnerHTML={{__html: badgeSvg}} />
+      Powered by<span dangerouslySetInnerHTML={{__html: badgeSvg}} />Auth0
     </a>
   </span>
 );


### PR DESCRIPTION
Added "Powered By Auth0" to Lock  of just the badge for Free accounts. 
![gif lock](https://cloud.githubusercontent.com/assets/1525285/17572773/f3cf5ea8-5f1b-11e6-8d55-3213decc8a86.gif)
