### PR TITLE
Fix security vulnerability CVE-2017-17068

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "zuul-ngrok": "4.0.0"
   },
   "dependencies": {
-    "auth0-js": "~8.11.2",
+    "auth0-js": "~8.12.1",
     "blueimp-md5": "2.3.1",
     "fbjs": "^0.3.1",
     "idtoken-verifier": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,9 +392,9 @@ atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
 
-auth0-js@~8.11.2:
-  version "8.11.2"
-  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-8.11.2.tgz#e86c402a7f0d787f7b38a2067aab3577adb6788e"
+auth0-js@~8.12.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-8.12.1.tgz#39ce288aef4301687d8bea25267273ea15cdae78"
   dependencies:
     base64-js "^1.2.0"
     idtoken-verifier "^1.1.0"


### PR DESCRIPTION
For full details https://auth0.com/docs/security/bulletins/cve-2017-17068.

This upgrades the dependency to the latest version of auth0-js.