### PR TITLE
Use replaceState for better browser history experience

### DIFF
--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -29,10 +29,11 @@ export function setupLock(id, clientID, domain, options, hookRunner, emitEventFn
 export function handleAuthCallback() {
   const ms = read(getCollection, "lock");
   const keepHash = ms.filter(m => !l.hashCleanup(m)).size > 0;
+  const urlWithoutHash = global.location.href.split('#')[0];
   const callback = (error, authResult) => {
     const parsed = !!(error || authResult);
     if (parsed && !keepHash) {
-      global.location.hash = "";
+      global.history.replaceState(null, '', urlWithoutHash);
     }
   };
   resumeAuth(global.location.hash, callback);


### PR DESCRIPTION
__Rationale__: Currently, when we get to the login callback, the callback url with and without the hash will be counted as two different browser history entries. This leads to the user not having the possibility to navigate back as the history entry that includes the hash will always trigger the authentication procedure again. Additionally I don't like the idea of tokens appearing in my browser history, because this way an attacker could steal them from there (although they will only be valid for a limited amount of time).

__Implementation__: Replace `window.location.hash = ''` with `window.history.replaceState(` so it will not create an additional history entry, but replace the existing one that includes the hash.

What do you think?