### PR TITLE
do not show popup if sso false

### DIFF
--- a/src/core/web_api/legacy_api.js
+++ b/src/core/web_api/legacy_api.js
@@ -76,7 +76,7 @@ class Auth0LegacyAPIClient {
 
     delete options.autoLogin;
 
-    const popupHandler = (autoLogin && popup) ? this.client.popup.preload() : null;
+    const popupHandler = (autoLogin && sso) ? this.client.popup.preload() : null;
 
     this.client.signup(options, (err, result) => cb(err, result, popupHandler));
   }


### PR DESCRIPTION
Trying to fix #912 

From the [popup docs](https://auth0.com/docs/libraries/lock/v10/popup-mode#database-connections-and-popup-mode), my understanding is that setting `sso: false` should prevent a popup. Right now, the popup is dictated by `redirect: false`.

Ultimately, I'd like to sign up a user without redirecting and without a popup.