### PR TITLE
Fix EscKeyDownHandler bug in Container when `closable` is false

### DIFF
--- a/src/ui/box/container.jsx
+++ b/src/ui/box/container.jsx
@@ -68,11 +68,15 @@ export default class Container extends React.Component {
       setTimeout(() => this.setState({isOpen: true}), 17);
     }
 
-    this.escKeydown = new EscKeyDownHandler(::this.handleEsc);
+    if (this.props.closeHandler) {
+      this.escKeydown = new EscKeyDownHandler(::this.handleEsc);
+    }
   }
 
   componentWillUnmount() {
-    this.escKeydown.release();
+    if (this.escKeydown) {
+      this.escKeydown.release();
+    }
   }
 
   handleSubmit(e) {


### PR DESCRIPTION
**Description:**
There is a bug in lock when Container is set to `container: "name"` and the `ESC` button is pressed, this error occurs:
```js
Uncaught TypeError: closeHandler is not a function - container.js:119
  handleClose @ container.js:119
  handleEsc @ container.js:128
  EscKeyDownHandler.handler @ container.js:54
```

The lock has the  `container` UI option set to `true`, which should cause `closable` to change to `false` as well, as per the [#Customization](https://github.com/auth0/lock#customization) section in the docs - so this behavior should not be expected, since the lock is still expecting a function to handle close.

**Changes Proposed:**

- Add condition to only mount **Container** component with `EscKeyDownHandler` to `this.escKeydown` when a `closeHandler` prop exists.

- Add condition to only release `this.escKeydown` if `this.escKeydown` exists on **Container** unmount.

The changes above should prevent any further errors from the container attempting to close, when it should not be able to.