### PR TITLE
Sending AD information when calling getssodata

### DIFF
--- a/src/__tests__/core/remote_data.test.js
+++ b/src/__tests__/core/remote_data.test.js
@@ -1,0 +1,39 @@
+const getSyncRemoteData = () => require('core/remote_data').syncRemoteData;
+
+describe('remote_data.syncRemoteData()', () => {
+  beforeEach(() => {
+    jest.resetModules();
+
+    jest.mock('sync', () => jest.fn());
+
+    jest.mock('connection/enterprise', () => ({
+      isADEnabled: () => true
+    }));
+
+    jest.mock('core/index', () => ({
+      useTenantInfo: () => true,
+      id: () => 'id'
+    }));
+
+    jest.mock('core/sso/data', () => ({
+      fetchSSOData: jest.fn()
+    }));
+  });
+  describe('calls getSSOData with AD information', () => {
+    [true, false].forEach(isAdEnabled => {
+      it(`when isADEnabled is ${isAdEnabled}`, () => {
+        require('connection/enterprise').isADEnabled = () => isAdEnabled;
+        const syncRemoteData = getSyncRemoteData();
+        syncRemoteData();
+        const ssoCall = require('sync').mock.calls.find(c => c[1] === 'sso');
+        ssoCall[2].syncFn('model', 'callback');
+        const [
+          id,
+          sendADInformation,
+          callback
+        ] = require('core/sso/data').fetchSSOData.mock.calls[0];
+        expect(sendADInformation).toBe(isAdEnabled);
+      });
+    });
+  });
+});

--- a/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
+++ b/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Auth0APIClient getSSOData should call client.client.getSSOData 1`] = `
+Array [
+  true,
+  [Function],
+]
+`;
+
 exports[`Auth0APIClient getUserCountry should call getUserCountry 1`] = `
 Array [
   "cb",

--- a/src/__tests__/core/web_api/p2_api.test.js
+++ b/src/__tests__/core/web_api/p2_api.test.js
@@ -14,7 +14,8 @@ const getClient = (options = {}) => {
   };
   client.client.client = {
     login: jest.fn(),
-    getUserCountry: jest.fn()
+    getUserCountry: jest.fn(),
+    getSSOData: jest.fn()
   };
   return client;
 };
@@ -185,6 +186,13 @@ describe('Auth0APIClient', () => {
     const client = getClient({});
     client.getUserCountry('cb');
     const { mock } = client.client.client.getUserCountry;
+    expect(mock.calls.length).toBe(1);
+    expect(mock.calls[0]).toMatchSnapshot();
+  });
+  it('getSSOData should call client.client.getSSOData', () => {
+    const client = getClient({});
+    client.getSSOData(true, () => {});
+    const { mock } = client.client.client.getSSOData;
     expect(mock.calls.length).toBe(1);
     expect(mock.calls[0]).toMatchSnapshot();
   });

--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -22,7 +22,7 @@ export function syncRemoteData(m) {
   m = sync(m, 'sso', {
     conditionFn: m => l.auth.sso(m) && l.ui.rememberLastLogin(m),
     waitFn: m => isSuccess(m, 'client'),
-    syncFn: (m, cb) => fetchSSOData(l.id(m), cb),
+    syncFn: (m, cb) => fetchSSOData(l.id(m), isADEnabled(m), cb),
     successFn: (m, result) => m.mergeIn(['sso'], Immutable.fromJS(result)),
     errorFn: (m, error) => {
       if (error.error === 'consent_required') {

--- a/src/core/sso/data.js
+++ b/src/core/sso/data.js
@@ -3,6 +3,6 @@ import Cache from '../../utils/cache';
 
 const cache = new Cache((...args) => webAPI.getSSOData(...args));
 
-export function fetchSSOData(id, cb) {
-  cache.get(id, cb);
+export function fetchSSOData(id, ...args) {
+  cache.get(id, ...args);
 }

--- a/src/core/web_api/p2_api.js
+++ b/src/core/web_api/p2_api.js
@@ -123,17 +123,8 @@ class Auth0APIClient {
     this.getUserInfo(token, callback);
   }
 
-  getSSOData(cb) {
-    if (this.isUniversalLogin) {
-      superagent
-        .get(`https://${this.domain}/user/ssodata`)
-        .withCredentials()
-        .end((err, res) => {
-          cb(err, res.body);
-        });
-    } else {
-      return this.client.client.getSSOData(cb);
-    }
+  getSSOData(...params) {
+    return this.client.client.getSSOData(...params);
   }
 
   getUserCountry(cb) {

--- a/test/helper/ui.js
+++ b/test/helper/ui.js
@@ -22,20 +22,20 @@ export const stubWebApis = () => {
   stub(ClientSettings, 'fetchClientSettings', (...args) => {
     args[args.length - 1](null, clientSettings);
   });
-  stub(SSOData, 'fetchSSOData', (id, cb) => {
+  stub(SSOData, 'fetchSSOData', (id, adInfo, cb) => {
     cb(null, ssoData);
   });
 };
 
 export const stubWebApisForKerberos = () => {
   SSOData.fetchSSOData.restore();
-  stub(SSOData, 'fetchSSOData', (id, cb) => {
+  stub(SSOData, 'fetchSSOData', (id, adInfo, cb) => {
     cb(null, ssoData);
   });
 };
 export const unStubWebApisForKerberos = () => {
   SSOData.fetchSSOData.restore();
-  stub(SSOData, 'fetchSSOData', (id, cb) => {
+  stub(SSOData, 'fetchSSOData', (id, adInfo, cb) => {
     cb(null, ssoData);
   });
 };


### PR DESCRIPTION
We're not sending the `AD` flag to auth0.js when we call getSSOData. This is fine for embedded since we ignore this flag. But for hosted pages, which use the /ssodata endpoint, this flag is required in order to return information about AD connections.