### PR TITLE
Fix a box-sizing issue that happened when bootstrap was being used with lock

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -156,6 +156,9 @@ tabsHeight = 40px
     box-sizing border-box
 
   .auth0-lock-close-button, .auth0-lock-back-button
+    -webkit-box-sizing content-box !important
+    -moz-box-sizing content-box !important
+    box-sizing content-box !important  
     background white
     border-radius 100px
     height 10px


### PR DESCRIPTION
fix #767 

### IE
![2017-02-10 14_01_01-dev - internet explorer](https://cloud.githubusercontent.com/assets/941075/22833593/a154f6ce-ef99-11e6-9b0d-574543097be1.png)

### Chrome
![2017-02-10 14_00_47-dev](https://cloud.githubusercontent.com/assets/941075/22833591/a13b93f0-ef99-11e6-9a5f-28adfa32236d.png)
