### PR TITLE
Enabled HTML formatting for flashMessages

### DIFF
--- a/src/__tests__/ui/box/__snapshots__/global_message.test.jsx.snap
+++ b/src/__tests__/ui/box/__snapshots__/global_message.test.jsx.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GlobalMessage renders correctly 1`] = `
+<div
+  className="auth0-global-message auth0-global-message-success"
+>
+  <span
+    className="animated fadeInUp"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Success!",
+      }
+    }
+  />
+</div>
+`;
+
+exports[`GlobalMessage renders with error type 1`] = `
+<div
+  className="auth0-global-message auth0-global-message-error"
+>
+  <span
+    className="animated fadeInUp"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "An error occurred.",
+      }
+    }
+  />
+</div>
+`;

--- a/src/__tests__/ui/box/__snapshots__/global_message.test.jsx.snap
+++ b/src/__tests__/ui/box/__snapshots__/global_message.test.jsx.snap
@@ -1,31 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GlobalMessage renders correctly 1`] = `
+exports[`GlobalMessage renders correctly given a success type 1`] = `
 <div
   className="auth0-global-message auth0-global-message-success"
 >
   <span
     className="animated fadeInUp"
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "Success!",
-      }
-    }
-  />
+  >
+    Success!
+  </span>
 </div>
 `;
 
-exports[`GlobalMessage renders with error type 1`] = `
+exports[`GlobalMessage renders correctly given an error type 1`] = `
 <div
   className="auth0-global-message auth0-global-message-error"
 >
   <span
     className="animated fadeInUp"
-    dangerouslySetInnerHTML={
-      Object {
-        "__html": "An error occurred.",
-      }
-    }
-  />
+  >
+    An error occurred.
+  </span>
 </div>
 `;

--- a/src/__tests__/ui/box/global_message.test.jsx
+++ b/src/__tests__/ui/box/global_message.test.jsx
@@ -12,11 +12,21 @@ describe('GlobalMessage', () => {
   it('renders correctly given an error type', () => {
     expectComponent(<GlobalMessage type="error" message="An error occurred." />).toMatchSnapshot();
   });
-  it('should not strip out HTML tags', () => {
+  it('should NOT strip out HTML tags if given a React node', () => {
+    const message = React.createElement('span', {
+      dangerouslySetInnerHTML: { __html: '<b>Success!</b>' }
+    });
+    const wrapper = mount(<GlobalMessage type="success" message={message} />);
+    expect(wrapper.html()).toBe(
+      '<div class="auth0-global-message auth0-global-message-success"><span class="animated fadeInUp">' +
+        '<span><b>Success!</b></span></span></div>'
+    );
+  });
+  it('should strip out HTML tags if given a string', () => {
     const wrapper = mount(<GlobalMessage type="success" message="<b>Success!</b>" />);
     expect(wrapper.html()).toBe(
       '<div class="auth0-global-message auth0-global-message-success"><span class="animated fadeInUp">' +
-        '<b>Success!</b></span></div>'
+        '&lt;b&gt;Success!&lt;/b&gt;</span></div>'
     );
   });
 });

--- a/src/__tests__/ui/box/global_message.test.jsx
+++ b/src/__tests__/ui/box/global_message.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { expectComponent } from '../../testUtils';
+
+import GlobalMessage from 'ui/box/global_message';
+
+describe('GlobalMessage', () => {
+  it('renders correctly given a success type', () => {
+    expectComponent(<GlobalMessage type="success" message="Success!" />).toMatchSnapshot();
+  });
+  it('renders correctly given an error type', () => {
+    expectComponent(<GlobalMessage type="error" message="An error occurred." />).toMatchSnapshot();
+  });
+  it('should not strip out HTML tags', () => {
+    const wrapper = mount(<GlobalMessage type="success" message="<b>Success!</b>" />);
+    expect(wrapper.html()).toBe(
+      '<div class="auth0-global-message auth0-global-message-success"><span class="animated fadeInUp">' +
+        '<b>Success!</b></span></div>'
+    );
+  });
+});

--- a/src/ui/box/chrome.jsx
+++ b/src/ui/box/chrome.jsx
@@ -210,11 +210,17 @@ export default class Chrome extends React.Component {
         ref="submit"
       />;
 
+    function wrapGlobalMessage(message) {
+      return typeof message === 'string'
+        ? React.createElement('span', { dangerouslySetInnerHTML: { __html: message } })
+        : message;
+    }
+
     const globalError = error
-      ? <GlobalMessage key="global-error" message={error} type="error" />
+      ? <GlobalMessage key="global-error" message={wrapGlobalMessage(error)} type="error" />
       : null;
     const globalSuccess = success
-      ? <GlobalMessage key="global-success" message={success} type="success" />
+      ? <GlobalMessage key="global-success" message={wrapGlobalMessage(success)} type="success" />
       : null;
 
     const Content = contentComponent;

--- a/src/ui/box/global_message.jsx
+++ b/src/ui/box/global_message.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 
 export default class GlobalMessage extends React.Component {
   render() {
@@ -8,7 +7,7 @@ export default class GlobalMessage extends React.Component {
     const className = `auth0-global-message auth0-global-message-${type}`;
     return (
       <div className={className}>
-        <span className="animated fadeInUp" dangerouslySetInnerHTML={{ __html: message }} />
+        <span className="animated fadeInUp">{message}</span>
       </div>
     );
   }

--- a/src/ui/box/global_message.jsx
+++ b/src/ui/box/global_message.jsx
@@ -8,7 +8,7 @@ export default class GlobalMessage extends React.Component {
     const className = `auth0-global-message auth0-global-message-${type}`;
     return (
       <div className={className}>
-        <span className="animated fadeInUp">{message}</span>
+        <span className="animated fadeInUp" dangerouslySetInnerHTML={{ __html: message }} />
       </div>
     );
   }


### PR DESCRIPTION
As part of https://github.com/auth0/lock/issues/878#issuecomment-286882027, successfully merged through https://github.com/auth0/lock/pull/928 you enabled html formatting in error/success messages.

However this only work only through languageDictionary strings and not when the message is called through: `lock.show({flashMessage: {...})`
 
This small change should fix that.