### PR TITLE
Spelling mistake fixed

### DIFF
--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -63,7 +63,7 @@ export default {
   failedLabel: 'Gescheitert!',
   forgotPasswordAction: 'Passwort vergessen?',
   forgotPasswordInstructions:
-    'Geben Sie bitte Ihre Email-Adresse ein. Wir werden Ihnen eine E-Mail senden um Ihr Passwort zurücksetzen zu können.',
+    'Geben Sie bitte Ihre E-Mail-Adresse ein. Wir werden Ihnen eine E-Mail senden um Ihr Passwort zurücksetzen zu können.',
   forgotPasswordSubmitLabel: 'E-Mail senden',
   invalidErrorHint: 'Ungültig',
   lastLoginInstructions: 'Letztes Mal waren Sie angemeldet mit',


### PR DESCRIPTION
@luisrudge You are so fast ... :+1: The correct spelling in german is "E-Mail". Have a look at 
https://www.duden.de/rechtschreibung/E_Mail.