### PR TITLE
Fire connectionResolver onSubmit instead of onBlur

### DIFF
--- a/src/__tests__/field/__snapshots__/email_pane.test.jsx.snap
+++ b/src/__tests__/field/__snapshots__/email_pane.test.jsx.snap
@@ -16,7 +16,6 @@ exports[`EmailPane renders correctly 1`] = `
   data-autoComplete={false}
   data-invalidHint="invalidErrorHint"
   data-isValid={false}
-  data-onBlur={[Function]}
   data-onChange={[Function]}
   data-placeholder="placeholder"
   data-value="user@example.com"
@@ -29,7 +28,6 @@ exports[`EmailPane sets \`blankErrorHint\` when username is empty 1`] = `
   data-autoComplete={false}
   data-invalidHint="blankErrorHint"
   data-isValid={false}
-  data-onBlur={[Function]}
   data-onChange={[Function]}
   data-placeholder="placeholder"
   data-value={undefined}
@@ -42,7 +40,6 @@ exports[`EmailPane sets autoComplete to true when \`allowAutocomplete\` is true 
   data-autoComplete={true}
   data-invalidHint="invalidErrorHint"
   data-isValid={false}
-  data-onBlur={[Function]}
   data-onChange={[Function]}
   data-placeholder="placeholder"
   data-value="user@example.com"
@@ -55,36 +52,8 @@ exports[`EmailPane sets isValid as true when \`isFieldVisiblyInvalid\` is false 
   data-autoComplete={false}
   data-invalidHint="invalidErrorHint"
   data-isValid={true}
-  data-onBlur={[Function]}
   data-onChange={[Function]}
   data-placeholder="placeholder"
   data-value="user@example.com"
 />
-`;
-
-exports[`EmailPane with a custom \`connectionResolver\` \`swap\` calls \`setResolvedConnection\` 1`] = `
-Array [
-  "model",
-  "resolvedConnection",
-]
-`;
-
-exports[`EmailPane with a custom \`connectionResolver\` calls \`connectionResolver\` onBlur 1`] = `
-Array [
-  "user@example.com",
-  Object {
-    "connections": "connections",
-    "id": "id",
-  },
-  [Function],
-]
-`;
-
-exports[`EmailPane with a custom \`connectionResolver\` calls \`swap\` in the \`connectionResolver\` callback 1`] = `
-Array [
-  "updateEntity",
-  "lock",
-  1,
-  [Function],
-]
 `;

--- a/src/__tests__/field/__snapshots__/username_pane.test.jsx.snap
+++ b/src/__tests__/field/__snapshots__/username_pane.test.jsx.snap
@@ -18,7 +18,6 @@ exports[`UsernamePane renders correctly 1`] = `
   data-autoComplete={false}
   data-invalidHint="invalidErrorHint"
   data-isValid={false}
-  data-onBlur={[Function]}
   data-onChange={[Function]}
   data-placeholder="placeholder"
   data-value="username"
@@ -31,7 +30,6 @@ exports[`UsernamePane sets \`blankErrorHint\` when username is empty 1`] = `
   data-autoComplete={false}
   data-invalidHint="blankErrorHint"
   data-isValid={false}
-  data-onBlur={[Function]}
   data-onChange={[Function]}
   data-placeholder="placeholder"
   data-value={undefined}
@@ -44,7 +42,6 @@ exports[`UsernamePane sets \`usernameFormatErrorHint\` when usernameLooksLikeEma
   data-autoComplete={false}
   data-invalidHint="usernameFormatErrorHint,min,max"
   data-isValid={false}
-  data-onBlur={[Function]}
   data-onChange={[Function]}
   data-placeholder="placeholder"
   data-value="username"
@@ -57,7 +54,6 @@ exports[`UsernamePane sets autoComplete to true when \`allowAutocomplete\` is tr
   data-autoComplete={true}
   data-invalidHint="invalidErrorHint"
   data-isValid={false}
-  data-onBlur={[Function]}
   data-onChange={[Function]}
   data-placeholder="placeholder"
   data-value="username"
@@ -70,36 +66,8 @@ exports[`UsernamePane sets isValid as true when \`isFieldVisiblyInvalid\` is fal
   data-autoComplete={false}
   data-invalidHint="invalidErrorHint"
   data-isValid={true}
-  data-onBlur={[Function]}
   data-onChange={[Function]}
   data-placeholder="placeholder"
   data-value="username"
 />
-`;
-
-exports[`UsernamePane with a custom \`connectionResolver\` \`swap\` calls \`setResolvedConnection\` 1`] = `
-Array [
-  "model",
-  "resolvedConnection",
-]
-`;
-
-exports[`UsernamePane with a custom \`connectionResolver\` calls \`connectionResolver\` onBlur 1`] = `
-Array [
-  "username",
-  Object {
-    "connections": "connections",
-    "id": "id",
-  },
-  [Function],
-]
-`;
-
-exports[`UsernamePane with a custom \`connectionResolver\` calls \`swap\` in the \`connectionResolver\` callback 1`] = `
-Array [
-  "updateEntity",
-  "lock",
-  1,
-  [Function],
-]
 `;

--- a/src/__tests__/field/email_pane.test.jsx
+++ b/src/__tests__/field/email_pane.test.jsx
@@ -13,12 +13,7 @@ describe('EmailPane', () => {
     i18n: {
       str: (...keys) => keys.join(',')
     },
-    lock: Immutable.fromJS({
-      client: {
-        connections: 'connections',
-        id: 'id'
-      }
-    }),
+    lock: {},
     placeholder: 'placeholder'
   };
 
@@ -45,8 +40,7 @@ describe('EmailPane', () => {
       ui: {
         avatar: () => false,
         allowAutocomplete: () => false
-      },
-      connectionResolver: () => undefined
+      }
     }));
 
     jest.mock('avatar', () => ({
@@ -118,60 +112,5 @@ describe('EmailPane', () => {
     const { mock } = require('store/index').swap;
     expect(mock.calls.length).toBe(1);
     expect(mock.calls[0]).toMatchSnapshot();
-  });
-  it('does nothing on blur when there is no custom `connectionResolver`', () => {
-    let EmailPane = getComponent();
-
-    const wrapper = mount(<EmailPane {...defaultProps} />);
-    const props = extractPropsFromWrapper(wrapper);
-    props.onBlur({ target: { value: 'newUser@example.com' } });
-
-    const { mock } = require('store/index').swap;
-    expect(mock.calls.length).toBe(0);
-  });
-  describe('with a custom `connectionResolver`', () => {
-    let connectionResolverMock;
-    let setResolvedConnectionMock;
-    beforeEach(() => {
-      connectionResolverMock = jest.fn();
-      setResolvedConnectionMock = jest.fn();
-      require('core/index').connectionResolver = () => connectionResolverMock;
-      require('core/index').setResolvedConnection = setResolvedConnectionMock;
-    });
-    it('calls `connectionResolver` onBlur', () => {
-      let EmailPane = getComponent();
-
-      const wrapper = mount(<EmailPane {...defaultProps} />);
-      const props = extractPropsFromWrapper(wrapper);
-      props.onBlur({ target: { value: 'newUser@example.com' } });
-
-      const { mock } = connectionResolverMock;
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0]).toMatchSnapshot();
-    });
-    it('calls `swap` in the `connectionResolver` callback', () => {
-      let EmailPane = getComponent();
-
-      const wrapper = mount(<EmailPane {...defaultProps} />);
-      const props = extractPropsFromWrapper(wrapper);
-      props.onBlur({ target: { value: 'newUser@example.com' } });
-      connectionResolverMock.mock.calls[0][2]('resolvedConnection');
-      const { mock } = require('store/index').swap;
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0]).toMatchSnapshot();
-    });
-    it('`swap` calls `setResolvedConnection`', () => {
-      let EmailPane = getComponent();
-
-      const wrapper = mount(<EmailPane {...defaultProps} />);
-      const props = extractPropsFromWrapper(wrapper);
-      props.onBlur({ target: { value: 'newUser@example.com' } });
-      connectionResolverMock.mock.calls[0][2]('resolvedConnection');
-      require('store/index').swap.mock.calls[0][3]('model');
-
-      const { mock } = setResolvedConnectionMock;
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0]).toMatchSnapshot();
-    });
   });
 });

--- a/src/__tests__/field/username_pane.test.jsx
+++ b/src/__tests__/field/username_pane.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Immutable from 'immutable';
 import { mount } from 'enzyme';
 
 import { expectComponent, extractPropsFromWrapper, mockComponent } from 'testUtils';
@@ -13,12 +12,7 @@ describe('UsernamePane', () => {
     i18n: {
       str: (...keys) => keys.join(',')
     },
-    lock: Immutable.fromJS({
-      client: {
-        connections: 'connections',
-        id: 'id'
-      }
-    }),
+    lock: {},
     placeholder: 'placeholder',
     validateFormat: false,
     usernameStyle: 'any',
@@ -48,8 +42,7 @@ describe('UsernamePane', () => {
       ui: {
         avatar: () => false,
         allowAutocomplete: () => false
-      },
-      connectionResolver: () => undefined
+      }
     }));
 
     jest.mock('avatar', () => ({
@@ -125,60 +118,5 @@ describe('UsernamePane', () => {
     const { mock } = require('store/index').swap;
     expect(mock.calls.length).toBe(1);
     expect(mock.calls[0]).toMatchSnapshot();
-  });
-  it('does nothing on blur when there is no custom `connectionResolver`', () => {
-    let EmailPane = getComponent();
-
-    const wrapper = mount(<EmailPane {...defaultProps} />);
-    const props = extractPropsFromWrapper(wrapper);
-    props.onBlur({ target: { value: 'newUser@example.com' } });
-
-    const { mock } = require('store/index').swap;
-    expect(mock.calls.length).toBe(0);
-  });
-  describe('with a custom `connectionResolver`', () => {
-    let connectionResolverMock;
-    let setResolvedConnectionMock;
-    beforeEach(() => {
-      connectionResolverMock = jest.fn();
-      setResolvedConnectionMock = jest.fn();
-      require('core/index').connectionResolver = () => connectionResolverMock;
-      require('core/index').setResolvedConnection = setResolvedConnectionMock;
-    });
-    it('calls `connectionResolver` onBlur', () => {
-      let UsernamePane = getComponent();
-
-      const wrapper = mount(<UsernamePane {...defaultProps} />);
-      const props = extractPropsFromWrapper(wrapper);
-      props.onBlur({ target: { value: 'newUser@example.com' } });
-
-      const { mock } = connectionResolverMock;
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0]).toMatchSnapshot();
-    });
-    it('calls `swap` in the `connectionResolver` callback', () => {
-      let UsernamePane = getComponent();
-
-      const wrapper = mount(<UsernamePane {...defaultProps} />);
-      const props = extractPropsFromWrapper(wrapper);
-      props.onBlur({ target: { value: 'newUser@example.com' } });
-      connectionResolverMock.mock.calls[0][2]('resolvedConnection');
-      const { mock } = require('store/index').swap;
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0]).toMatchSnapshot();
-    });
-    it('`swap` calls `setResolvedConnection`', () => {
-      let UsernamePane = getComponent();
-
-      const wrapper = mount(<UsernamePane {...defaultProps} />);
-      const props = extractPropsFromWrapper(wrapper);
-      props.onBlur({ target: { value: 'newUser@example.com' } });
-      connectionResolverMock.mock.calls[0][2]('resolvedConnection');
-      require('store/index').swap.mock.calls[0][3]('model');
-
-      const { mock } = setResolvedConnectionMock;
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0]).toMatchSnapshot();
-    });
   });
 });

--- a/src/__tests__/ui/box/__snapshots__/chrome.test.jsx.snap
+++ b/src/__tests__/ui/box/__snapshots__/chrome.test.jsx.snap
@@ -1,0 +1,142 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Chrome renders correctly 1`] = `
+<div
+  className="auth0-lock-cred-pane auth0-lock-quiet"
+>
+  <div
+    className="auth0-lock-header"
+  >
+    <div
+      className="auth0-lock-header-bg auth0-lock-blur-support"
+    >
+      <div
+        className="auth0-lock-header-bg-blur"
+        style={
+          Object {
+            "backgroundImage": "url('https://cdn.auth0.com/styleguide/components/1.0.8/media/logos/img/badge.png')",
+          }
+        }
+      />
+      <div
+        className="auth0-lock-header-bg-solid"
+        style={
+          Object {
+            "backgroundColor": "\\"#ea5323",
+          }
+        }
+      />
+    </div>
+    <div
+      className="auth0-lock-header-welcome"
+    >
+      <img
+        className="auth0-lock-header-logo centered"
+        src="https://cdn.auth0.com/styleguide/components/1.0.8/media/logos/img/badge.png"
+      />
+    </div>
+  </div>
+  <span />
+  <div
+    style={
+      Object {
+        "position": "relative",
+      }
+    }
+  >
+    <span>
+      <div
+        style={Object {}}
+      >
+        <div
+          style={
+            Object {
+              "visibility": "inherit",
+            }
+          }
+        >
+          <div
+            className="auth0-lock-view-content"
+          >
+            <div
+              style={
+                Object {
+                  "position": "relative",
+                }
+              }
+            >
+              <div
+                className="auth0-lock-body-content"
+              >
+                <div
+                  className="auth0-lock-content"
+                >
+                  <div
+                    className="auth0-lock-form"
+                  >
+                    <div>
+                      content component
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </span>
+  </div>
+  <button
+    className="auth0-lock-submit"
+    disabled={false}
+    onClick={[Function]}
+    style={
+      Object {
+        "backgroundColor": "\\"#ea5323",
+      }
+    }
+    type="submit"
+  >
+    <div
+      className="auth0-loading-container"
+    >
+      <div
+        className="auth0-loading"
+      />
+    </div>
+    <span
+      className="auth0-label-submit"
+    >
+      Submit
+      <span
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<svg focusable=\\"false\\" class=\\"icon-text\\" width=\\"8px\\" height=\\"12px\\" viewBox=\\"0 0 8 12\\" version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\"><g id=\\"Symbols\\" stroke=\\"none\\" stroke-width=\\"1\\" fill=\\"none\\" fill-rule=\\"evenodd\\"><g id=\\"Web/Submit/Active\\" transform=\\"translate(-148.000000, -32.000000)\\" fill=\\"#FFFFFF\\"><polygon id=\\"Shape\\" points=\\"148 33.4 149.4 32 155.4 38 149.4 44 148 42.6 152.6 38\\"></polygon></g></g></svg>",
+          }
+        }
+      />
+    </span>
+  </button>
+  <span />
+</div>
+`;
+
+exports[`Chrome with a custom \`connectionResolver\` calls \`connectionResolver\` onSubmit 1`] = `
+Array [
+  "peter_picked@pickledpepper.com",
+  Object {
+    "connections": Object {
+      "database": Array [
+        Object {
+          "name": "dbA",
+        },
+        Object {
+          "name": "dbB",
+        },
+      ],
+    },
+    "id": "skjd2fhk27s2dyialk53js9dlf",
+  },
+  [Function],
+]
+`;

--- a/src/__tests__/ui/box/chrome.test.jsx
+++ b/src/__tests__/ui/box/chrome.test.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import immutable from 'immutable';
+import { expectComponent } from '../../testUtils';
+import Chrome from 'ui/box/chrome';
+
+const getComponent = () => require('ui/box/chrome').default;
+
+describe('Chrome', () => {
+  const defaultProps = {
+    autofocus: true,
+    contentComponent: () => {
+      return <div>content component</div>;
+    },
+    contentProps: {
+      i18n: {},
+      model: immutable.fromJS({
+        core: {
+          connectionResolver: () => {}
+        },
+        sync: {
+          client: {}
+        },
+        client: {
+          connections: {
+            database: [{ name: 'dbA' }, { name: 'dbB' }]
+          },
+          id: 'skjd2fhk27s2dyialk53js9dlf'
+        },
+        field: {
+          email: {
+            invalidHint: null,
+            showInvalid: false,
+            valid: true,
+            value: 'peter_picked@pickledpepper.com'
+          }
+        }
+      })
+    },
+    disableSubmitButton: false,
+    isSubmitting: false,
+    logo: 'https://cdn.auth0.com/styleguide/components/1.0.8/media/logos/img/badge.png',
+    primaryColor: '"#ea5323',
+    screenName: 'loading',
+    showSubmitButton: true,
+    submitButtonLabel: 'Submit',
+    transitionName: 'fade'
+  };
+
+  beforeEach(() => {
+    jest.mock('store/index', () => ({
+      swap: jest.fn(),
+      updateEntity: 'updateEntity'
+    }));
+  });
+
+  it('renders correctly', () => {
+    expectComponent(<Chrome {...defaultProps} />).toMatchSnapshot();
+  });
+
+  it('does not call `connectionResolver` on submit when there is no custom `connectionResolver`', () => {
+    let EmailPane = getComponent();
+
+    const wrapper = mount(<Chrome {...defaultProps} />);
+    const submitButton = wrapper.ref('submit').find('button');
+    submitButton.simulate('click');
+    const { mock } = require('store/index').swap;
+    expect(mock.calls.length).toBe(0);
+  });
+
+  describe('with a custom `connectionResolver`', () => {
+    let connectionResolverMock;
+    beforeEach(() => {
+      connectionResolverMock = jest.fn();
+      require('core/index').connectionResolver = () => connectionResolverMock;
+    });
+
+    it('calls `connectionResolver` onSubmit', () => {
+      let Chrome = getComponent();
+
+      const wrapper = mount(<Chrome {...defaultProps} />);
+      const submitButton = wrapper.ref('submit').find('button');
+      submitButton.simulate('click');
+
+      const { mock } = connectionResolverMock;
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0]).toMatchSnapshot();
+    });
+  });
+});

--- a/src/field/email/email_pane.jsx
+++ b/src/field/email/email_pane.jsx
@@ -24,19 +24,6 @@ export default class EmailPane extends React.Component {
     swap(updateEntity, 'lock', l.id(lock), setEmail, e.target.value);
   }
 
-  handleBlur() {
-    const { lock } = this.props;
-    const connectionResolver = l.connectionResolver(lock);
-    if (!connectionResolver) {
-      return;
-    }
-    const { connections, id } = lock.get('client').toJS();
-    const context = { connections, id };
-    connectionResolver(c.getFieldValue(lock, 'email'), context, resolvedConnection => {
-      swap(updateEntity, 'lock', l.id(lock), m => l.setResolvedConnection(m, resolvedConnection));
-    });
-  }
-
   render() {
     const { i18n, lock, placeholder, forceInvalidVisibility = false } = this.props;
     const allowAutocomplete = l.ui.allowAutocomplete(lock);
@@ -55,7 +42,6 @@ export default class EmailPane extends React.Component {
         invalidHint={invalidHint}
         isValid={isValid}
         onChange={::this.handleChange}
-        onBlur={::this.handleBlur}
         placeholder={placeholder}
         autoComplete={allowAutocomplete}
       />

--- a/src/field/username/username_pane.jsx
+++ b/src/field/username/username_pane.jsx
@@ -31,18 +31,6 @@ export default class UsernamePane extends React.Component {
       validateFormat
     );
   }
-  handleBlur() {
-    const { lock } = this.props;
-    const connectionResolver = l.connectionResolver(lock);
-    if (!connectionResolver) {
-      return;
-    }
-    const { connections, id } = lock.get('client').toJS();
-    const context = { connections, id };
-    connectionResolver(c.getFieldValue(lock, 'username'), context, resolvedConnection => {
-      swap(updateEntity, 'lock', l.id(lock), m => l.setResolvedConnection(m, resolvedConnection));
-    });
-  }
 
   render() {
     const { i18n, lock, placeholder, validateFormat } = this.props;
@@ -74,7 +62,6 @@ export default class UsernamePane extends React.Component {
         invalidHint={invalidHint(value)}
         isValid={!c.isFieldVisiblyInvalid(lock, 'username')}
         onChange={::this.handleChange}
-        onBlur={::this.handleBlur}
         placeholder={placeholder}
         autoComplete={allowAutocomplete}
       />

--- a/src/ui/input/email_input.jsx
+++ b/src/ui/input/email_input.jsx
@@ -61,11 +61,8 @@ export default class EmailInput extends React.Component {
     this.setState({ focused: true });
   }
 
-  handleBlur(e) {
+  handleBlur() {
     this.setState({ focused: false });
-    if (this.props.onBlur) {
-      this.props.onBlur(e);
-    }
   }
 }
 

--- a/src/ui/input/username_input.jsx
+++ b/src/ui/input/username_input.jsx
@@ -63,11 +63,8 @@ export default class UsernameInput extends React.Component {
     this.setState({ focused: true });
   }
 
-  handleBlur(e) {
+  handleBlur() {
     this.setState({ focused: false });
-    if (this.props.onBlur) {
-      this.props.onBlur(e);
-    }
   }
 }
 


### PR DESCRIPTION
Fixes #1081

Fires connectionResolver onSubmit instead of onBlur. The connectionResolver function was not getting executed when email and username fields were pre-filled by password managers (LastPass..., Mozilla password manager).

- [x] Removes blur event from username and email pane
- [x] Fires connectionResolver onSubmit
- [x] Updates tests

cc @luisrudge 