### PR TITLE
Updated auth0.js to v8.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "zuul-ngrok": "4.0.0"
   },
   "dependencies": {
-    "auth0-js": "8.2.0",
+    "auth0-js": "~8.3.0",
     "blueimp-md5": "2.3.1",
     "fbjs": "^0.3.1",
     "idtoken-verifier": "^1.0.1",


### PR DESCRIPTION
Start using tilde (~) for auth0.js version to get patches automatically.

Fixes #867 by including https://github.com/auth0/auth0.js/pull/370