### PR TITLE
Resolved Connection should be an Immutable.Map

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -94,7 +94,8 @@ export function setResolvedConnection(m, resolvedConnection) {
 }
 
 export function resolvedConnection(m) {
-  return Map(get(m, 'resolvedConnection'));
+  const conenction = get(m, 'resolvedConnection');
+  return conenction && Map(conenction);
 }
 
 export function languageBaseUrl(m) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -94,7 +94,7 @@ export function setResolvedConnection(m, resolvedConnection) {
 }
 
 export function resolvedConnection(m) {
-  return get(m, 'resolvedConnection');
+  return Map(get(m, 'resolvedConnection'));
 }
 
 export function languageBaseUrl(m) {


### PR DESCRIPTION
Hi @luisrudge: I did not know you were planning on releasing 10.21 today so I was building the repo and including the minified file in my project for testing/release sometime today. I came across this error in the Chrome console:

`index.js:361 Uncaught TypeError: (g(...) || n.i(...)(...)).toJS is not a function`

I tested with the unminified version of the build. It looks like `databaseConnection()` is expected to return an Immutable.Map, because downstream functions are calling `.toJS()` on its result. But `l.resolvedConnection` is returning a regular JS object.

This PR offers one solution -- convert before returning the resolved connection. There might be another solution where we convert on setting the resolved connection? Not sure which is better.

After tweaking this, I built the minified file and integrated it into my project. The error went away, and it looks like the resolver is working correctly on form submit.