### PR TITLE
Change description of notYourAccountAction

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -60,7 +60,7 @@ export default {
   loginLabel: "Log In",
   loginSubmitLabel: "Log In",
   loginWithLabel: "Log in with %s",
-  notYourAccountAction: "Not your account?",
+  notYourAccountAction: "Use a different account",
   passwordInputPlaceholder: "your password",
   passwordStrength: {
     containsAtLeast: "Contain at least %d of the following %d types of characters:",


### PR DESCRIPTION
I'd like to propose changing the description of this action, because I think it makes more sense to an end user with multiple identities.  It could be unclear to the end user how to retrieve the additional identity options if this is technically their account, but they just want to use a different identity provider.

I also have a bit more context available in this issue, which describes reproduction steps.

https://github.com/mozilla-iam/auth0-deploy/issues/53