### PR TITLE
[RFC] Slightly better Romanian translations

### DIFF
--- a/src/i18n/ro.js
+++ b/src/i18n/ro.js
@@ -2,7 +2,7 @@ export default {
   error: {
     forgotPassword: {
       too_many_requests:
-        'Ai depășit limita de introducere a parolei. Avem rugămintea să așteptați până la următoarea încercare.',
+        'Ai depășit limita de introducere a parolei. Avem rugămintea să aștepți până la următoarea încercare.',
       'lock.fallback': 'Ne pare rău, a apărut o eroare în procesul de recuperare a parolei.'
     },
     login: {
@@ -13,21 +13,21 @@ export default {
       'lock.invalid_email_password': 'Email sau parolă greșite.',
       'lock.invalid_username_password': 'Nume utilizator sau parolă greșite.',
       'lock.network':
-        'Nu am putut să ne conectăm la server. Avem rugămintea să verificați conexiunea și să încercați din nou.',
-      'lock.popup_closed': 'Fereastră popup a fost închisă. Încercați din nou.',
-      'lock.unauthorized': 'Nu ați primit permisiunea să vă conectați. Încercați din nou.',
+        'Nu am putut să ne conectăm la server. Avem rugămintea să verifici conexiunea și să încerci din nou.',
+      'lock.popup_closed': 'Fereastra popup a fost închisă. Te rugăm încearcă din nou.',
+      'lock.unauthorized': 'Nu ai primit permisiunea să te conectezi. Te rugăm încearcă din nou.',
       'lock.mfa_registration_required':
-        'Dispozitivul dvs. nu permite conectarea. Avem rugămintea să verificați setările.',
-      'lock.mfa_invalid_code': ' Cod greșit. Încercați din nou.',
+        'Dispozitivul tău nu permite conectarea. Avem rugămintea să verifici setările.',
+      'lock.mfa_invalid_code': 'Cod greșit. Te rugăm să încerci din nou',
       password_change_required:
-        'Trebuie să schimbați parola de acces. Parola a expirat sau este prima oară când vă conectați.',
+        'Trebuie să schimbi parola de acces. Parola a expirat sau este prima oară când te conectezi.',
       password_leaked:
-        'Am identificat o posibilă problemă de securitate cu acest utilizator. Am blocat contul pentru a vă proteja. Urmează să primiți un email cu instrucțiunile de deblocare a contului Dvs.',
+        'Am identificat o posibilă problemă de securitate cu acest cont. Am blocat contul pentru a te proteja. Urmează să primești un email cu instrucțiunile de deblocare a contului',
       too_many_attempts:
-        'Contul Dvs a fost blocat după mai multe încercări nereușite de conectare.',
+        'Contul tău a fost blocat după mai multe încercări nereușite de conectare.',
       session_missing:
-        'Nu am putut finaliza procesul de autentificare. Avem rugămintea să încercați după ce închideți toate ferestrele deschise.',
-      'hrd.not_matching_email': 'Vă rugăm să folosiți adresa de email corporate pentru conectare.'
+        'Nu am putut finaliza procesul de autentificare. Avem rugămintea să încerci după ce închizi toate ferestrele deschise.',
+      'hrd.not_matching_email': 'Te rugăm să folosești adresa de email corporate pentru conectare.'
     },
     passwordless: {
       'bad.email': 'Adresa de email este invalidă',
@@ -45,36 +45,36 @@ export default {
     }
   },
   success: {
-    logIn: 'Vă mulțumim pentru înregistrare.',
-    forgotPassword: 'V-am transmis un email pentru resetarea parolei.',
-    magicLink: 'V-am trimis un email pentru a vă înregistra<br />la %s.',
-    signUp: 'Vă mulțumim pentru înregistrare.'
+    logIn: 'Îți mulțumim pentru înregistrare.',
+    forgotPassword: 'Ți-am transmis un email pentru resetarea parolei.',
+    magicLink: 'Ți-am trimis un email pentru a te înregistra<br />la %s.',
+    signUp: 'Îți mulțumim pentru înregistrare.'
   },
   blankErrorHint: 'Câmpul nu poate fi gol',
-  codeInputPlaceholder: 'codul dvs',
+  codeInputPlaceholder: 'codul tău',
   databaseEnterpriseLoginInstructions: '',
   databaseEnterpriseAlternativeLoginInstructions: 'sau',
   databaseSignUpInstructions: '',
   databaseAlternativeSignUpInstructions: 'sau',
   emailInputPlaceholder: 'yours@example.com',
-  enterpriseLoginIntructions: 'Înregistrați-vă cu datele corporate.',
-  enterpriseActiveLoginInstructions: ' Înregistrați-vă cu datele corporate la %s.',
+  enterpriseLoginIntructions: 'Înregistrează-te cu datele corporate.',
+  enterpriseActiveLoginInstructions: ' Înregistrează-te cu datele corporate la %s.',
   failedLabel: 'Eșuat!',
-  forgotPasswordTitle: 'Resetați parola',
-  forgotPasswordAction: 'Nu vă amintiți parola?',
+  forgotPasswordTitle: 'Resetează parola',
+  forgotPasswordAction: 'Nu îți amintești parola?',
   forgotPasswordInstructions:
-    'Avem rugămintea să introduceți adresa de email. Urmează să primiți un email pentru resetarea parolei.',
+    'Avem rugămintea să introduci adresa de email. Urmează să primești un email pentru resetarea parolei.',
   forgotPasswordSubmitLabel: 'Email transmis',
   invalidErrorHint: 'Invalid',
-  lastLoginInstructions: 'Ultima oară când v-ați conectat',
-  loginAtLabel: ' Autentificați-vă cu %s',
+  lastLoginInstructions: 'Ultima oară când te-ai conectat',
+  loginAtLabel: ' Autentifică-te cu %s',
   loginLabel: 'Autentificat',
   loginSubmitLabel: 'Autentificat',
-  loginWithLabel: ' Autentificați-vă cu %s',
-  notYourAccountAction: 'Nu este contul Dvs?',
-  passwordInputPlaceholder: 'parola Dvs',
+  loginWithLabel: ' Autentifică-te cu %s',
+  notYourAccountAction: 'Nu este contul tău?',
+  passwordInputPlaceholder: 'parola ta',
   passwordStrength: {
-    containsAtLeast: 'Includeți cel puțin %d din urmatoarele %d caractere:',
+    containsAtLeast: 'Include cel puțin %d din urmatoarele %d caractere:',
     identicalChars: 'Nu mai mult de %d caractere identice (e.x., "%s" nu sunt permise)',
     nonEmpty: 'Este necesară o parolă pentru logare',
     numbers: 'Numere (de la 0-9)',
@@ -85,20 +85,20 @@ export default {
     upperCase: 'Litere cu majuscule (A-Z)'
   },
   passwordlessEmailAlternativeInstructions:
-    'Dacă nu, introduceți adresa de email pentru conectare<br/>sau creați un cont.',
+    'Dacă nu, introdu adresa de email pentru conectare<br/>sau creează un cont.',
   passwordlessEmailCodeInstructions: 'Un email cu codul a fost trimis la %s.',
   passwordlessEmailInstructions:
-    'Introduceți adresa de email pentru conectare<br/>sau creați un cont',
+    'Introdu adresa de email pentru conectare<br/>sau creează un cont',
   passwordlessSMSAlternativeInstructions:
-    ' Dacă nu, introduceți un numar de telefon pentru conectare <br/>sau creați un cont',
+    ' Dacă nu, introdu un număr de telefon pentru conectare <br/>sau creează un cont',
   passwordlessSMSCodeInstructions: 'Un SMS cu codul de acces a fost trimis la<br/>la %s.',
   passwordlessSMSInstructions:
-    'Introduceți numărul de telefon pentru conectare<br/>sau creați un cont',
+    'Introdu numărul de telefon pentru conectare<br/>sau creează un cont',
   phoneNumberInputPlaceholder: 'numărul tău de telefon',
-  resendCodeAction: 'Nu ați primit codul de acces? ',
-  resendLabel: 'Retrimiteți',
+  resendCodeAction: 'Nu ai primit codul de acces? ',
+  resendLabel: 'Retrimite',
   resendingLabel: 'Se retrimite...',
-  retryLabel: 'Reîncercați',
+  retryLabel: 'Reîncearcă',
   sentLabel: 'Transmis!',
   showPassword: 'Arată parola',
   signupTitle: 'Inregistrează-te',
@@ -111,19 +111,19 @@ export default {
   ssoEnabled: ' Inregistrare activată',
   submitLabel: 'Trimite',
   unrecoverableError:
-    'Ceva nu a mers.<br />Avem rugămintea să contacați serviciul de suport tehnic.',
+    'Ceva nu a mers.<br />Avem rugămintea să contactezi serviciul de suport tehnic.',
   usernameFormatErrorHint:
     'Folosește %d-%d litere, cifre și următoarele caractere speciale: "_", ".", "+", "-"',
   usernameInputPlaceholder: 'numele tău de utilizator',
   usernameOrEmailInputPlaceholder: 'utilizator/email',
   title: 'Auth0',
   welcome: 'Bine ai venit %s!',
-  windowsAuthInstructions: 'Ești conectat de pe serverul tău corporate;',
+  windowsAuthInstructions: 'Ești conectat de pe serverul tău corporate',
   windowsAuthLabel: 'Autentificare Windows ',
   mfaInputPlaceholder: 'Cod',
   mfaLoginTitle: 'Verificare în doi pași',
   mfaLoginInstructions:
-    'Vă rugăm să introduceți codul de autentificare generat de aplicația mobilă.',
+    'Te rugăm să introduci codul de autentificare generat de aplicația mobilă.',
   mfaSubmitLabel: 'Conectare',
   mfaCodeErrorHint: 'Utilizează %d cifre'
 };


### PR DESCRIPTION
Hey there,

The Romanian language uses polite second-person pronouns in formal settings (see https://en.wikipedia.org/wiki/Personal_pronounhttps://en.wikipedia.org/wiki/Personal_pronoun#Formality). The thing is:

- The translations were inconsistent, sometimes the formal version was used, sometimes the informal one
- The audience is different depending on the application folks are building. I'd probably go as far as to say there could probably be two versions of the translation, one for "formal" settings, and one for "informal"? You would't want to address kids/students using a very formal tone, but maybe you would for the customers of a bank, for example? 

**Either way, for now this patch does two things:**
- Fixes the formality inconsistency, the tone used now is informal, not a mix of informal/formal. FWIW, this is the approach most large companies take when it comes to translations (Google, Facebook, etc)
- Fixed some typos here and there as I went through the translated strings. 

**Test plan:**
Honestly I just edited this in the GitHub editor. So uh, eyes. 

Please let me know if there's anything I should do, maybe split this in two variants as suggested above?