### PR TITLE
Clarify `sso` option behavior in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ var options = {
 - **redirectUrl {String}**: The url Auth0 will redirect back after authentication. Defaults to the empty string `""` (no redirect URL).
 - **responseMode {String}**:  Should be set to `"form_post"` if you want the code or the token to be transmitted via an HTTP POST request to the `redirectUrl` instead of being included in its query or fragment parts. Otherwise, it should be ommited.
 - **responseType {String}**:  Should be set to `"token"` for Single Page Applications, and `"code"` otherwise. Also, `"id_token"` is supported for the first case. Defaults to `"code"` when `redirectUrl` is provided, and to `"token"` otherwise.
-- **sso {Boolean}**:  Determines whether to fetch Single Sign On data on show or not. Defaults to `true`. The Auth0 SSO session will be created in both cases.
+- **sso {Boolean}**:  Determines whether to fetch Single Sign On data on show or not. Defaults to `true`. The Auth0 SSO session will be created regardless of this option if SSO is enabled for you client.
 - **connectionScopes {Object}**:  Allows to set scopes to be sent to the oauth2/social connection for authentication.
 
 #### Social options

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ var options = {
 - **redirectUrl {String}**: The url Auth0 will redirect back after authentication. Defaults to the empty string `""` (no redirect URL).
 - **responseMode {String}**:  Should be set to `"form_post"` if you want the code or the token to be transmitted via an HTTP POST request to the `redirectUrl` instead of being included in its query or fragment parts. Otherwise, it should be ommited.
 - **responseType {String}**:  Should be set to `"token"` for Single Page Applications, and `"code"` otherwise. Also, `"id_token"` is supported for the first case. Defaults to `"code"` when `redirectUrl` is provided, and to `"token"` otherwise.
-- **sso {Boolean}**:  Determines whether Single Sign On is enabled or not. Defaults to `true`.
+- **sso {Boolean}**:  Determines whether to fetch Single Sign On data on show or not. Defaults to `true`. The Auth0 SSO session will be created in both cases.
 - **connectionScopes {Object}**:  Allows to set scopes to be sent to the oauth2/social connection for authentication.
 
 #### Social options


### PR DESCRIPTION
As stated in [this support ticket](https://support.auth0.com/tickets/20698) the sso switch does not actually influence the creation of a SSO session on the Auth0 side. This is imho not properly reflected in the docs for this switch, so I updated it.

I'm still not sure if the `sso` switch in the current state couldn't be unified with `rememberLastLogin` because, according to the ticket, both are only frontend features and the SSO data is probably not used for other cases.