### PR TITLE
Clarify checksession accepts params and not options

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,10 @@ Logs out the user
 lock.logout({ returnTo: 'https://myapp.com/bye-bye' });
 ```
 
-### checkSession(options, callback)
+### checkSession(params, callback)
 
 The checkSession method allows you to acquire a new token from Auth0 for a user who is already authenticated against the universal login page for your domain. The method accepts any valid OAuth2 parameters that would normally be sent to authorize. In order to use this method, you have to enable Web Origins for your application. For more information, see [Using checkSession to acquire new tokens](https://auth0.com/docs/libraries/auth0js#using-checksession-to-acquire-new-tokens).
-- **options {Object}**: OAuth2 options object to send to Auth0's servers.
+- **params {Object}**: OAuth2 params object to send to Auth0's servers.
 - **callback {Function}**: Will be invoked after the response from the server is returned. Has an error (if any) as the first argument and the authentication result as the second one.
 
 #### Example


### PR DESCRIPTION
The docks describe options as:
```var options = {
  auth: {
    params: {scope: 'openid email user_metadata app_metadata picture'},
  }
};``` 
(https://auth0.com/docs/libraries/lock/v11/sending-authentication-parameters)

But checksession seems to expect a params object like this:
```{scope: 'openid email user_metadata app_metadata picture'}```