### PR TITLE
Added default values to the dictionary and warn about missing keys

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -29,7 +29,8 @@ export function setup(id, clientID, domain, options, hookRunner, emitEventFn) {
     emitEventFn: emitEventFn,
     hookRunner: hookRunner,
     allowedConnections: Immutable.fromJS(options.allowedConnections || []),
-    ui: extractUIOptions(id, options)
+    ui: extractUIOptions(id, options),
+    debug_mode: options.__DEBUG || false
   }));
 
   m = i18n.initI18n(m);
@@ -425,7 +426,13 @@ export function emitAuthorizationErrorEvent(m, error) {
 }
 
 export function emitUnrecoverableErrorEvent(m, error) {
-  emitEvent(m, "unrecoverable_error", error)
+  emitEvent(m, "unrecoverable_error", error);
+}
+
+export function emitDebugInfo(m, level, message){
+  if (get(m, "debug_mode")) {
+    console[level](message);
+  }
 }
 
 export function showBadge(m) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -29,8 +29,7 @@ export function setup(id, clientID, domain, options, hookRunner, emitEventFn) {
     emitEventFn: emitEventFn,
     hookRunner: hookRunner,
     allowedConnections: Immutable.fromJS(options.allowedConnections || []),
-    ui: extractUIOptions(id, options),
-    debug_mode: options.__DEBUG || false
+    ui: extractUIOptions(id, options)
   }));
 
   m = i18n.initI18n(m);
@@ -427,12 +426,6 @@ export function emitAuthorizationErrorEvent(m, error) {
 
 export function emitUnrecoverableErrorEvent(m, error) {
   emitEvent(m, "unrecoverable_error", error);
-}
-
-export function emitDebugInfo(m, level, message){
-  if (get(m, "debug_mode")) {
-    console[level](message);
-  }
 }
 
 export function showBadge(m) {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -31,7 +31,7 @@ export function initI18n(m) {
 
   let base = languageDictionaries[language] || Map({});
 
-  if (base.isEmpty()) {
+  if (base.isEmpty()) { 
     base = overrides;
     m = sync(m, "i18n", {
       syncFn: (_, cb) => syncLang(m, language, cb),
@@ -41,7 +41,7 @@ export function initI18n(m) {
 
         const overrided = Immutable.fromJS(result).mergeDeep(overrides);
 
-        assertLanguage(overrided.toJS(), enDictionary);
+        assertLanguage(m, overrided.toJS(), enDictionary);
 
         return set(
           m,
@@ -51,7 +51,7 @@ export function initI18n(m) {
       }
     });
   } else {
-    assertLanguage(base.toJS(), enDictionary);
+    assertLanguage(m, base.toJS(), enDictionary);
   }
 
   base = defaultDictionary.mergeDeep(base).mergeDeep(overrides);
@@ -59,13 +59,13 @@ export function initI18n(m) {
   return set(m, "strings", base);
 }
 
-function assertLanguage(language, base, path = "") { 
+function assertLanguage(m, language, base, path = "") { 
   Object.keys(base).forEach( key => {
     if (!language.hasOwnProperty(key)) {
-      console.warn(`language does not have property ${path}${key}`);
+      l.emitDebugInfo(m, 'warn', `language does not have property ${path}${key}`);
     } else {
       if (typeof base[key] === 'object') {
-        assertLanguage(language[key], base[key], `${path}${key}.`);
+        assertLanguage(m, language[key], base[key], `${path}${key}.`);
       }
     }
   });
@@ -73,7 +73,7 @@ function assertLanguage(language, base, path = "") {
 
 // sync
 
-function syncLang(m, language, cb) {
+function syncLang(m, language, cb) { 
   load({
     method: "registerLanguageDictionary",
     url: `${l.languageBaseUrl(m)}/js/lock/${__VERSION__}/${language}.js`,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -25,6 +25,7 @@ export function group(m, keyPath) {
 }
 
 export function initI18n(m) {
+
   const language = l.ui.language(m);
   const overrides = l.ui.dict(m);
   const defaultDictionary = Immutable.fromJS(enDictionary);
@@ -36,7 +37,6 @@ export function initI18n(m) {
     m = sync(m, "i18n", {
       syncFn: (_, cb) => syncLang(m, language, cb),
       successFn: (m, result) => {
-
         registerLanguageDictionary(language, result);
 
         const overrided = Immutable.fromJS(result).mergeDeep(overrides);
@@ -62,7 +62,7 @@ export function initI18n(m) {
 function assertLanguage(m, language, base, path = "") { 
   Object.keys(base).forEach( key => {
     if (!language.hasOwnProperty(key)) {
-      l.emitDebugInfo(m, 'warn', `language does not have property ${path}${key}`);
+      l.warn(m, `language does not have property ${path}${key}`);
     } else {
       if (typeof base[key] === 'object') {
         assertLanguage(m, language[key], base[key], `${path}${key}.`);

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -27,6 +27,7 @@ export function group(m, keyPath) {
 export function initI18n(m) {
   const language = l.ui.language(m);
   const overrides = l.ui.dict(m);
+  const defaultDictionary = Immutable.fromJS(enDictionary);
 
   let base = languageDictionaries[language] || Map({});
 
@@ -35,26 +36,39 @@ export function initI18n(m) {
     m = sync(m, "i18n", {
       syncFn: (_, cb) => syncLang(m, language, cb),
       successFn: (m, result) => {
+
         registerLanguageDictionary(language, result);
+
+        const overrided = Immutable.fromJS(result).mergeDeep(overrides);
+
+        assertLanguage(overrided.toJS(), enDictionary);
 
         return set(
           m,
           "strings",
-          languageDictionaries[language].mergeDeep(overrides)
+          defaultDictionary.mergeDeep(overrided)
         );
       }
     });
+  } else {
+    assertLanguage(base.toJS(), enDictionary);
   }
 
-  if (!base.has("title")) {
-    base = base.set("title", enDictionary.title);
-  }
+  base = defaultDictionary.mergeDeep(base).mergeDeep(overrides);
 
-  if (!base.has("unrecoverableError")) {
-    base = base.set("unrecoverableError", enDictionary.unrecoverableError);
-  }
+  return set(m, "strings", base);
+}
 
-  return set(m, "strings", base.mergeDeep(overrides));
+function assertLanguage(language, base, path = "") { 
+  Object.keys(base).forEach( key => {
+    if (!language.hasOwnProperty(key)) {
+      console.warn(`language does not have property ${path}${key}`);
+    } else {
+      if (typeof base[key] === 'object') {
+        assertLanguage(language[key], base[key], `${path}${key}.`);
+      }
+    }
+  });
 }
 
 // sync

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -25,14 +25,13 @@ export function group(m, keyPath) {
 }
 
 export function initI18n(m) {
-
   const language = l.ui.language(m);
   const overrides = l.ui.dict(m);
   const defaultDictionary = Immutable.fromJS(enDictionary);
 
   let base = languageDictionaries[language] || Map({});
 
-  if (base.isEmpty()) { 
+  if (base.isEmpty()) {
     base = overrides;
     m = sync(m, "i18n", {
       syncFn: (_, cb) => syncLang(m, language, cb),
@@ -73,7 +72,7 @@ function assertLanguage(m, language, base, path = "") {
 
 // sync
 
-function syncLang(m, language, cb) { 
+function syncLang(m, language, cb) {
   load({
     method: "registerLanguageDictionary",
     url: `${l.languageBaseUrl(m)}/js/lock/${__VERSION__}/${language}.js`,

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -87,7 +87,7 @@ export default {
   sentLabel: "Sent!",
   signUpLabel: "Sign Up",
   signUpSubmitLabel: "Sign Up",
-  signUpTerms: "",
+  signUpTerms: "I agree to the <a href='/terms' target='_new'>terms of service</a> and <a href='/privacy' target='_new'>privacy policy</a>.",
   signUpWithLabel: "Sign up with %s",
   socialLoginInstructions: "",
   socialSignUpInstructions: "",

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -87,7 +87,7 @@ export default {
   sentLabel: "Sent!",
   signUpLabel: "Sign Up",
   signUpSubmitLabel: "Sign Up",
-  signUpTerms: "I agree to the <a href='/terms' target='_new'>terms of service</a> and <a href='/privacy' target='_new'>privacy policy</a>.",
+  signUpTerms: "",
   signUpWithLabel: "Sign up with %s",
   socialLoginInstructions: "",
   socialSignUpInstructions: "",

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -1,0 +1,54 @@
+import expect from 'expect.js';
+import Immutable from 'immutable';
+import {initI18n} from '../src/i18n';
+import { go } from '../src/sync';
+import { swap, setEntity, updateEntity, observe } from '../src/store/index';
+import { dataFns } from '../src/utils/data_utils';
+
+import enDictionary from '../src/i18n/en';
+import esDictionary from '../src/i18n/es';
+
+const core = dataFns(["core"]);
+
+describe("load i18n configuration", function() {
+
+  it("should merge and warn missing keys", function(done) {
+
+    const id = 1;
+
+    var m = Immutable.fromJS({
+      languageBaseUrl: "https://cdn.auth0.com",
+      ui: {
+        disableWarnings: true,
+        language: "es"
+      }
+    });
+    
+    go(id);
+
+    observe("test", id, (m) => { 
+      if (m.getIn(['sync', 'i18n', 'syncStatus']) === 'ok') {
+        assertLanguage(m.getIn(['i18n', 'strings']).toJS(), enDictionary, esDictionary)
+        done();
+      }
+    });
+    
+    m = core.init(id, m);
+
+    m = initI18n(m);
+
+    m = swap(setEntity, "lock", id, m);
+  });
+});
+
+function assertLanguage(language, en, es) { 
+  Object.keys(en).forEach( (key) => {
+    expect(language).to.have.property(key);
+    if (typeof en[key] === 'object') {
+      assertLanguage(language[key], en[key], es[key]);
+    }
+    else {
+      expect([en[key], es[key]]).to.contain(language[key]);
+    }
+  });
+}


### PR DESCRIPTION
- It will use the `en` dictionary as a default for missing keys.
- If there is any missing key, it will throw a warning in the console.