### PR TITLE
 Don't disable mfa-code input

### DIFF
--- a/src/__tests__/field/__snapshots__/mfa_code_pane.test.jsx.snap
+++ b/src/__tests__/field/__snapshots__/mfa_code_pane.test.jsx.snap
@@ -8,21 +8,9 @@ Array [
 ]
 `;
 
-exports[`MFACodePane disables input when submitting 1`] = `
-<div
-  data-__type="mfa_code_input"
-  data-disabled={true}
-  data-invalidHint="mfaCodeErrorHint,6"
-  data-isValid={false}
-  data-onChange={[Function]}
-  data-placeholder="placeholder"
-  data-value="mfa" />
-`;
-
 exports[`MFACodePane renders correctly 1`] = `
 <div
   data-__type="mfa_code_input"
-  data-disabled={false}
   data-invalidHint="mfaCodeErrorHint,6"
   data-isValid={false}
   data-onChange={[Function]}
@@ -33,7 +21,6 @@ exports[`MFACodePane renders correctly 1`] = `
 exports[`MFACodePane sets isValid as true when \`isFieldVisiblyInvalid\` is false 1`] = `
 <div
   data-__type="mfa_code_input"
-  data-disabled={false}
   data-invalidHint="mfaCodeErrorHint,6"
   data-isValid={true}
   data-onChange={[Function]}

--- a/src/__tests__/field/mfa_code_pane.test.jsx
+++ b/src/__tests__/field/mfa_code_pane.test.jsx
@@ -51,16 +51,6 @@ describe('MFACodePane', () => {
         />
     ).toMatchSnapshot();
   });
-  it('disables input when submitting', () => {
-    require('core/index').submitting = () => true;
-    const MFACodePane = getComponent();
-
-    expectComponent(
-      <MFACodePane
-        {...defaultProps}
-        />
-    ).toMatchSnapshot();
-  });
   it('sets isValid as true when `isFieldVisiblyInvalid` is false', () => {
     require('field/index').isFieldVisiblyInvalid = () => false;
     let MFACodePane = getComponent();

--- a/src/field/mfa-code/mfa_code_pane.jsx
+++ b/src/field/mfa-code/mfa_code_pane.jsx
@@ -22,7 +22,6 @@ export default class MFACodePane extends React.Component {
         isValid={!c.isFieldVisiblyInvalid(lock, "mfa_code")}
         onChange={::this.handleChange}
         placeholder={placeholder}
-        disabled={l.submitting(lock)}
       />
     );
   }


### PR DESCRIPTION
The complete dialog is disabled while submitting, there's no need to disable this particular input separately. 
As can be seen in `email_pane` and `username_pane`, they don't include this `disabled` property either.

Fixes issue with cordova: the first time the mfa-code input is displayed it starts in a disabled state until you click once in submit.