### PR TITLE
`plugins` option added. Forwarded to WebAuth.

### DIFF
--- a/src/__tests__/core/web_api/legacy_api.test.js
+++ b/src/__tests__/core/web_api/legacy_api.test.js
@@ -40,6 +40,26 @@ describe('Auth0LegacyAPIClient', () => {
       const { overrides } = mock.WebAuth.mock.calls[0][0];
       expect(overrides).toEqual({ __tenant: 'tenant1', __token_issuer: 'issuer1' });
     });
+    it('forwards options to WebAuth', () => {
+      const options = {
+        redirectUrl: '//bar',
+        responseMode: 'query',
+        responseType: 'code',
+        plugins: [{ name: 'Plugin' }]
+      };
+      const callMapping = {
+        redirectUrl: 'redirectUri',
+        responseMode: 'responseMode',
+        responseType: 'responseType',
+        plugins: 'plugins'
+      };
+      const client = getClient(options);
+      const mock = getAuth0ClientMock();
+      const calledOptions = mock.WebAuth.mock.calls[0][0];
+      Object.keys(options).forEach(optionName => {
+        expect(calledOptions[callMapping[optionName]]).toBe(options[optionName]);
+      });
+    });
   });
 
   describe('logIn', () => {

--- a/src/__tests__/core/web_api/p2_api.test.js
+++ b/src/__tests__/core/web_api/p2_api.test.js
@@ -34,6 +34,30 @@ describe('Auth0APIClient', () => {
         const { overrides } = mock.WebAuth.mock.calls[0][0];
         expect(overrides).toEqual({ __tenant: 'tenant1', __token_issuer: 'issuer1' });
       });
+      it('forwards options to WebAuth', () => {
+        const options = {
+          audience: 'foo',
+          redirectUrl: '//bar',
+          responseMode: 'query',
+          responseType: 'code',
+          leeway: 60,
+          plugins: [{ name: 'Plugin' }]
+        };
+        const callMapping = {
+          audience: 'audience',
+          redirectUrl: 'redirectUri',
+          responseMode: 'responseMode',
+          responseType: 'responseType',
+          leeway: 'leeway',
+          plugins: 'plugins'
+        };
+        const client = getClient(options);
+        const mock = getAuth0ClientMock();
+        const calledOptions = mock.WebAuth.mock.calls[0][0];
+        Object.keys(options).forEach(optionName => {
+          expect(calledOptions[callMapping[optionName]]).toBe(options[optionName]);
+        });
+      });
     });
   });
   describe('logIn', () => {

--- a/src/core/web_api/legacy_api.js
+++ b/src/core/web_api/legacy_api.js
@@ -26,7 +26,7 @@ class Auth0LegacyAPIClient {
       redirectUri: opts.redirectUrl,
       responseMode: opts.responseMode,
       responseType: opts.responseType,
-      plugins: [new CordovaAuth0Plugin()],
+      plugins: opts.plugins || [new CordovaAuth0Plugin()],
       overrides: webAuthOverrides(opts.overrides),
       _sendTelemetry: opts._sendTelemetry === false ? false : true,
       _telemetryInfo: opts._telemetryInfo || default_telemetry,

--- a/src/core/web_api/p2_api.js
+++ b/src/core/web_api/p2_api.js
@@ -24,7 +24,7 @@ class Auth0APIClient {
       responseMode: opts.responseMode,
       responseType: opts.responseType,
       leeway: opts.leeway || 1,
-      plugins: [new CordovaAuth0Plugin()],
+      plugins: opts.plugins || [new CordovaAuth0Plugin()],
       overrides: webAuthOverrides(opts.overrides),
       _sendTelemetry: opts._sendTelemetry === false ? false : true,
       _telemetryInfo: opts._telemetryInfo || default_telemetry


### PR DESCRIPTION
To be able to set plugins during Lock creation. For example:

```
var lock = new Auth0Lock(clientId, domain, {
    plugins: [new MyOwnEnvironmentPlugin()],
});
```