### PR TITLE
`plugins` option added. Forwarded to WebAuth.

### DIFF
--- a/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
+++ b/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
@@ -12,7 +12,10 @@ Object {
   "clientID": "cid",
   "domain": "domain",
   "leeway": 60,
-  "overrides": null,
+  "overrides": Object {
+    "__tenant": "tenant1",
+    "__token_issuer": "issuer1",
+  },
   "plugins": Array [
     Object {
       "name": "ExamplePlugin",

--- a/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
+++ b/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Auth0APIClient init with overwrites forwards options to WebAuth 1`] = `
+Object {
+  "_sendTelemetry": true,
+  "_telemetryInfo": Object {
+    "lib_version": "9.0.1",
+    "name": "lock.js",
+    "version": "11.0.1",
+  },
+  "audience": "foo",
+  "clientID": "cid",
+  "domain": "domain",
+  "leeway": 60,
+  "overrides": null,
+  "plugins": Array [
+    Object {
+      "name": "ExamplePlugin",
+    },
+  ],
+  "redirectUri": "//localhost:8080/login/callback",
+  "responseMode": "query",
+  "responseType": "code",
+}
+`;
+
 exports[`Auth0APIClient logIn with credentials should call client.login 1`] = `
 Object {
   "nonce": undefined,

--- a/src/__tests__/core/web_api/p2_api.test.js
+++ b/src/__tests__/core/web_api/p2_api.test.js
@@ -24,17 +24,6 @@ describe('Auth0APIClient', () => {
   });
   describe('init', () => {
     describe('with overwrites', () => {
-      it('should configure WebAuth with the proper overrides', () => {
-        const client = getClient({
-          overrides: {
-            __tenant: 'tenant1',
-            __token_issuer: 'issuer1'
-          }
-        });
-        const mock = getAuth0ClientMock();
-        const { overrides } = mock.WebAuth.mock.calls[0][0];
-        expect(overrides).toEqual({ __tenant: 'tenant1', __token_issuer: 'issuer1' });
-      });
       it('forwards options to WebAuth', () => {
         const options = {
           audience: 'foo',
@@ -42,6 +31,10 @@ describe('Auth0APIClient', () => {
           responseMode: 'query',
           responseType: 'code',
           leeway: 60,
+          overrides: {
+            __tenant: 'tenant1',
+            __token_issuer: 'issuer1'
+          },
           plugins: [{ name: 'ExamplePlugin' }]
         };
         const client = getClient(options);

--- a/src/__tests__/core/web_api/p2_api.test.js
+++ b/src/__tests__/core/web_api/p2_api.test.js
@@ -35,6 +35,19 @@ describe('Auth0APIClient', () => {
         const { overrides } = mock.WebAuth.mock.calls[0][0];
         expect(overrides).toEqual({ __tenant: 'tenant1', __token_issuer: 'issuer1' });
       });
+      it('forwards options to WebAuth', () => {
+        const options = {
+          audience: 'foo',
+          redirectUrl: '//localhost:8080/login/callback',
+          responseMode: 'query',
+          responseType: 'code',
+          leeway: 60,
+          plugins: [{ name: 'ExamplePlugin' }]
+        };
+        const client = getClient(options);
+        const mock = getAuth0ClientMock();
+        expect(mock.WebAuth.mock.calls[0][0]).toMatchSnapshot();
+      });
     });
   });
   describe('logIn', () => {

--- a/src/core/web_api/p2_api.js
+++ b/src/core/web_api/p2_api.js
@@ -24,7 +24,7 @@ class Auth0APIClient {
       responseMode: opts.responseMode,
       responseType: opts.responseType,
       leeway: opts.leeway || 1,
-      plugins: [new CordovaAuth0Plugin()],
+      plugins: opts.plugins || [new CordovaAuth0Plugin()],
       overrides: webAuthOverrides(opts.overrides),
       _sendTelemetry: opts._sendTelemetry === false ? false : true,
       _telemetryInfo: opts._telemetryInfo || default_telemetry


### PR DESCRIPTION
To be able to set plugins during embeded Lock creation. For example:

```
const lock = new Auth0Lock(clientId, domain, {
    plugins: [new CustomPlugin()],
});

lock.show();
```