### PR TITLE
Fixed overrides sent to auth0.js

### DIFF
--- a/src/__tests__/core/web_api/helper.test.js
+++ b/src/__tests__/core/web_api/helper.test.js
@@ -1,0 +1,21 @@
+import expect from 'expect.js';
+import { webAuthOverrides } from 'core/web_api/helper';
+
+describe('webAuthOverrides', () => {
+  it('should return overrides if any field is compatible with WebAuth', function() {
+    expect(webAuthOverrides({ __tenant: 'tenant1', __token_issuer: 'issuer1' })).to.eql({
+      __tenant: 'tenant1',
+      __token_issuer: 'issuer1'
+    });
+  });
+
+  it('should omit overrides that are not compatible with WebAuth', function() {
+    expect(
+      webAuthOverrides({ __tenant: 'tenant1', __token_issuer: 'issuer1', backgroundColor: 'blue' })
+    ).to.eql({ __tenant: 'tenant1', __token_issuer: 'issuer1' });
+  });
+
+  it('should return null if no fields are compatible with WebAuth', function() {
+    expect(webAuthOverrides({ backgroundColor: 'blue' })).to.not.be.ok();
+  });
+});

--- a/src/__tests__/core/web_api/legacy_api.test.js
+++ b/src/__tests__/core/web_api/legacy_api.test.js
@@ -28,6 +28,20 @@ describe('Auth0LegacyAPIClient', () => {
     jest.resetModules();
   });
 
+  describe('with overwrites', () => {
+    it('should configure WebAuth with the proper overrides', () => {
+      const client = getClient({
+        overrides: {
+          __tenant: 'tenant1',
+          __token_issuer: 'issuer1'
+        }
+      });
+      const mock = getAuth0ClientMock();
+      const { overrides } = mock.WebAuth.mock.calls[0][0];
+      expect(overrides).toEqual({ __tenant: 'tenant1', __token_issuer: 'issuer1' });
+    });
+  });
+
   describe('logIn', () => {
     const assertCallWithCallback = (mock, callbackFunction) => {
       expect(mock.calls.length).toBe(1);

--- a/src/__tests__/core/web_api/p2_api.test.js
+++ b/src/__tests__/core/web_api/p2_api.test.js
@@ -21,6 +21,21 @@ describe('Auth0APIClient', () => {
   beforeEach(() => {
     jest.resetModules();
   });
+  describe('init', () => {
+    describe('with overwrites', () => {
+      it('should configure WebAuth with the proper overrides', () => {
+        const client = getClient({
+          overrides: {
+            __tenant: 'tenant1',
+            __token_issuer: 'issuer1'
+          }
+        });
+        const mock = getAuth0ClientMock();
+        const { overrides } = mock.WebAuth.mock.calls[0][0];
+        expect(overrides).toEqual({ __tenant: 'tenant1', __token_issuer: 'issuer1' });
+      });
+    });
+  });
   describe('logIn', () => {
     const assertCallWithCallback = (mock, callbackFunction) => {
       expect(mock.calls.length).toBe(1);

--- a/src/core/web_api/helper.js
+++ b/src/core/web_api/helper.js
@@ -113,3 +113,14 @@ export function loginCallback(redirect, cb) {
 export function normalizeAuthParams({ connection_scope, popup, popupOptions, ...authParams }) {
   return authParams;
 }
+
+export function webAuthOverrides({ __tenant, __token_issuer } = {}) {
+  if (__tenant || __token_issuer) {
+    return {
+      __tenant,
+      __token_issuer
+    };
+  }
+
+  return null;
+}

--- a/src/core/web_api/legacy_api.js
+++ b/src/core/web_api/legacy_api.js
@@ -2,7 +2,7 @@ import IdTokenVerifier from 'idtoken-verifier';
 import auth0 from 'auth0-js';
 import CordovaAuth0Plugin from 'auth0-js/plugins/cordova';
 import request from 'superagent';
-import { normalizeError, loginCallback, normalizeAuthParams } from './helper';
+import { normalizeError, loginCallback, normalizeAuthParams, webAuthOverrides } from './helper';
 import qs from 'qs';
 
 class Auth0LegacyAPIClient {
@@ -27,10 +27,9 @@ class Auth0LegacyAPIClient {
       responseMode: opts.responseMode,
       responseType: opts.responseType,
       plugins: [new CordovaAuth0Plugin()],
+      overrides: webAuthOverrides(opts.overrides),
       _sendTelemetry: opts._sendTelemetry === false ? false : true,
       _telemetryInfo: opts._telemetryInfo || default_telemetry,
-      __tenant: opts.overrides && opts.overrides.__tenant,
-      __token_issuer: opts.overrides && opts.overrides.__token_issuer,
       _disableDeprecationWarnings: true
     });
 

--- a/src/core/web_api/p2_api.js
+++ b/src/core/web_api/p2_api.js
@@ -2,7 +2,7 @@ import auth0 from 'auth0-js';
 import CordovaAuth0Plugin from 'auth0-js/plugins/cordova';
 import * as l from '../index';
 import { getEntity, read } from '../../store/index';
-import { normalizeError, loginCallback, normalizeAuthParams } from './helper';
+import { normalizeError, loginCallback, normalizeAuthParams, webAuthOverrides } from './helper';
 
 class Auth0APIClient {
   constructor(lockID, clientID, domain, opts) {
@@ -25,10 +25,9 @@ class Auth0APIClient {
       responseType: opts.responseType,
       leeway: opts.leeway || 1,
       plugins: [new CordovaAuth0Plugin()],
+      overrides: webAuthOverrides(opts.overrides),
       _sendTelemetry: opts._sendTelemetry === false ? false : true,
-      _telemetryInfo: opts._telemetryInfo || default_telemetry,
-      __tenant: opts.overrides && opts.overrides.__tenant,
-      __token_issuer: opts.overrides && opts.overrides.__token_issuer
+      _telemetryInfo: opts._telemetryInfo || default_telemetry
     });
 
     this.authOpt = {


### PR DESCRIPTION
Overrides are currently not working, because auth0.js requires them to be part of `opts.overrides`, while currently they are being added on `ops` directly.

Reference: https://github.com/auth0/auth0.js/blob/master/src/web-auth/index.js#L48-L53