### PR TITLE
Add min/max username validation from client info settings

### DIFF
--- a/src/core/client/index.js
+++ b/src/core/client/index.js
@@ -45,7 +45,7 @@ function strategyNameToConnectionType(str) {
 }
 
 function formatConnectionValidation (connectionValidation = {}) {
-  const validation = Object.assign({}, DEFAULT_CONNECTION_VALIDATION, connectionValidation);
+  const validation = { ...DEFAULT_CONNECTION_VALIDATION, ...connectionValidation };
   const defaultMin = DEFAULT_CONNECTION_VALIDATION.username.min;
   const defaultMax = DEFAULT_CONNECTION_VALIDATION.username.max;
 

--- a/src/core/client/index.js
+++ b/src/core/client/index.js
@@ -6,6 +6,8 @@ import { STRATEGIES as ENTERPRISE_STRATEGIES } from '../../connection/enterprise
 
 const { initNS, get } = dataFns(["client"]);
 
+const DEFAULT_CONNECTION_VALIDATION = { username: { min: 1, max: 15 } };
+
 export function hasFreeSubscription(m) {
   return ["free", "dev"].indexOf(get(m, ["tenant", "subscription"])) > -1;
 }
@@ -40,6 +42,22 @@ function strategyNameToConnectionType(str) {
   } else {
     return "unknown";
   }
+}
+
+function formatConnectionValidation (connectionValidation = {}) {
+  const validation = Object.assign({}, DEFAULT_CONNECTION_VALIDATION, connectionValidation);
+  const defaultMin = DEFAULT_CONNECTION_VALIDATION.username.min;
+  const defaultMax = DEFAULT_CONNECTION_VALIDATION.username.max;
+
+  validation.username.min = parseInt(validation.username.min, 10) || defaultMin;
+  validation.username.max = parseInt(validation.username.max, 10) || defaultMax;
+
+  if (validation.username.min > validation.username.max) {
+    validation.username.min = defaultMin;
+    validation.username.max = defaultMax;
+  }
+
+  return validation;
 }
 
 const emptyConnections = Immutable.fromJS({
@@ -98,6 +116,7 @@ function formatClientConnection(connectionType, strategyName, connection) {
     result.requireUsername = typeof connection.requires_username === "boolean"
       ? connection.requires_username
       : false;
+    result.validation = formatConnectionValidation(connection.validation);
   }
 
   if (connectionType === "enterprise") {

--- a/src/field/username.js
+++ b/src/field/username.js
@@ -2,12 +2,27 @@ import { setField } from './index';
 import { validateEmail } from './email';
 import trim from 'trim';
 
-const regExp = /^[a-zA-Z0-9_]{1,15}$/;
+const regExp = /^[a-zA-Z0-9_]+$/;
 
-function validateUsername(str, validateFormat) {
-  if (!validateFormat) return trim(str).length > 0;
+function validateUsername(str, validateFormat, settings = { min: 1, max: 15 }) {
+  if (!validateFormat) {
+    return trim(str).length > 0;
+  }
 
-  const result = regExp.exec(trim(str.toLowerCase()));
+  const lowercased = trim(str.toLowerCase());
+
+  // chekc min value matched
+  if (lowercased.length <= settings.min) {
+    return false;
+  }
+
+  // check max value matched
+  if (lowercased.length >= settings.max) {
+    return false;
+  }
+
+  // check allowed characters matched
+  const result = regExp.exec(lowercased);
   return result && result[0];
 }
 

--- a/src/field/username.js
+++ b/src/field/username.js
@@ -29,10 +29,12 @@ function validateUsername(str, validateFormat, settings = DEFAULT_CONNECTION_VAL
   return result && result[0];
 }
 
+export function getUsernameValidation(m) {
+  return databaseConnection(m).getIn(['validation', 'username']).toJS()
+}
+
 export function setUsername(m, str, usernameStyle = "username", validateUsernameFormat = true) {
-  const usernameValidation = validateUsernameFormat
-    ? databaseConnection(m).getIn(['validation', 'username']).toJS()
-    : null;
+  const usernameValidation = validateUsernameFormat ? getUsernameValidation(m) : null;
 
   const validator = value => {
     switch (usernameStyle) {

--- a/src/field/username/username_pane.jsx
+++ b/src/field/username/username_pane.jsx
@@ -3,7 +3,7 @@ import UsernameInput from '../../ui/input/username_input';
 import * as c from '../index';
 import { swap, updateEntity } from '../../store/index';
 import * as l from '../../core/index';
-import { setUsername, usernameLooksLikeEmail } from '../username';
+import { setUsername, usernameLooksLikeEmail, getUsernameValidation } from '../username';
 import { debouncedRequestAvatar, requestAvatar } from '../../avatar';
 
 export default class UsernamePane extends React.Component {
@@ -27,17 +27,28 @@ export default class UsernamePane extends React.Component {
   render() {
     const { i18n, lock, placeholder, validateFormat } = this.props;
     const value = c.getFieldValue(lock, "username");
+    const usernameValidation = validateFormat ? getUsernameValidation(lock) : {};
 
-    const invalidHintKey = str => {
+    const invalidHintKey = (str) => {
       if (!str) return "blankErrorHint";
       if (usernameLooksLikeEmail(str) || !validateFormat) return "invalidErrorHint";
       return "usernameFormatErrorHint";
     };
 
+    const invalidHint = (str) => {
+      const hintKey = invalidHintKey(str);
+
+      if ("usernameFormatErrorHint" === hintKey && validateFormat) {
+        return i18n.str(hintKey, usernameValidation.min, usernameValidation.max)
+      }
+
+      return i18n.str(hintKey)
+    }
+
     return (
       <UsernameInput
         value={value}
-        invalidHint={i18n.str(invalidHintKey(value))}
+        invalidHint={invalidHint(value)}
         isValid={!c.isFieldVisiblyInvalid(lock, "username")}
         onChange={::this.handleChange}
         placeholder={placeholder}

--- a/src/i18n/da.js
+++ b/src/i18n/da.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Single Sign-On aktiveret",
   submitLabel: "Send",
   unrecoverableError: "Der skete en fejl.<br />Kontakt venligst den tekniske support.",
-  usernameFormatErrorHint: "Brug 1-15 bogstaver, numre og \"_\"",
+  usernameFormatErrorHint: "Brug %d-%d bogstaver, numre og \"_\"",
   usernameInputPlaceholder: "dit brugernavn",
   usernameOrEmailInputPlaceholder: "brugernavn/email",
   title: "Auth0",

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Single Sign-On aktiviert",
   submitLabel: "Einreichen",
   unrecoverableError: "Etwas ist schief gelaufen.<br />Bitte kontaktieren Sie den technischen Support.",
-  usernameFormatErrorHint: "Verwenden Sie 1-15 Buchstaben, Zahlen und \"_\"",
+  usernameFormatErrorHint: "Verwenden Sie %d-%d Buchstaben, Zahlen und \"_\"",
   usernameInputPlaceholder: "dein Benutzername",
   usernameOrEmailInputPlaceholder: "Benutzername/E-Mail",
   title: "Auth0",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Single Sign-On enabled",
   submitLabel: "Submit",
   unrecoverableError: "Something went wrong.<br />Please contact technical support.",
-  usernameFormatErrorHint: "Use 1-15 letters, numbers and \"_\"",
+  usernameFormatErrorHint: "Use %d-%d letters, numbers and \"_\"",
   usernameInputPlaceholder: "your username",
   usernameOrEmailInputPlaceholder: "username/email",
   title: "Auth0",

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Inicio de sesión único activado",
   submitLabel: "Enviar",
   unrecoverableError: "Ocurrió un error.<br />Por favor, contacte a soporte técnico.",
-  usernameFormatErrorHint: "1-15 letras, números y \"_\"",
+  usernameFormatErrorHint: "%d-%d letras, números y \"_\"",
   usernameInputPlaceholder: "su usuario",
   usernameOrEmailInputPlaceholder: "usuario/correo electrónico",
   title: "Auth0",

--- a/src/i18n/fr.js
+++ b/src/i18n/fr.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Authentification unique activée",
   submitLabel: "Envoyer",
   unrecoverableError: "Un problème est survenu.<br />Veuillez contacter l’assistance technique.",
-  usernameFormatErrorHint: "Utilisez entre 1-15 lettres, chiffres et «&nbsp;_&nbsp;»",
+  usernameFormatErrorHint: "Utilisez entre %d-%d lettres, chiffres et «&nbsp;_&nbsp;»",
   usernameInputPlaceholder: "votre nom d’utilisateur",
   usernameOrEmailInputPlaceholder: "nom d’utilisateur/adresse de messagerie",
   title: "Auth0",

--- a/src/i18n/hu.js
+++ b/src/i18n/hu.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Egyszeri bejelentkezés engedélyezve",
   submitLabel: "Mehet",
   unrecoverableError: "Valaim hiba történt.<br />Kérlek, lépj kapcsolatba a műszaki ügyfélszolgálattal.",
-  usernameFormatErrorHint: "Használj 1-15 betűt, számot és \"_\"-t",
+  usernameFormatErrorHint: "Használj %d-%d betűt, számot és \"_\"-t",
   usernameInputPlaceholder: "felhasználóneved",
   usernameOrEmailInputPlaceholder: "felhasználónév/e-mail",
   title: "Auth0",

--- a/src/i18n/it.js
+++ b/src/i18n/it.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Single Sign-On abilitati",
   submitLabel: "Invio", // needs review
   unrecoverableError: "Qualcosa è andato storto.<br />Si prega di contattare il supporto tecnico.",
-  usernameFormatErrorHint: "Si prega di utilizzare 1-15 lettere, numeri e \"_\"",
+  usernameFormatErrorHint: "Si prega di utilizzare %d-%d lettere, numeri e \"_\"",
   usernameInputPlaceholder: "il Suo nome utente",
   usernameOrEmailInputPlaceholder: "il Suo nome utente or email", // TODO
   title: "Auth0",

--- a/src/i18n/nb.js
+++ b/src/i18n/nb.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Single Sign-On aktivert",
   submitLabel: "Send",
   unrecoverableError: "Noe gikk galt.<br />Ta kontakt med teknisk support.",
-  usernameFormatErrorHint: "Bruk 1-15 bokstaver, tall og \"_\"",
+  usernameFormatErrorHint: "Bruk %d-%d bokstaver, tall og \"_\"",
   usernameInputPlaceholder: "ditt brukernavn",
   usernameOrEmailInputPlaceholder: "brukernavn/epost",
   title: "Auth0",

--- a/src/i18n/pt-br.js
+++ b/src/i18n/pt-br.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Single Sign-On habilitado",
   submitLabel: "Enviar", // needs review
   unrecoverableError: "Algo deu errado.<br />Por favor entre em contato com o suporte.",
-  usernameFormatErrorHint: "Use 1-15 letras, números e \"_\"",
+  usernameFormatErrorHint: "Use %d-%d letras, números e \"_\"",
   usernameInputPlaceholder: "seu nome de usuário",
   usernameOrEmailInputPlaceholder: "usuário/email",
   title: "Auth0",

--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Единый вход включен",
   submitLabel: "Отправить", // needs review
   unrecoverableError: "Произошла непредвиденная ошибка.<br />Пожалуйста, обратитесь в службу технической поддержки.",
-  usernameFormatErrorHint: "Используйте 1-15 букв, цифр и \"_\"",
+  usernameFormatErrorHint: "Используйте %d-%d букв, цифр и \"_\"",
   usernameInputPlaceholder: "Ваше имя пользователя",
   useranmeOrEmailInputPlaceholder: "электронной почты/пользователя", // TODO review
   title: "Auth0",

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "Single Sign-On aktiverad",
   submitLabel: "Skicka",
   unrecoverableError: "Något gick fel.<br />Vänligen kontakta teknisk support.",
-  usernameFormatErrorHint: "Använd 1-15 bokstäver, siffror och \"_\"",
+  usernameFormatErrorHint: "Använd %d-%d bokstäver, siffror och \"_\"",
   usernameInputPlaceholder: "ditt användarnamn",
   usernameOrEmailInputPlaceholder: "användarnamn/e-postadress",
   title: "Auth0",

--- a/src/i18n/zh.js
+++ b/src/i18n/zh.js
@@ -92,7 +92,7 @@ export default {
   ssoEnabled: "单点登录已激活",
   submitLabel: "提交", // needs review
   unrecoverableError: "出现错误。<br />请联系技术人员。",
-  usernameFormatErrorHint: "请使用1-15个字母, 数字或 \"_\"的组合",
+  usernameFormatErrorHint: "请使用%d-%d个字母, 数字或 \"_\"的组合",
   usernameInputPlaceholder: "您的用户名",
   usernameOrEmailInputPlaceholder: "用户名/邮箱",
   title: "Auth0",


### PR DESCRIPTION
After the introduction of the new feature for configuring username validation min/max values at Auth0 we required to handle those modifications within the Lock UI. Therefore:

1. If the validation settings is defined within the client info object, use those parameters (configured from the [Dashboard](https://manage.auth0.com/#/connections/database))
2. If validation settings is missing from within the client info settings, defaults to the current values `{min: 1, max: 15}`.
3. No validations are performed for `enterprise` connections, as it was the previous behavior.

