### PR TITLE
Avoid recommendations that hamper users that zoom their browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ After installing the `auth0-lock` module, you'll need bundle it up along with al
 If you are targeting mobile audiences, it's recommended that you add:
 
 ```html
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
 ```
 
 ## API


### PR DESCRIPTION
The old code suggestion would prevent users that like or need to zoom their browser content from doing so. The new suggestion presents a sensible default without locking users out of sometimes-essential assistive technology.

This also brings the README and the docs at https://auth0.com/docs/libraries/lock/v10 in sync.