### PR TITLE
Fix #884: ability to submit form after removing the email from the input

### DIFF
--- a/src/field/email.js
+++ b/src/field/email.js
@@ -20,7 +20,7 @@ export function setEmail(m, str) {
     const validHRDEMail = isHRDEmailValid(m, str);
 
     return {
-      valid: trim(str) === '' || (validateEmail(str) && validHRDEMail),
+      valid: validateEmail(str) && validHRDEMail,
       hint: !validHRDEMail ? i18n.str(m, ["error", "login", "hrd.not_matching_email"]) : undefined
     };
   });

--- a/test/regression.test.js
+++ b/test/regression.test.js
@@ -1,0 +1,30 @@
+import expect from 'expect.js';
+import webApi from '../src/core/web_api';
+import * as h from './helper/ui';
+
+describe("regression", function() {
+    before(h.stubWebApis);
+    after(h.restoreWebApis);
+
+    beforeEach(function(done) {
+        const opts = {
+            rememberLastLogin: false
+        };
+
+        this.lock = h.displayLock("all", opts, done);
+    });
+
+    afterEach(function() {
+        this.lock.hide();
+    });
+
+    it("does not attempt to log in with an empty email input", function() {
+        h.fillEmailInput(this.lock, 'test@test.te');
+        h.fillEmailInput(this.lock, '');
+        h.fillPasswordInput(this.lock, 'anypass');
+
+        h.submit(this.lock);
+
+        expect(webApi.logIn.callCount).to.equal(0);
+    });
+});


### PR DESCRIPTION
This fixes #884 that the Lock form can be submitted after removing the value from the email input.