### PR TITLE
Fixes corporate network connection usage

### DIFF
--- a/src/connection/enterprise.js
+++ b/src/connection/enterprise.js
@@ -113,9 +113,9 @@ export function isInCorpNetwork(m) {
 }
 
 export function corpNetworkConnection(m) {
-  // TODO: ensure there is a connection there with the expected
-  // format.
-  return m.getIn(["sso", "connection"]);
+  // Information about connection is stored in to flat properties connection and strategy.
+  // If connection is present, strategy will always be present as defined by the server.
+  return  m.getIn(["sso", "connection"]) && Immutable.Map({name:m.getIn(["sso", "connection"]),strategy:m.getIn(["sso","strategy"])});
 }
 
 // hrd


### PR DESCRIPTION
Improves handling of the format sent by the server using and AD connection with Kerberos authentication.

When connecting from a corporate network a user can choose to connect using Kerberos or certificate authentication. In any of these cases lock relies in information provided by the server to validate that the user is in a corporate network and to obtain the name and strategy of the connection associated with the network. 

However, the format of the information is flat inside the `sso` object and not in the connection format used in other cases. The fix manages the flat format and creates a temporary object with the known format to allow `KerberosScreen` to work as expected.

---
- Fixes auth0/lock#590
