### PR TITLE
Ensure popupOptions gets passed to auth0.WebAuth

### DIFF
--- a/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
+++ b/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
@@ -35,6 +35,7 @@ Object {
 exports[`Auth0APIClient logIn with credentials should call client.login 1`] = `
 Object {
   "nonce": undefined,
+  "popupOptions": undefined,
   "realm": undefined,
   "state": undefined,
   "username": "foo",
@@ -44,6 +45,7 @@ Object {
 exports[`Auth0APIClient logIn with credentials should call popup.loginWithCredentials when redirect is false and sso is false 1`] = `
 Object {
   "nonce": undefined,
+  "popupOptions": undefined,
   "state": undefined,
   "username": "foo",
 }
@@ -52,6 +54,7 @@ Object {
 exports[`Auth0APIClient logIn with credentials should call popup.loginWithCredentials when redirect is false and sso is true 1`] = `
 Object {
   "nonce": undefined,
+  "popupOptions": undefined,
   "state": undefined,
   "username": "foo",
 }
@@ -60,6 +63,7 @@ Object {
 exports[`Auth0APIClient logIn with social/enterprise (without username and email) should call authorize when redirect===true 1`] = `
 Object {
   "nonce": undefined,
+  "popupOptions": undefined,
   "state": undefined,
 }
 `;
@@ -68,6 +72,7 @@ exports[`Auth0APIClient logIn with social/enterprise (without username and email
 Object {
   "nonce": undefined,
   "owp": true,
+  "popupOptions": undefined,
   "state": undefined,
 }
 `;

--- a/src/core/web_api/helper.js
+++ b/src/core/web_api/helper.js
@@ -117,7 +117,7 @@ export function loginCallback(redirect, cb) {
     : (error, result) => cb(normalizeError(error), result);
 }
 
-export function normalizeAuthParams({ popup, popupOptions, ...authParams }) {
+export function normalizeAuthParams({ popup, ...authParams }) {
   return authParams;
 }
 


### PR DESCRIPTION
As far as I can tell, Lock's `popupOptions` config option is removed by the `normalizeAuthParams` helper and never gets passed to auth0.WebAuth (in either the p2 or legacy apis) where it is used to control the `window.open` settings. Therefore the current `popupOptions` setting listed in the documentation is misleading (it doesn't work)...