### PR TITLE
Don't emit error when registering for event 'signin ready'

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -39,7 +39,8 @@ export default class Base extends EventEmitter {
       'unrecoverable_error',
       'authenticated',
       'authorization_error',
-      'hash_parsed'
+      'hash_parsed',
+      'signin ready'
     ];
 
     this.id = idu.incremental();

--- a/src/core.js
+++ b/src/core.js
@@ -40,7 +40,8 @@ export default class Base extends EventEmitter {
       'authenticated',
       'authorization_error',
       'hash_parsed',
-      'signin ready'
+      'signin ready',
+      'signup ready'
     ];
 
     this.id = idu.incremental();


### PR DESCRIPTION
### Problem 

Looks like Lock v10.8.0 added event validation via https://github.com/auth0/lock/pull/756. However this feature emits error messages for many events that Lock makes available (e.g. those events from https://github.com/auth0/docs/pull/191). 

This bug occurs on all supported browsers and operating systems since at least the v10.8.0 release, including the latest version today.

### Fix

I simply added 'signin ready' to the whitelist of valid events: https://github.com/auth0/lock/blob/master/src/core.js#L36

There are other events in https://github.com/auth0/docs/pull/191 that have the same issue but for my purposes I only need 'signin ready' fixed in order to unblock my production issue. 

When I build this branch locally I no longer see the 'Invalid event' console error.

### Issue Reproduction

The following code in my application results in the error `Invalid event "signin ready".`.

Here's the same code in a codepen so you can confirm that 'Invalid event' shows up in the browser console: http://codepen.io/theopak/pen/QdjVZX

```js
lock.show()

// This function adds a message to the Lock.js dialog box, 
// as a proof-of-concept of something that can only be done
// after the 'signin ready' event is triggered.
const addMessageToLock = (event) => {
  let myDiv = document.createElement('h4')
  myDiv.style.textAlign = 'center'
  myDiv.style.textAlign = 'center'
  myDiv.innerHTML = 'Example Message Added to Lock'
  const targetNode = document.getElementsByClassName('auth0-lock-input-block')[0].parentNode
  targetNode.insertBefore(myDiv, targetNode.firstChild)
}

// Here's an example of how the 'signin ready' event is used
// to do something that's only possible after Lock.js is in 
// the DOM and done appearing.
lock.on('signin ready', addMessageToLock)
```