### PR TITLE
Resolve connection for reset password

### DIFF
--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -16,17 +16,12 @@ import {
 } from './index';
 import * as i18n from '../../i18n';
 
-function connectionName(lock) {
-  const customResolvedConnection = l.resolvedConnection(lock) || {};
-  return customResolvedConnection.name || databaseConnectionName(lock);
-}
-
 export function logIn(id, needsMFA = false) {
   const m = read(getEntity, 'lock', id);
   const usernameField = databaseLogInWithEmail(m) ? 'email' : 'username';
   const username = c.getFieldValue(m, usernameField);
   const params = {
-    connection: connectionName(m),
+    connection: databaseConnectionName(m),
     username: username,
     password: c.getFieldValue(m, 'password')
   };
@@ -154,7 +149,7 @@ function autoLogInError(id, error) {
 export function resetPassword(id) {
   validateAndSubmit(id, ['email'], m => {
     const params = {
-      connection: connectionName(m),
+      connection: databaseConnectionName(m),
       email: c.getFieldValue(m, 'email')
     };
 

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -17,12 +17,8 @@ import {
 import * as i18n from '../../i18n';
 
 function connectionName(lock) {
-  const customResolvedConnection = l.resolvedConnection(lock);
-  let connectionName = databaseConnectionName(m);
-  if (customResolvedConnection) {
-    connectionName = customResolvedConnection.name;
-  }
-  return connectionName;
+  const customResolvedConnection = l.resolvedConnection(lock) || {};
+  return customResolvedConnection.name || databaseConnectionName(m);
 }
 
 export function logIn(id, needsMFA = false) {

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -154,7 +154,7 @@ function autoLogInError(id, error) {
 export function resetPassword(id) {
   validateAndSubmit(id, ['email'], m => {
     const params = {
-      connection: databaseConnectionName(m),
+      connection: connectionName(m),
       email: c.getFieldValue(m, 'email')
     };
 

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -16,17 +16,21 @@ import {
 } from './index';
 import * as i18n from '../../i18n';
 
-export function logIn(id, needsMFA = false) {
-  const m = read(getEntity, 'lock', id);
-  const usernameField = databaseLogInWithEmail(m) ? 'email' : 'username';
-  const username = c.getFieldValue(m, usernameField);
-  const customResolvedConnection = l.resolvedConnection(m);
+function connectionName(lock) {
+  const customResolvedConnection = l.resolvedConnection(lock);
   let connectionName = databaseConnectionName(m);
   if (customResolvedConnection) {
     connectionName = customResolvedConnection.name;
   }
+  return connectionName;
+}
+
+export function logIn(id, needsMFA = false) {
+  const m = read(getEntity, 'lock', id);
+  const usernameField = databaseLogInWithEmail(m) ? 'email' : 'username';
+  const username = c.getFieldValue(m, usernameField);
   const params = {
-    connection: connectionName,
+    connection: connectionName(m),
     username: username,
     password: c.getFieldValue(m, 'password')
   };

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -18,7 +18,7 @@ import * as i18n from '../../i18n';
 
 function connectionName(lock) {
   const customResolvedConnection = l.resolvedConnection(lock) || {};
-  return customResolvedConnection.name || databaseConnectionName(m);
+  return customResolvedConnection.name || databaseConnectionName(lock);
 }
 
 export function logIn(id, needsMFA = false) {

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -288,7 +288,7 @@ export function databaseConnection(m) {
 }
 
 export function databaseConnectionName(m) {
-  return (databaseConnection(m) || new Map()).get('name');
+  return (databaseConnection(m) || Map()).get('name');
 }
 
 export function forgotPasswordLink(m, notFound = '') {

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -282,8 +282,11 @@ export function databaseConnection(m) {
   return defaultDirectory(m) || defaultDatabaseConnection(m) || l.connection(m, 'database');
 }
 
-export function databaseConnectionName(m) {
-  return (databaseConnection(m) || Map()).get('name');
+export function databaseConnectionName(lock) {
+  const customResolvedConnection = l.resolvedConnection(lock);
+  const standardConnection = databaseConnection(lock);
+  const connection = customResolvedConnection || standardConnection || {};
+  return connection.name;
 }
 
 export function forgotPasswordLink(m, notFound = '') {

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -288,8 +288,8 @@ export function databaseConnection(m) {
   );
 }
 
-export function databaseConnectionName(lock) {
-  return (databaseConnection(lock) || new Map()).get('name');
+export function databaseConnectionName(m) {
+  return (databaseConnection(m) || new Map()).get('name');
 }
 
 export function forgotPasswordLink(m, notFound = '') {

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -279,9 +279,8 @@ export function defaultDatabaseConnectionName(m) {
 }
 
 export function databaseConnection(m) {
-  const customResolvedConnection = l.resolvedConnection(lock);
   return (
-    customResolvedConnection ||
+    l.resolvedConnection(m) ||
     defaultDirectory(m) ||
     defaultDatabaseConnection(m) ||
     l.connection(m, 'database')

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -289,8 +289,7 @@ export function databaseConnection(m) {
 }
 
 export function databaseConnectionName(lock) {
-  const connection = databaseConnection(lock) || new Map();
-  return connection.get('name');
+  return (databaseConnection(lock) || new Map()).get('name');
 }
 
 export function forgotPasswordLink(m, notFound = '') {

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -279,14 +279,18 @@ export function defaultDatabaseConnectionName(m) {
 }
 
 export function databaseConnection(m) {
-  return defaultDirectory(m) || defaultDatabaseConnection(m) || l.connection(m, 'database');
+  const customResolvedConnection = l.resolvedConnection(lock);
+  return (
+    customResolvedConnection ||
+    defaultDirectory(m) ||
+    defaultDatabaseConnection(m) ||
+    l.connection(m, 'database')
+  );
 }
 
 export function databaseConnectionName(lock) {
-  const customResolvedConnection = l.resolvedConnection(lock);
-  const standardConnection = databaseConnection(lock);
-  const connection = customResolvedConnection || standardConnection || {};
-  return connection.name;
+  const connection = databaseConnection(lock) || new Map();
+  return connection.get('name');
 }
 
 export function forgotPasswordLink(m, notFound = '') {


### PR DESCRIPTION
Looks like the `connectionResolver` option was added in 10.19 to allow control over which connection to authenticate against during `logIn`. We've been using this feature since its release, and it's worked well so far.

We've noticed that `resetPassword` does not respect this function, and this can result in some really confusing behavior. For users whose default connection is overridden by the `connectionResolver`, they could be logging into one connection but resetting their password in another. And so their interaction with the Lock might go as follows:

* Log in for the first time in a month and don't really remember their password. They try their default. Incorrect.
* They click "Forgot your password?" and trigger a password reset email. They click on the link in the email and submit a new password.
* They try to log in again with their new password. Incorrect.
* Typically we get a support email after this.

I looked at the original `connectionResolver` PR (#1052) to get my bearings in the project. I was hoping to mirror some test cases for `resetPassword`, but I only saw new pane tests, which I believe should remain unchanged in this PR. Let me know if there are any changes you'd like to see here, and I'll try to update ASAP.

Thanks!