### PR TITLE
Update en.js

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -58,7 +58,7 @@ export default {
   databaseSignUpInstructions: '',
   databaseAlternativeSignUpInstructions: 'or',
   emailInputPlaceholder: 'yours@example.com',
-  enterpriseLoginIntructions: 'Login with your corporate credentials.',
+  enterpriseLoginInstructions: 'Login with your corporate credentials.',
   enterpriseActiveLoginInstructions: 'Please enter your corporate credentials at %s.',
   failedLabel: 'Failed!',
   forgotPasswordTitle: 'Reset your password',


### PR DESCRIPTION
Typo for enterpriseLoginInstructions. Missing an 's'.