### PR TITLE
Fix password managers submitting the form incorrectly

### DIFF
--- a/src/ui/box/chrome.jsx
+++ b/src/ui/box/chrome.jsx
@@ -305,6 +305,7 @@ export default class Chrome extends React.Component {
             which doesn't trigger the `onsubmit` event handler, which
             makes impossible to react to handle the submit event, 
             causing the page to send a POST request to `window.location.href`
+            with all the form data.
          */}
         <SubmitButton
           color={primaryColor}

--- a/src/ui/box/chrome.jsx
+++ b/src/ui/box/chrome.jsx
@@ -303,7 +303,7 @@ export default class Chrome extends React.Component {
             The submit button should always be included in the DOM.
             Otherwise, password managers will call `form.submit()`,
             which doesn't trigger the `onsubmit` event handler, which
-            makes impossible to react to handle the submit event, 
+            makes impossible for react to handle the submit event, 
             causing the page to send a POST request to `window.location.href`
             with all the form data.
          */}

--- a/src/ui/box/chrome.jsx
+++ b/src/ui/box/chrome.jsx
@@ -40,7 +40,7 @@ class SubmitButton extends React.Component {
   }
 
   render() {
-    const { color, disabled, label } = this.props;
+    const { color, disabled, label, display } = this.props;
     const content = label ? (
       <span className="auth0-label-submit">
         {label}
@@ -54,8 +54,9 @@ class SubmitButton extends React.Component {
       <button
         className="auth0-lock-submit"
         disabled={disabled}
-        style={{ backgroundColor: color }}
+        style={{ backgroundColor: color, display }}
         onClick={::this.handleSubmit}
+        name="submit"
         type="submit"
       >
         <div className="auth0-loading-container">
@@ -217,18 +218,7 @@ export default class Chrome extends React.Component {
       name = '';
     }
 
-    const submitButton = showSubmitButton &&
-      !delayingShowSubmitButton && (
-        <SubmitButton
-          color={primaryColor}
-          disabled={disableSubmitButton}
-          screenName={screenName}
-          contentProps={contentProps}
-          key="submit"
-          label={submitButtonLabel}
-          ref="submit"
-        />
-      );
+    const shouldShowSubmitButton = showSubmitButton && !delayingShowSubmitButton;
 
     function wrapGlobalMessage(message) {
       return typeof message === 'string'
@@ -309,7 +299,22 @@ export default class Chrome extends React.Component {
             </div>
           </MultisizeSlide>
         </div>
-        {submitButton}
+        {/*
+            The submit button should always be included in the DOM.
+            Otherwise, password managers will call `form.submit()`,
+            which doesn't trigger the `onsubmit` event handler, which
+            makes impossible to react to handle the submit event, 
+            causing the page to send a POST request to `window.location.href`
+         */}
+        <SubmitButton
+          color={primaryColor}
+          disabled={disableSubmitButton}
+          screenName={screenName}
+          contentProps={contentProps}
+          label={submitButtonLabel}
+          ref={el => (this.submitButton = el)}
+          display={shouldShowSubmitButton ? 'initial' : 'none'}
+        />
         {auxiliaryPane && (
           <TransitionGroup>
             <CSSTransition
@@ -326,7 +331,7 @@ export default class Chrome extends React.Component {
   }
 
   focusSubmit() {
-    this.refs.submit.focus();
+    this.submitButton.focus();
   }
 
   handleBack() {

--- a/test/helper/ui.js
+++ b/test/helper/ui.js
@@ -189,7 +189,9 @@ export const hasQuickAuthButton = (lock, icon, domain) => {
 };
 export const hasSocialButtons = hasViewFn('.auth0-lock-social-button');
 export const hasSSONotice = hasViewFn('.auth0-sso-notice-container');
-export const hasSubmitButton = hasFn('button.auth0-lock-submit');
+export const hasSubmitButton = hasFn('button.auth0-lock-submit[name=submit]');
+export const hasSubmitButtonVisible = lock =>
+  q(lock, 'button.auth0-lock-submit[name=submit]', false).style.display !== 'none';
 export const hasUsernameInput = hasInputFn('username');
 export const isLoginTabCurrent = lock => isTabCurrent(lock, /log in/i);
 export const isSignUpTabCurrent = lock => isTabCurrent(lock, /sign up/i);

--- a/test/layout.ui.test.js
+++ b/test/layout.ui.test.js
@@ -184,7 +184,8 @@ describe('layout', function() {
       expect(h.hasUsernameInput(this.lock)).to.not.be.ok();
       expect(h.hasPasswordInput(this.lock)).to.not.be.ok();
       expect(h.hasAlternativeLink(this.lock)).to.not.be.ok(); // forgot password
-      expect(h.hasSubmitButton(this.lock)).to.not.be.ok();
+      expect(h.hasSubmitButton(this.lock)).to.be.ok();
+      expect(h.hasSubmitButtonVisible(this.lock)).to.not.be.ok();
     });
   });
 
@@ -465,7 +466,8 @@ describe('layout', function() {
       expect(h.hasUsernameInput(this.lock)).to.not.be.ok();
       expect(h.hasPasswordInput(this.lock)).to.not.be.ok();
       expect(h.hasAlternativeLink(this.lock)).to.be.ok(); // not my account
-      expect(h.hasSubmitButton(this.lock)).to.not.be.ok();
+      expect(h.hasSubmitButton(this.lock)).to.be.ok();
+      expect(h.hasSubmitButtonVisible(this.lock)).to.not.be.ok();
     });
   });
 
@@ -519,7 +521,8 @@ describe('layout', function() {
       expect(h.hasUsernameInput(this.lock)).to.not.be.ok();
       expect(h.hasPasswordInput(this.lock)).to.not.be.ok();
       expect(h.hasAlternativeLink(this.lock)).to.not.be.ok(); // forgot password
-      expect(h.hasSubmitButton(this.lock)).to.not.be.ok();
+      expect(h.hasSubmitButton(this.lock)).to.be.ok();
+      expect(h.hasSubmitButtonVisible(this.lock)).to.not.be.ok();
     });
   });
 });


### PR DESCRIPTION
Discussion about the issue: https://spectrum.chat/?t=90bc0f1b-54fc-40f4-b718-353e80b47cdc

TLDR: Password managers use `form.submit()` to submit the form. This, according to the [docs](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit), prevents the `onsubmit` event from being emitted, which prevents react to handle the event.

> When invoking this method directly, no submit event is raised (in particular, the form's onsubmit event handler is not run),  and constraint validation is not triggered either.

The fix is also in the docs: 

> If a form control (such as a submit button) has a name or id of submit it will mask the form's submit method.

So, all we have to do is to add `name="submit"` to our submit button. In our specific case, I also had to change the behavior to make sure the button is always inside the dom (it was being added/removed  based on specific properties). Now, it's always in the DOM, but we toggle its visibility with a custom `style` rule.