### PR TITLE
Handle uncaught unrecoverable_error

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -343,7 +343,14 @@ export function runHook(m, str, ...args) {
 }
 
 export function emitEvent(m, str, ...args) {
-  setTimeout(() => get(m, "emitEventFn")(str, ...args), 0);
+  setTimeout(() => {
+    const emitEventFn = get(m, "emitEventFn");
+    const hadListener = emitEventFn(str, ...args);
+    // Handle uncaught custom error
+    if (str === "unrecoverable_error" && !hadListener) {
+      throw new Error(...arg);
+    }
+  }, 0);
 }
 
 export function loginErrorMessage(m, error, type) {


### PR DESCRIPTION
Since the `emitEventFn` inherits from `EventEmitter` and custom errors are being emitted, the default `error` event will not be triggered.

This change checks if an `unrecoverable_error` is being emitted and throws it if there are no attached listeners.

An `unrecoverable_error` can be triggered for testing by turning off all Client Connections and trying to create an instance of Lock.