### PR TITLE
fixed propType misspell in header.jsx

### DIFF
--- a/src/ui/box/header.jsx
+++ b/src/ui/box/header.jsx
@@ -111,7 +111,7 @@ class Background extends React.Component {
 }
 
 Background.propTypes = {
-  backgorundColor: React.PropTypes.string,
+  backgroundColor: React.PropTypes.string,
   grayScale: React.PropTypes.bool,
   imageUrl: React.PropTypes.string
 }


### PR DESCRIPTION
Change propType `backgorundColor` to `backgroundColor`. Little bit of shameless self-promotion here, but I caught this using [maybe-you-meant](https://github.com/nickpisacane/maybe-you-meant) while working on an app of mine. Appreciate the great work on Lock!