### PR TITLE
Bump blueimp-md5@2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,14 +63,14 @@
   },
   "dependencies": {
     "auth0-js": "7.1.0",
-    "blueimp-md5": "1.1.1",
+    "blueimp-md5": "2.3.1",
     "fbjs": "^0.3.1",
     "immutable": "^3.7.3",
     "jsonp": "^0.2.0",
     "password-sheriff": "^1.0.0",
     "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0",
     "react-addons-css-transition-group": "^15.0.0 || ^16.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0",
     "trim": "0.0.1"
   }
 }


### PR DESCRIPTION
Bumping `blueimp-md5@2.3.1` which introduces a set of updates in the module loader.

- Fixes https://github.com/auth0/lock/issues/466
