### PR TITLE
Backward compatibility for name/pass login on cordova.

### DIFF
--- a/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
+++ b/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
@@ -31,6 +31,7 @@ Object {
 
 exports[`Auth0APIClient logIn with credentials should call client.login 1`] = `
 Object {
+  "cordova": false,
   "nonce": undefined,
   "realm": undefined,
   "state": undefined,
@@ -38,8 +39,21 @@ Object {
 }
 `;
 
+exports[`Auth0APIClient logIn with credentials should call loginWithResourceOwner when redirect is false and sso is true 1`] = `
+Array [
+  Object {
+    "cordova": true,
+    "nonce": undefined,
+    "state": undefined,
+    "username": "foo",
+  },
+  [Function],
+]
+`;
+
 exports[`Auth0APIClient logIn with credentials should call popup.loginWithCredentials when redirect is false and sso is false 1`] = `
 Object {
+  "cordova": false,
   "nonce": undefined,
   "state": undefined,
   "username": "foo",
@@ -48,6 +62,7 @@ Object {
 
 exports[`Auth0APIClient logIn with credentials should call popup.loginWithCredentials when redirect is false and sso is true 1`] = `
 Object {
+  "cordova": false,
   "nonce": undefined,
   "state": undefined,
   "username": "foo",
@@ -56,6 +71,7 @@ Object {
 
 exports[`Auth0APIClient logIn with social/enterprise (without username and email) should call authorize when redirect===true 1`] = `
 Object {
+  "cordova": false,
   "nonce": undefined,
   "state": undefined,
 }
@@ -63,6 +79,7 @@ Object {
 
 exports[`Auth0APIClient logIn with social/enterprise (without username and email) should call popup.authorize when redirect===false 1`] = `
 Object {
+  "cordova": false,
   "nonce": undefined,
   "owp": true,
   "state": undefined,

--- a/src/__tests__/core/web_api/p2_api.test.js
+++ b/src/__tests__/core/web_api/p2_api.test.js
@@ -14,7 +14,8 @@ const getClient = (options = {}) => {
   };
   client.client.client = {
     login: jest.fn(),
-    getUserCountry: jest.fn()
+    getUserCountry: jest.fn(),
+    loginWithResourceOwner: jest.fn()
   };
   return client;
 };
@@ -135,6 +136,17 @@ describe('Auth0APIClient', () => {
         const loginWithCredentialsMock =
           mock.WebAuth.mock.instances[0].popup.loginWithCredentials.mock;
         assertCallWithCallback(loginWithCredentialsMock, callback);
+      });
+      it('should call loginWithResourceOwner when redirect is false and sso is true', () => {
+        const client = getClient({
+          redirect: false,
+          cordova: true
+        });
+        const callback = jest.fn();
+        client.logIn({ username: 'foo' }, {}, callback);
+        const { mock } = client.client.client.loginWithResourceOwner;
+        expect(mock.calls.length).toBe(1);
+        expect(mock.calls[0]).toMatchSnapshot();
       });
     });
   });

--- a/src/core/web_api.js
+++ b/src/core/web_api.js
@@ -13,9 +13,10 @@ class Auth0WebAPI {
 
     // for cordova and electron we should force popup without SSO so it uses
     // /ro or /oauth/token for DB connections
-    if (window && (!!window.cordova || !!window.electron)) {
+    if (window && (window.cordova || window.electron)) {
       opts.redirect = false;
       opts.sso = false;
+      opts.cordova = true;
     }
 
     this.clients[lockID] = new Auth0APIClient(lockID, clientID, domain, opts);

--- a/src/core/web_api/p2_api.js
+++ b/src/core/web_api/p2_api.js
@@ -37,7 +37,8 @@ class Auth0APIClient {
       popup: !opts.redirect,
       popupOptions: opts.popupOptions,
       nonce: opts.nonce,
-      state: opts.state
+      state: opts.state,
+      cordova: !!opts.cordova
     };
     if (this.isUniversalLogin && opts.sso !== undefined) {
       this.authOpt.sso = opts.sso;
@@ -56,6 +57,8 @@ class Auth0APIClient {
       } else {
         this.client.authorize(loginOptions, f);
       }
+    } else if (this.authOpt.popup && this.authOpt.cordova) {
+      this.client.client.loginWithResourceOwner(loginOptions, f);
     } else if (this.authOpt.popup) {
       this.client.popup.loginWithCredentials(loginOptions, f);
     } else {


### PR DESCRIPTION
Fix 1) for https://github.com/auth0/lock/issues/1235
Adds similar check for cordova environment as in old legacy_api and fires loginWithResourceOwner() to login. 