### PR TITLE
Change the default value for hash in WebApi.parseHash() internal method

### DIFF
--- a/src/core/web_api.js
+++ b/src/core/web_api.js
@@ -80,7 +80,7 @@ class Auth0WebAPI {
     client.startPasswordless(options, err => cb(normalizeError(err)));
   }
 
-  parseHash(lockID, hash = undefined) {
+  parseHash(lockID, hash = '') {
     return this.clients[lockID].parseHash(decodeURIComponent(hash));
   }
 


### PR DESCRIPTION
Due to the recent change decoding the hash value, whenever a `decodeURIComponent(undefined)` is done, then the value passed to `auth0-js`'s parseHash() method would be `"undefined"`.
This change prevents possible errors or wrong assumptions inside that method.