### PR TITLE
Fix long header title and Error messages overflow

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -107,6 +107,7 @@ tabsHeight = 40px
       vertical-align middle
       display table-cell
       margin auto
+      overflow-y auto
 
   .auth0-lock-widget
     width 300px
@@ -118,7 +119,6 @@ tabsHeight = 40px
     margin 0 auto
     border-radius 5px
     max-height 100vh
-    overflow-y auto
     
     +breakpoint("mobile")
       -webkit-transition -webkit-transform .4s, opacity .3s

--- a/css/index.styl
+++ b/css/index.styl
@@ -268,9 +268,17 @@ tabsHeight = 40px
   .auth0-lock-firstname
     font-size 18px
     margin-top 64px
+    text-overflow ellipsis
+    white-space nowrap
+    overflow hidden
+    padding 0 10px
 
   .auth0-lock-name
     font-size 22px
+    text-overflow ellipsis
+    white-space nowrap
+    overflow hidden
+    padding 0 10px
 
 
   // Lock body content

--- a/src/ui/box/header.jsx
+++ b/src/ui/box/header.jsx
@@ -58,7 +58,7 @@ class WelcomeMessage extends React.Component {
       message = title;
     }
 
-    return <div className={className}>{message}</div>;
+    return <div className={className} title={message}>{message}</div>;
   }
 }
 


### PR DESCRIPTION
Before:
<img width="353" alt="screen shot 2017-04-27 at 3 45 09 pm" src="https://cloud.githubusercontent.com/assets/4560567/25499062/95c76dac-2b60-11e7-9ccf-62a2c7a2228e.png">

After:
<img width="363" alt="screen shot 2017-04-27 at 3 45 27 pm" src="https://cloud.githubusercontent.com/assets/4560567/25499071/9f9e87e8-2b60-11e7-8854-942f9d96a8e5.png">
