### PR TITLE
Fallback to email if the username field is empty

### DIFF
--- a/src/__tests__/connection/database/index.test.js
+++ b/src/__tests__/connection/database/index.test.js
@@ -1,7 +1,7 @@
 import Immutable, { List, Map } from 'immutable';
 import { databaseUsernameValue } from '../../../connection/database';
 
-describe.only('databaseUsernameValue', () => {
+describe('databaseUsernameValue', () => {
   const getModel = (email, username, usernameRequired) =>
     Immutable.fromJS({
       field: {

--- a/src/__tests__/connection/database/index.test.js
+++ b/src/__tests__/connection/database/index.test.js
@@ -1,0 +1,55 @@
+import Immutable, { List, Map } from 'immutable';
+import { databaseUsernameValue } from '../../../connection/database';
+
+describe.only('databaseUsernameValue', () => {
+  const getModel = (email, username, usernameRequired) =>
+    Immutable.fromJS({
+      field: {
+        email: {
+          value: email
+        },
+        username: {
+          value: username
+        }
+      },
+      core: {
+        transient: {
+          connections: {
+            database: [
+              {
+                requireUsername: usernameRequired
+              }
+            ]
+          }
+        }
+      }
+    });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('for database connection without username required', () => {
+    const model = getModel('user@contoso.com', null, false);
+
+    it('should get the email', () => {
+      expect(databaseUsernameValue(model)).toEqual('user@contoso.com');
+    });
+  });
+
+  describe('for database connection with username required', () => {
+    const model = getModel('user@contoso.com', 'user', true);
+
+    it('should get the username', () => {
+      expect(databaseUsernameValue(model)).toEqual('user');
+    });
+
+    describe('and only email address is filled in', () => {
+      const model = getModel('user@contoso.com', null, true);
+
+      it('should get the email address', () => {
+        expect(databaseUsernameValue(model)).toEqual('user@contoso.com');
+      });
+    });
+  });
+});

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -354,7 +354,12 @@ export function databaseLogInWithEmail(m) {
 }
 
 export function databaseUsernameValue(m) {
-  return getFieldValue(m, databaseLogInWithEmail(m) ? 'email' : 'username');
+  const isEmailOnly = databaseLogInWithEmail(m);
+  if (isEmailOnly) {
+    return getFieldValue(m, 'email');
+  }
+
+  return getFieldValue(m, 'username') || getFieldValue(m, 'email');
 }
 
 export function authWithUsername(m) {


### PR DESCRIPTION
## Description

Today when you have an enterprise connection configured and you type in an email address that matches the domain of this connection (eg: john@contoso.com => contoso.com), the login/signup/password reset pages will take that into account.

- Login => will change to SSO mode
- Signup => will change to SSO mode
- Password Reset => will prevent you from changing your password with a message saying you need to contact your administrator

While this works fine for database connections, there is an issue when the database connection requires a username. With usernames required, the `databaseUsernameValue` method will only look at the username field. While this works for the login page, it does not for signup and password reset (because there you enter your email address ... in the email field). This currently results in:

- Login => will change to SSO mode
- Signup => will not change to SSO. instead the signup form is still shown.
- Password Reset => will not show a warning.

This change will have `databaseUsernameValue` fallback to the email address if the username field is not filled in. With that, when an enterprise user accidentally fills in their corporate email address on the signup or password reset page, we will trigger the correct behavior of forcing them to use SSO (or preventing them to change their password).

## Testing

The change has manually been tested. An account configured with a DB connection requiring a username + an enterprise connection now results in this behavior:

- Login => will change to SSO mode
- Signup => will change to SSO mode
- Password Reset => will prevent you from changing your password with a message saying you need to contact your administrator

Unit tests were also added.