### PR TITLE
Remove absolute positioning that brakes alignment on small screens

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -924,15 +924,6 @@ tabsHeight = 40px
       .auth0-lock-form p
         @media screen and (max-width: 480px)
           font-size 14px
-    
-    .auth0-lock-tabs-container
-      //mobile view
-      @media screen and (max-width: 480px)
-        position absolute
-        top 0
-        left 0
-        width 100%
-        margin 0
 
 
     .auth0-lock-terms


### PR DESCRIPTION
The absolute positioning introduced in https://github.com/auth0/lock/pull/597 breakes alignment as the siblings of the tabs-container do not get absolute positioning in small screens. Also since we have to go high up in the parents hierarchy to get a positioned parent, it should be better to not have the absolute positioning here. I also checked that the terms still remain beneath password:

Before:
![screen shot 2016-09-12 at 5 55 48 pm](https://cloud.githubusercontent.com/assets/6305959/18458000/35ab531c-7912-11e6-9386-8404c60df822.png)

After:
![screen shot 2016-09-12 at 5 50 20 pm](https://cloud.githubusercontent.com/assets/6305959/18458004/39fc7bbc-7912-11e6-8f5c-a62960b005b2.png)
