### PR TITLE
Support connectionScopes for oauth2 connections

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -159,6 +159,7 @@ export const ui = {
 const { get: getAuthAttribute } = dataFns(["core", "auth"]);
 
 export const auth = {
+  connectionScopes: m => getAuthAttribute(m, "connectionScopes"),
   params: m => tget(m, "authParams") || getAuthAttribute(m, "params"),
   redirect: lock => getAuthAttribute(lock, "redirect"),
   redirectUrl: lock => getAuthAttribute(lock, "redirectUrl"),
@@ -169,6 +170,7 @@ export const auth = {
 
 function extractAuthOptions(options) {
   let {
+    connectionScopes,
     params,
     redirect,
     redirectUrl,
@@ -177,6 +179,7 @@ function extractAuthOptions(options) {
     sso
   } = options.auth || {};
 
+  connectionScopes = typeof connectionScopes === "object" ? connectionScopes : {};
   params = typeof params === "object" ? params : {};
   redirectUrl = typeof redirectUrl === "string" && redirectUrl ? redirectUrl : undefined;
   redirect = typeof redirect === "boolean" ? redirect : true;
@@ -190,6 +193,7 @@ function extractAuthOptions(options) {
   }
 
   return Immutable.fromJS({
+    connectionScopes,
     params,
     redirect,
     redirectUrl,

--- a/src/quick-auth/actions.js
+++ b/src/quick-auth/actions.js
@@ -9,7 +9,13 @@ export function skipQuickAuth(id) {
 
 export function logIn(id, connection, loginHint) {
   const m = read(getEntity, "lock", id);
-  const params = {connection: connection.get("name")};
+  const connectionScopes = l.auth.connectionScopes(m);
+  const scopes = connectionScopes.get(connection.get("strategy"));
+  const params = {
+    connection: connection.get("name"), 
+    connection_scope: scopes ? scopes.toJS() : []
+  };
+  
   if (!l.auth.redirect(m) && connection.get("strategy") === "facebook") {
     params.display = "popup";
   }

--- a/test/helper/ui.js
+++ b/test/helper/ui.js
@@ -27,6 +27,13 @@ export const stubWebApis = () => {
   });
 }
 
+export const assertAuthorizeRedirection = (cb) => {
+  if (webApi.logIn.restore) {
+    webApi.logIn.restore();
+  }
+  stub(webApi, "logIn", cb);
+};
+
 export const restoreWebApis = () => {
   webApi.logIn.restore();
   gravatarProvider.displayName.restore();
@@ -154,8 +161,13 @@ export const isSubmitButtonDisabled = hasFn("button.auth0-lock-submit[disabled]"
 const check = (lock, query) => {
   Simulate.change(q(lock, query), {});
 };
+const click = (lock, query) => {
+  Simulate.click(q(lock, query));
+};
 const checkFn = query => lock => check(lock, query);
+const clickFn = (lock, query) => click(lock, query);
 export const clickTermsCheckbox = checkFn(".auth0-lock-sign-up-terms-agreement label input[type='checkbox']");
+export const clickSocialConnectionButton = (lock, connection) => clickFn(lock, `.auth0-lock-social-button[data-provider='${connection}']`);
 const fillInput = (lock, name, str) => {
   Simulate.change(qInput(lock, name, true), {target: {value: str}});
 };

--- a/test/social_login.test.js
+++ b/test/social_login.test.js
@@ -1,0 +1,36 @@
+import expect from 'expect.js';
+import Auth0Lock from '../src/index';
+import * as h from './helper/ui';
+
+describe("show lock connection scopes", function() {
+
+  beforeEach(function(done) {
+    h.stubWebApis();
+    const opts = {
+      auth: {
+        connectionScopes: {
+          'facebook': ['scope_1', 'scope_2']
+        }
+      }
+    };
+    this.lock = h.displayLock("multiple social", opts, done);
+  });
+
+  afterEach(function() {
+    this.lock.hide();
+    h.restoreWebApis();
+  });
+
+  it("should show an error flash message", function(done) {
+    h.assertAuthorizeRedirection((lockID, options, authParams) => {
+      expect(options).to.be.an('object');
+      expect(options.connection).to.be('facebook');
+      expect(options.connection_scope).to.be.an('array');
+      expect(options.connection_scope).to.have.length(2);
+      expect(options.connection_scope).to.contain('scope_1');
+      expect(options.connection_scope).to.contain('scope_2');
+      done();
+    })
+    h.clickSocialConnectionButton(this.lock, 'facebook');
+  });
+});


### PR DESCRIPTION
```js
Auth0Lock(cid, domain, {
  auth: {
    connectionScopes: {
      'google-oauth': ['scope1', 'scope2'],
      'facebook': ['scope1', 'scope2']
    }
  }
});
```