### PR TITLE
Added .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ bower.json
 Gruntfile.js
 .css.map
 *~
+.babelrc


### PR DESCRIPTION
Your `.babelrc` file is published to npm. This causes i.e that if I want to transpile my project along with dependencies, I am dependent on your babel configuration (plugins, presets, etc).

Could you please add `.babelrc` file to `.npmignore`?