### PR TITLE
Introduce clientBaseUrl and languageBaseUrl options to deprecate assetsUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ var options = {
 
 #### Other options
 
-- **assetsUrl {String}**: Will be used as the assets base url. Defaults to Auth0's the CDN url when `domain` has the format `*.auth0.com`. Otherwise, it defaults to `domain`.
+- **clientBaseUrl {String}**: Overrides client settings base url. By default it uses Auth0's CDN url when `domain` has the format `*.auth0.com`. Otherwise, it uses the provided `domain`.
+- **languageBaseUrl {String}**: Overrides the language source url for Auth0's provided translations. By default it uses to Auth0's CDN url `https://cdn.auth0.com`.
 
 #### Language Dictionary Specification
 

--- a/src/core/client/settings.js
+++ b/src/core/client/settings.js
@@ -1,9 +1,9 @@
 import { load } from '../../utils/cdn_utils';
 
-export function fetchClientSettings(clientID, assetsUrl, cb) {
+export function fetchClientSettings(clientID, clientBaseUrl, cb) {
   load({
     method: "setClient",
-    url: `${assetsUrl}/client/${clientID}.js?t${+new Date()}`,
+    url: `${clientBaseUrl}/client/${clientID}.js?t${+new Date()}`,
     check: o => o && o.id === clientID,
     cb: cb
   });

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -21,7 +21,8 @@ const {
 
 export function setup(id, clientID, domain, options, hookRunner, emitEventFn) {
   let m = init(id, Immutable.fromJS({
-    assetsUrl: extractAssetsUrlOption(options, domain),
+    clientBaseUrl: extractClientBaseUrlOption(options, domain),
+    languageBaseUrl: extractLanguageBaseUrlOption(options, domain),
     auth: extractAuthOptions(options),
     clientID: clientID,
     domain: domain,
@@ -48,10 +49,13 @@ export function domain(m) {
   return get(m, "domain");
 }
 
-export function assetsUrl(m) {
-  return get(m, "assetsUrl");
+export function clientBaseUrl(m) {
+  return get(m, "clientBaseUrl");
 }
 
+export function languageBaseUrl(m) {
+  return get(m, "languageBaseUrl");
+}
 export function setSubmitting(m, value, error = "") {
   m = tset(m, "submitting", value);
   m = clearGlobalSuccess(m);
@@ -201,7 +205,11 @@ export function withAuthOptions(m, opts) {
     .toJS();
 }
 
-function extractAssetsUrlOption(opts, domain) {
+function extractClientBaseUrlOption(opts, domain) {
+  if (opts.clientBaseUrl && typeof opts.clientBaseUrl === "string") {
+    return opts.clientBaseUrl;
+  }
+
   if (opts.assetsUrl && typeof opts.assetsUrl === "string") {
     return opts.assetsUrl;
   }
@@ -219,6 +227,19 @@ function extractAssetsUrlOption(opts, domain) {
     return domainUrl;
   }
 }
+
+function extractLanguageBaseUrlOption(opts, domain) {
+  if (opts.languageBaseUrl && typeof opts.languageBaseUrl === "string") {
+    return opts.languageBaseUrl;
+  }
+
+  if (opts.assetsUrl && typeof opts.assetsUrl === "string") {
+    return opts.assetsUrl;
+  }
+
+  return "https://cdn.auth0.com"
+}
+
 
 export function render(m) {
   return tset(m, "render", true);

--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -8,7 +8,7 @@ import sync, { isSuccess } from '../sync';
 
 export function syncRemoteData(m) {
   m = sync(m, "client", {
-    syncFn: (m, cb) => fetchClientSettings(l.clientID(m), l.assetsUrl(m), cb),
+    syncFn: (m, cb) => fetchClientSettings(l.clientID(m), l.clientBaseUrl(m), cb),
     successFn: syncClientSettingsSuccess
   });
 

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -62,7 +62,7 @@ export function initI18n(m) {
 function syncLang(m, language, cb) {
   load({
     method: "registerLanguageDictionary",
-    url: `${l.assetsUrl(m)}/js/lock/${__VERSION__}/${language}.js`,
+    url: `${l.languageBaseUrl(m)}/js/lock/${__VERSION__}/${language}.js`,
     check: str => str && str === language,
     cb: (err, _, dictionary) => {
       cb(err, dictionary);

--- a/support/design/index.js
+++ b/support/design/index.js
@@ -73,7 +73,7 @@ WebAPI.prototype.parseHash = function(lockID, ...args) {
   return null;
 }
 
-ClientSettings.fetchClientSettings = function(clientID, assetsUrl, cb) {
+ClientSettings.fetchClientSettings = function(clientID, clientBaseUrl, cb) {
   // TODO: we should have propper settings for every configuration.
   const settings =  {
     strategies: [


### PR DESCRIPTION
Introduce `languageBaseUrl` and `cliengBaseUrl` in replacement of `assetsUrl`.

- The client will be fetched from `${clientBaseUrl}/${clientID}.js` and will default to the CDN url including the region (e.g. `https://cdn.eu.auth0.com/client`). The region is inferred from the `domain`.
- The language will be fetched from `${languageBaseUrl}/${lang}.js` and will default to the CDN without the region (e.g. `https://cdn.auth0.com/js/lock/${lockVersion}/`).
- The new options have priority over `assetsUrl`.
- If `assetsUrl` is provided, keep the current behavior: fetch client from `${assetsUrl}/client/${clientID}.js` and languages from `{assetsUrl}/js/lock/${lockVersion}/${language}.js`.

### Pending
- [ ] Add `console.warn()` of deprecation when using `assetsUrl`.

---
- Fixes auth0/lock#576