### PR TITLE
Bump auth0.js to 8.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "zuul-ngrok": "gnandretta/zuul-ngrok#upgrade-ngrok"
   },
   "dependencies": {
-    "auth0-js": "8.1.1",
+    "auth0-js": "8.1.2",
     "blueimp-md5": "2.3.1",
     "fbjs": "^0.3.1",
     "idtoken-verifier": "^1.0.1",


### PR DESCRIPTION
In the previous version of auth0.js, it whitelisted oauth2 only parameters, that produced to lost some parameters needed by auth0-server to carry on session information.