### PR TITLE
Introduce logo link theme option

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ var options = {
   theme: {
     labeledSubmitButton: false,
     logo: "https://example.com/assets/logo.png",
+    logoLink: "https://example.com/",
     primaryColor: "green",
     authButtons: {
       connectionName: {
@@ -272,6 +273,7 @@ var options = {
 
 - **labeledSubmitButton {Boolean}**: Indicates whether or not the submit button should have a label. Defaults to `true`. When set to `false` a icon will be shown. The labels can be customized through the `languageDictionary`.
 - **logo {String}**: Url for an image that will be placed in the Lock's header. Defaults to Auth0's logo.
+- **logoLink {String}**: When set to a non-empty string, the user will be linked to the provided URL when clicking the logo. 
 - **primaryColor {String}**: Defines the primary color of the Lock, all colors used in the widget will be calculated from it. This option is useful when providing a custom `logo` to ensure all colors go well together with the logo's color palette. Defaults to `"#ea5323"`.
 - **authButtons {Object}**: Allows the customization of the custom oauth2 login buttons.
   + **displayName {String}**: The name to show instead of the connection name.

--- a/src/__tests__/core/__snapshots__/index.test.js.snap
+++ b/src/__tests__/core/__snapshots__/index.test.js.snap
@@ -76,6 +76,7 @@ Object {
     "labeledSubmitButton": true,
     "language": "en",
     "logo": undefined,
+    "logoLink": undefined,
     "mobile": false,
     "popupOptions": Object {},
     "primaryColor": undefined,

--- a/src/core.js
+++ b/src/core.js
@@ -120,6 +120,7 @@ export default class Base extends EventEmitter {
           isModal: l.ui.appendContainer(m),
           isSubmitting: l.submitting(m),
           logo: l.ui.logo(m),
+          logoLink: l.ui.logoLink(m),
           primaryColor: l.ui.primaryColor(m),
           screenName: screen.name,
           showBadge: l.showBadge(m) === true,

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -157,9 +157,18 @@ export function stopRendering(m) {
 function extractUIOptions(id, options) {
   const closable = options.container
     ? false
-    : undefined === options.closable ? true : !!options.closable;
+    : undefined === options.closable
+      ? true
+      : !!options.closable;
   const theme = options.theme || {};
-  const { labeledSubmitButton, hideMainScreenTitle, logo, primaryColor, authButtons } = theme;
+  const {
+    labeledSubmitButton,
+    hideMainScreenTitle,
+    logo,
+    logoLink,
+    primaryColor,
+    authButtons
+  } = theme;
 
   const avatar = options.avatar !== null;
   const customAvatarProvider =
@@ -180,6 +189,7 @@ function extractUIOptions(id, options) {
     avatar: avatar,
     avatarProvider: avatarProvider,
     logo: typeof logo === 'string' ? logo : undefined,
+    logoLink: typeof logoLink === 'string' ? logoLink : undefined,
     closable: closable,
     hideMainScreenTitle: !!hideMainScreenTitle,
     labeledSubmitButton: undefined === labeledSubmitButton ? true : !!labeledSubmitButton,
@@ -222,6 +232,7 @@ export const ui = {
   hideMainScreenTitle: lock => getUIAttribute(lock, 'hideMainScreenTitle'),
   language: lock => getUIAttribute(lock, 'language'),
   logo: lock => getUIAttribute(lock, 'logo'),
+  logoLink: lock => getUIAttribute(lock, 'logoLink'),
   mobile: lock => getUIAttribute(lock, 'mobile'),
   popupOptions: lock => getUIAttribute(lock, 'popupOptions'),
   primaryColor: lock => getUIAttribute(lock, 'primaryColor'),
@@ -591,6 +602,10 @@ export function overrideOptions(m, opts) {
 
     if (opts.theme.logo) {
       m = tset(m, ['ui', 'logo'], opts.theme.logo);
+    }
+
+    if (opts.theme.logoLink) {
+      m = tset(m, ['ui', 'logoLink'], opts.theme.logoLink);
     }
   }
 

--- a/src/ui/box/chrome.jsx
+++ b/src/ui/box/chrome.jsx
@@ -195,6 +195,7 @@ export default class Chrome extends React.Component {
       info,
       isSubmitting,
       logo,
+      logoLink,
       primaryColor,
       screenName,
       showSubmitButton,
@@ -276,6 +277,7 @@ export default class Chrome extends React.Component {
           backgroundUrl={backgroundUrl}
           backgroundColor={primaryColor}
           logoUrl={logo}
+          logoLink={logoLink}
         />
         <TransitionGroup>
           <CSSTransition classNames="global-message" timeout={MESSAGE_ANIMATION_DURATION}>
@@ -350,6 +352,7 @@ Chrome.propTypes = {
   info: PropTypes.node,
   isSubmitting: PropTypes.bool.isRequired,
   logo: PropTypes.string.isRequired,
+  logoLink: PropTypes.string,
   primaryColor: PropTypes.string.isRequired,
   screenName: PropTypes.string.isRequired,
   showSubmitButton: PropTypes.bool.isRequired,

--- a/src/ui/box/container.jsx
+++ b/src/ui/box/container.jsx
@@ -147,6 +147,7 @@ export default class Container extends React.Component {
       isModal,
       isSubmitting,
       logo,
+      logoLink,
       primaryColor,
       screenName,
       showBadge,
@@ -224,6 +225,7 @@ export default class Container extends React.Component {
                 info={info}
                 isSubmitting={isSubmitting}
                 logo={logo}
+                logoLink={logoLink}
                 screenName={screenName}
                 primaryColor={primaryColor}
                 ref="chrome"
@@ -260,6 +262,7 @@ Container.propTypes = {
   isModal: PropTypes.bool.isRequired,
   isSubmitting: PropTypes.bool.isRequired,
   logo: PropTypes.string.isRequired,
+  logoLink: PropTypes.string,
   primaryColor: PropTypes.string.isRequired,
   screenName: PropTypes.string.isRequired,
   showBadge: PropTypes.bool.isRequired,

--- a/src/ui/box/header.jsx
+++ b/src/ui/box/header.jsx
@@ -6,13 +6,26 @@ import { BackButton } from './button';
 
 export default class Header extends React.Component {
   render() {
-    const { backHandler, backgroundColor, backgroundUrl, logoUrl, name, title } = this.props;
+    const {
+      backHandler,
+      backgroundColor,
+      backgroundUrl,
+      logoUrl,
+      logoLink,
+      name,
+      title
+    } = this.props;
 
     return (
       <div className="auth0-lock-header">
         {backHandler && <BackButton onClick={backHandler} />}
         <Background imageUrl={backgroundUrl} backgroundColor={backgroundColor} grayScale={!!name} />
-        <Welcome title={title} name={name} imageUrl={name ? undefined : logoUrl} />
+        <Welcome
+          title={title}
+          name={name}
+          logoUrl={name ? undefined : logoUrl}
+          logoLink={logoLink}
+        />
       </div>
     );
   }
@@ -26,14 +39,15 @@ Header.propTypes = {
 
 class Welcome extends React.Component {
   render() {
-    const { name, imageUrl, title } = this.props;
+    const { name, logoUrl, logoLink, title } = this.props;
     const imgClassName = !!title ? 'auth0-lock-header-logo' : 'auth0-lock-header-logo centered';
-    const img = <img className={imgClassName} src={imageUrl} />;
+    const img = <img className={imgClassName} src={logoUrl} />;
+    const logo = logoLink ? <a href={logoLink}>{img}</a> : img;
     const welcome = title ? <WelcomeMessage title={title} name={name} /> : null;
 
     return (
       <div className="auth0-lock-header-welcome">
-        {imageUrl && img}
+        {logoUrl && logo}
         {welcome}
       </div>
     );
@@ -41,7 +55,7 @@ class Welcome extends React.Component {
 }
 
 Welcome.propTypes = {
-  imageUrl: PropTypes.string,
+  logoUrl: PropTypes.string,
   name: PropTypes.string
 };
 

--- a/test/helper/ui.js
+++ b/test/helper/ui.js
@@ -134,6 +134,16 @@ const hasInputFn = (name, str) => lock => {
 const hasViewFn = query => lock => !!qView(lock, query);
 const hasOneViewFn = query => lock => qView(lock, query, true).length == 1;
 
+export const logoUrl = lock => {
+  const logo = q(lock, `.auth0-lock-header-logo`);
+  return logo.src;
+};
+
+export const logoLink = lock => {
+  const logo = q(lock, `.auth0-lock-header-welcome > a`);
+  return logo.href;
+};
+
 const isTabCurrent = (lock, regexp) => {
   // TODO: this won't work with translations, we need another
   // mechanism.

--- a/test/override_options.test.js
+++ b/test/override_options.test.js
@@ -38,7 +38,8 @@ describe('Override state with options on show', () => {
       language: 'es',
       theme: {
         primaryColor: 'red',
-        logo: 'http://test.com/logo.png'
+        logo: 'http://test.com/logo.png',
+        logoLink: 'http://test.com/'
       }
     };
 
@@ -52,6 +53,7 @@ describe('Override state with options on show', () => {
           ui: {
             primaryColor: 'red',
             logo: 'http://test.com/logo.png',
+            logoLink: 'http://test.com/',
             language: 'es',
             dict: {
               title: 'new_title'

--- a/test/theme.ui.test.js
+++ b/test/theme.ui.test.js
@@ -1,0 +1,51 @@
+import expect from 'expect.js';
+import * as h from './helper/ui';
+import Auth0Lock from '../src/index';
+
+describe('theme options', function() {
+  before(h.stubWebApis);
+  after(h.restoreWebApis);
+
+  describe('logo', function() {
+    it('renders auth0 logo from cdn by default', function(done) {
+      const options = {};
+      const lock = new Auth0Lock('cid', 'domain', options);
+
+      lock.on('show', () => {
+        expect(h.logoUrl(lock)).to.equal(
+          'http://cdn.auth0.com/styleguide/components/1.0.8/media/logos/img/badge.png'
+        );
+        lock.hide();
+        done();
+      });
+
+      lock.show();
+    });
+
+    it('renders auth0 logo passed via options', function(done) {
+      const options = { theme: { logo: 'https://my.logo/logo.svg' } };
+      const lock = new Auth0Lock('cid', 'domain', options);
+
+      lock.on('show', () => {
+        expect(h.logoUrl(lock)).to.equal('https://my.logo/logo.svg');
+        lock.hide();
+        done();
+      });
+
+      lock.show();
+    });
+
+    it('renders a link around the logo if logoLink is specified', function(done) {
+      const options = { theme: { logoLink: 'https://my.domain/' } };
+      const lock = new Auth0Lock('cid', 'domain', options);
+
+      lock.on('show', () => {
+        expect(h.logoLink(lock)).to.equal('https://my.domain/');
+        lock.hide();
+        done();
+      });
+
+      lock.show();
+    });
+  });
+});


### PR DESCRIPTION
Since it's a common use case to link the logo to the copmpany's home or other page we want to suggest a new theme option: `logoLink` in this PR.

This option will make the logo in the Lock header a link to the specified URL.

It makes theming and customising the auth0-lock ui component more flexible 💪.