### PR TITLE
Fix Configuration URL when using __tenantInfo and a baseConfigurationURL

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -337,6 +337,10 @@ function extractClientBaseUrlOption(opts, domain) {
 
 export function extractTenantBaseUrlOption(opts, domain) {
   if (opts.configurationBaseUrl && typeof opts.configurationBaseUrl === 'string') {
+    if (opts.overrides && opts.overrides.__tenant) {
+      // When using a custom domain and a configuration URL hosted in auth0's cdn
+      return urljoin(opts.configurationBaseUrl, 'tenants', 'v1', `${opts.overrides.__tenant}.js`);
+    }
     return urljoin(opts.configurationBaseUrl, 'info-v1.js');
   }
 

--- a/test/tenantinfo.test.js
+++ b/test/tenantinfo.test.js
@@ -6,6 +6,20 @@ import expect from 'expect.js';
 import { extractTenantBaseUrlOption } from '../src/core/index';
 
 describe('extractTenantBaseUrlOption', () => {
+  it('should return the configurationBaseUrl with tenant in path', () => {
+    var url = extractTenantBaseUrlOption(
+      {
+        configurationBaseUrl: 'https://test.com',
+        overrides: {
+          __tenant: 'lbalmaceda'
+        }
+      },
+      'lbalmaceda.auth0.com'
+    );
+
+    expect(url).to.be('https://test.com/tenants/v1/lbalmaceda.js');
+  });
+
   it('should return the configurationBaseUrl', () => {
     var url = extractTenantBaseUrlOption(
       {


### PR DESCRIPTION
ZD Num: 43661

This generates the right configuration URL when a `baseConfigurationUrl` is set and Tenant Info is being used.

Fixes #1417