### PR TITLE
Fix inconsistent state assignment

### DIFF
--- a/src/__tests__/core/web_api/p2_api.test.js
+++ b/src/__tests__/core/web_api/p2_api.test.js
@@ -70,6 +70,14 @@ describe('Auth0APIClient', () => {
         const client = getClient(options);
         expect(client.authOpt.sso).toBe(undefined);
       });
+      it('should set state from options.state', () => {
+        const client = getClient({ state: 'foo' });
+        expect(client.authOpt.state).toBe('foo');
+      });
+      it('should set state from options.params.state', () => {
+        const client = getClient({ params: { state: 'foo' } });
+        expect(client.authOpt.state).toBe('foo');
+      });
     });
   });
   describe('logIn', () => {

--- a/src/core/web_api/p2_api.js
+++ b/src/core/web_api/p2_api.js
@@ -34,11 +34,16 @@ class Auth0APIClient {
       _telemetryInfo: opts._telemetryInfo || default_telemetry
     });
 
+    var state = opts.state;
+    if (opts.params && opts.params.state) {
+      state = opts.params.state;
+    }
+
     this.authOpt = {
       popup: !opts.redirect,
       popupOptions: opts.popupOptions,
       nonce: opts.nonce,
-      state: opts.state
+      state: state
     };
     if (this.isUniversalLogin && opts.sso !== undefined) {
       this.authOpt.sso = opts.sso;


### PR DESCRIPTION
The correct way of sending the `state` parameter in the authentication request is

```js
var options = {
  auth: {
    params: { state: 'foobar' }
  }
}
```

But, because of the bug I just fixed, this state, although being sent in the auth requests, wasn't being sent in the parseHash method, which caused the '`state` doesn't match' error.
This gets the correct state without breaking anyone.

With this code, both version will work for parsing the hash with a specific state:

```js
var options = {
  auth: {
    params: { state: 'foobar' }
  }
}
```

```js
var options = {
  auth: {
    state: 'foobar'
  }
}
```