### PR TITLE
Shorten Russian signUpLabel to fit into the widget width

### DIFF
--- a/src/i18n/ru.js
+++ b/src/i18n/ru.js
@@ -83,7 +83,7 @@ export default {
   resendingLabel: "Повторная отправка...",
   retryLabel: "Повторить попытку",
   sentLabel: "Отправлено!",
-  signUpLabel: "Зарегистрироваться",
+  signUpLabel: "Регистрация",
   signUpSubmitLabel: "Зарегистрироваться", // needs review
   signUpTerms: "",
   signUpWithLabel: "Зарегистрироваться через %s",


### PR DESCRIPTION
Please change the Russian translation for the signUpLabel key from "Зарегистрироваться" to "Регистрация". Semantically it's the same but "Зарегистрироваться" is longer and does not fit well into the width of container. Consider the following screenshots:

![image](https://cloud.githubusercontent.com/assets/5896622/20858187/26c73310-b950-11e6-85aa-9185f8fc71d9.png)

![image](https://cloud.githubusercontent.com/assets/5896622/20858207/879477fc-b950-11e6-9d83-5e69e12dc110.png)
