### PR TITLE
Allow select field arrow to be clicked

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -350,6 +350,7 @@ tabsHeight = 40px
       width 12px
       height 14px
       right 14px
+      pointer-events none
 
     .auth0-lock-icon, .auth0-lock-custom-icon
       position absolute


### PR DESCRIPTION
Currently, if a user clicks directly on the arrow icon in a select field, nothing will happen.

This PR applies `pointer-events: none` to the arrow icon. As a result, clicking on the icon will now open the select menu.