### PR TITLE
Only call getSSOData when rememberLastLogin is true

### DIFF
--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -20,7 +20,7 @@ export function syncRemoteData(m) {
   }
 
   m = sync(m, 'sso', {
-    conditionFn: m => l.auth.sso(m),
+    conditionFn: m => l.auth.sso(m) && l.ui.rememberLastLogin(m),
     waitFn: m => isSuccess(m, 'client'),
     syncFn: (m, cb) => fetchSSOData(l.id(m), cb),
     successFn: (m, result) => m.mergeIn(['sso'], Immutable.fromJS(result)),


### PR DESCRIPTION
the quick auth screen is only shown when rememberLastLogin is true, so there's no need to cal getSSOData if we're not showing that screen.

fix #1238