### PR TITLE
Add new flash message type `info`

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -48,6 +48,9 @@ tabsHeight = 40px
     &.auth0-global-message-success
       background #7ED321
 
+    &.auth0-global-message-info
+      background #44C7F4
+
     &.global-message-enter
       height 0
       paddingTop 0

--- a/src/__tests__/ui/box/__snapshots__/global_message.test.jsx.snap
+++ b/src/__tests__/ui/box/__snapshots__/global_message.test.jsx.snap
@@ -23,3 +23,15 @@ exports[`GlobalMessage renders correctly given an error type 1`] = `
   </span>
 </div>
 `;
+
+exports[`GlobalMessage renders correctly given an info type 1`] = `
+<div
+  className="auth0-global-message auth0-global-message-info"
+>
+  <span
+    className="animated fadeInUp"
+  >
+    Some additional information.
+  </span>
+</div>
+`;

--- a/src/__tests__/ui/box/global_message.test.jsx
+++ b/src/__tests__/ui/box/global_message.test.jsx
@@ -12,6 +12,11 @@ describe('GlobalMessage', () => {
   it('renders correctly given an error type', () => {
     expectComponent(<GlobalMessage type="error" message="An error occurred." />).toMatchSnapshot();
   });
+  it('renders correctly given an info type', () => {
+    expectComponent(
+      <GlobalMessage type="info" message="Some additional information." />
+    ).toMatchSnapshot();
+  });
   it('should call scrollIntoView if parameter is set and top < 0', () => {
     const wrapper = mount(<GlobalMessage type="success" message="foo" scrollIntoView={true} />);
     const getBoundingClientRectSpy = jest.fn().mockReturnValue({ top: -1 });

--- a/src/core.js
+++ b/src/core.js
@@ -107,6 +107,7 @@ export default class Base extends EventEmitter {
           contentProps: { i18n: i18nProp, model: m },
           disableSubmitButton: disableSubmitButton,
           error: l.globalError(m),
+          info: l.globalInfo(m),
           isMobile: l.ui.mobile(m),
           isModal: l.ui.appendContainer(m),
           isSubmitting: l.submitting(m),

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -85,10 +85,11 @@ export function openLock(id, opts) {
   }
 
   if (opts.flashMessage) {
-    if (!opts.flashMessage.type || ['error', 'success'].indexOf(opts.flashMessage.type) === -1) {
+    const supportedTypes = ['error', 'success', 'info'];
+    if (!opts.flashMessage.type || supportedTypes.indexOf(opts.flashMessage.type) === -1) {
       return l.emitUnrecoverableErrorEvent(
         m,
-        "'flashMessage' must provide a valid type ['error','success']"
+        "'flashMessage' must provide a valid type ['error','success','info']"
       );
     }
     if (!opts.flashMessage.text) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -134,6 +134,18 @@ export function clearGlobalSuccess(m) {
   return tremove(m, 'globalSuccess');
 }
 
+export function setGlobalInfo(m, str) {
+  return tset(m, 'globalInfo', str);
+}
+
+export function globalInfo(m) {
+  return tget(m, 'globalInfo', '');
+}
+
+export function clearGlobalInfo(m) {
+  return tremove(m, 'globalInfo');
+}
+
 export function rendering(m) {
   return tget(m, 'render', false);
 }
@@ -563,8 +575,9 @@ export function overrideOptions(m, opts) {
   }
 
   if (opts.flashMessage) {
-    const key = 'success' === opts.flashMessage.type ? 'globalSuccess' : 'globalError';
-    m = tset(m, key, opts.flashMessage.text);
+    const { type } = opts.flashMessage;
+    const typeCapitalized = type.charAt(0).toUpperCase() + type.slice(1);
+    m = tset(m, `global${typeCapitalized}`, opts.flashMessage.text);
   }
 
   if (opts.auth && opts.auth.params) {

--- a/src/ui/box/chrome.jsx
+++ b/src/ui/box/chrome.jsx
@@ -186,6 +186,7 @@ export default class Chrome extends React.Component {
       contentProps,
       disableSubmitButton,
       error,
+      info,
       isSubmitting,
       logo,
       primaryColor,
@@ -245,6 +246,14 @@ export default class Chrome extends React.Component {
         scrollIntoView={scrollGlobalMessagesIntoView}
       />
     ) : null;
+    const globalInfo = info ? (
+      <GlobalMessage
+        key="global-info"
+        message={wrapGlobalMessage(info)}
+        type="info"
+        scrollIntoView={scrollGlobalMessagesIntoView}
+      />
+    ) : null;
 
     const Content = contentComponent;
 
@@ -267,6 +276,7 @@ export default class Chrome extends React.Component {
             <div>
               {globalSuccess}
               {globalError}
+              {globalInfo}
             </div>
           </CSSTransition>
         </TransitionGroup>
@@ -331,6 +341,7 @@ Chrome.propTypes = {
   contentProps: PropTypes.object.isRequired,
   disableSubmitButton: PropTypes.bool.isRequired,
   error: PropTypes.node,
+  info: PropTypes.node,
   isSubmitting: PropTypes.bool.isRequired,
   logo: PropTypes.string.isRequired,
   primaryColor: PropTypes.string.isRequired,

--- a/src/ui/box/container.jsx
+++ b/src/ui/box/container.jsx
@@ -142,6 +142,7 @@ export default class Container extends React.Component {
       disableSubmitButton,
       disallowClose,
       error,
+      info,
       isMobile, // TODO: not documented and should be removed (let the design team know first)
       isModal,
       isSubmitting,
@@ -220,6 +221,7 @@ export default class Container extends React.Component {
                 contentProps={contentProps}
                 disableSubmitButton={disableSubmitButton}
                 error={error}
+                info={info}
                 isSubmitting={isSubmitting}
                 logo={logo}
                 screenName={screenName}
@@ -253,6 +255,7 @@ Container.propTypes = {
   contentProps: PropTypes.object.isRequired,
   disableSubmitButton: PropTypes.bool.isRequired,
   error: PropTypes.node,
+  info: PropTypes.node,
   isMobile: PropTypes.bool.isRequired,
   isModal: PropTypes.bool.isRequired,
   isSubmitting: PropTypes.bool.isRequired,
@@ -282,9 +285,9 @@ export const defaultProps = (Container.defaultProps = {
   disableSubmitButton: false,
   isMobile: false,
   isSubmitting: false,
-  logo: `${isFileProtocol
-    ? 'https:'
-    : ''}//cdn.auth0.com/styleguide/components/1.0.8/media/logos/img/badge.png`,
+  logo: `${
+    isFileProtocol ? 'https:' : ''
+  }//cdn.auth0.com/styleguide/components/1.0.8/media/logos/img/badge.png`,
   primaryColor: '#ea5323',
   showBadge: true,
   scrollGlobalMessagesIntoView: true

--- a/src/ui/box/global_message.jsx
+++ b/src/ui/box/global_message.jsx
@@ -30,7 +30,7 @@ export default class GlobalMessage extends React.Component {
 
 GlobalMessage.propTypes = {
   message: PropTypes.node.isRequired,
-  type: PropTypes.oneOf(['error', 'success']).isRequired,
+  type: PropTypes.oneOf(['error', 'success', 'info']).isRequired,
   scrollIntoView: PropTypes.bool
 };
 

--- a/test/helper/ui.js
+++ b/test/helper/ui.js
@@ -170,6 +170,9 @@ export const hasErrorMessage = (lock, message) => {
 export const hasSuccessMessage = (lock, message) => {
   return hasFlashMessage('.auth0-global-message-success', lock, message);
 };
+export const hasInfoMessage = (lock, message) => {
+  return hasFlashMessage('.auth0-global-message-info', lock, message);
+};
 
 export const hasOneSocialButton = hasOneViewFn('.auth0-lock-social-button');
 export const hasOneSocialBigButton = hasOneViewFn(

--- a/test/show_with_flash_message.test.js
+++ b/test/show_with_flash_message.test.js
@@ -90,5 +90,23 @@ describe('show lock with flash message', function() {
         }
       });
     });
+
+    it('should show an info flash message', function(done) {
+      const lock = new Auth0Lock('cid', 'domain');
+
+      lock.on('show', () => {
+        var hasInfoMessage = h.hasInfoMessage(lock, 'an info message');
+        expect(hasInfoMessage).to.be.ok();
+        lock.hide();
+        done();
+      });
+
+      lock.show({
+        flashMessage: {
+          type: 'info',
+          text: 'an info message'
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
As discussed in #1220, we want to add a new `flashMessage` type `info` in order to show messages that are neither an error nor a success message.
