### PR TITLE
prevent access_denied to invalid_user_password error or code mapping if in HLP env

### DIFF
--- a/src/__tests__/core/web_api/__snapshots__/helper.test.js.snap
+++ b/src/__tests__/core/web_api/__snapshots__/helper.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`normalizeError should map access_denied error to invalid_user_password when error.code === access_denied 1`] = `
+exports[`normalizeError access_denied to invalid_user_password mapping domain doesn't match current host should map access_denied error to invalid_user_password when error.code === access_denied 1`] = `
 Object {
   "code": "invalid_user_password",
   "description": "foobar",
@@ -8,7 +8,39 @@ Object {
 }
 `;
 
-exports[`normalizeError should map access_denied error to invalid_user_password when error.error === access_denied 1`] = `
+exports[`normalizeError access_denied to invalid_user_password mapping domain doesn't match current host should map access_denied error to invalid_user_password when error.error === access_denied 1`] = `
+Object {
+  "code": "invalid_user_password",
+  "description": "foobar",
+  "error": "invalid_user_password",
+}
+`;
+
+exports[`normalizeError access_denied to invalid_user_password mapping domain is undefined should map access_denied error to invalid_user_password when error.code === access_denied 1`] = `
+Object {
+  "code": "invalid_user_password",
+  "description": "foobar",
+  "error": "invalid_user_password",
+}
+`;
+
+exports[`normalizeError access_denied to invalid_user_password mapping domain is undefined should map access_denied error to invalid_user_password when error.error === access_denied 1`] = `
+Object {
+  "code": "invalid_user_password",
+  "description": "foobar",
+  "error": "invalid_user_password",
+}
+`;
+
+exports[`normalizeError access_denied to invalid_user_password mapping domain match current host should not map access_denied error to invalid_user_password when error.code === access_denied 1`] = `
+Object {
+  "code": "invalid_user_password",
+  "description": "foobar",
+  "error": "invalid_user_password",
+}
+`;
+
+exports[`normalizeError access_denied to invalid_user_password mapping domain match current host should not map access_denied error to invalid_user_password when error.error === access_denied 1`] = `
 Object {
   "code": "invalid_user_password",
   "description": "foobar",

--- a/src/__tests__/core/web_api/helper.test.js
+++ b/src/__tests__/core/web_api/helper.test.js
@@ -32,30 +32,63 @@ describe('normalizeError', () => {
     const normalized = normalizeError(undefined);
     expect(normalized).toBe(undefined);
   });
-  it('should map access_denied error to invalid_user_password when error.error === access_denied', () => {
-    const error = {
+
+  describe('access_denied to invalid_user_password mapping', function() {
+    const domainMock = 'domainMock';
+    const errorObjWithError = {
       error: 'access_denied',
       description: 'foobar'
     };
-    const expectedError = {
-      code: 'invalid_user_password',
-      error: 'invalid_user_password',
-      description: 'foobar'
-    };
-    const actualError = normalizeError(error);
-    expect(actualError).toMatchSnapshot();
-  });
-  it('should map access_denied error to invalid_user_password when error.code === access_denied', () => {
-    const error = {
+    const errorObjWithCode = {
       code: 'access_denied',
       description: 'foobar'
     };
-    const expectedError = {
-      code: 'invalid_user_password',
-      error: 'invalid_user_password',
-      description: 'foobar'
-    };
-    const actualError = normalizeError(error);
-    expect(actualError).toMatchSnapshot();
+    let currentWindowObj;
+
+    beforeAll(function() {
+      currentWindowObj = global.window;
+      global.window = {
+        locaction: {
+          host: domainMock
+        }
+      };
+    });
+
+    afterAll(function() {
+      global.window = currentWindowObj;
+    });
+
+    describe('domain is undefined', function() {
+      it('should map access_denied error to invalid_user_password when error.error === access_denied', () => {
+        const actualError = normalizeError(errorObjWithError);
+        expect(actualError).toMatchSnapshot();
+      });
+      it('should map access_denied error to invalid_user_password when error.code === access_denied', () => {
+        const actualError = normalizeError(errorObjWithCode);
+        expect(actualError).toMatchSnapshot();
+      });
+    });
+
+    describe("domain doesn't match current host", function() {
+      it('should map access_denied error to invalid_user_password when error.error === access_denied', () => {
+        const actualError = normalizeError(errorObjWithError, 'loremIpsum');
+        expect(actualError).toMatchSnapshot();
+      });
+      it('should map access_denied error to invalid_user_password when error.code === access_denied', () => {
+        const actualError = normalizeError(errorObjWithCode, 'loremIpsum');
+        expect(actualError).toMatchSnapshot();
+      });
+    });
+
+    describe('domain match current host', function() {
+      it('should not map access_denied error to invalid_user_password when error.error === access_denied', () => {
+        const actualError = normalizeError(errorObjWithError, domainMock);
+        expect(actualError).toMatchSnapshot();
+      });
+      it('should not map access_denied error to invalid_user_password when error.code === access_denied', () => {
+        const actualError = normalizeError(errorObjWithCode, domainMock);
+        expect(actualError).toMatchSnapshot();
+      });
+    });
   });
 });

--- a/src/core/web_api/helper.js
+++ b/src/core/web_api/helper.js
@@ -1,4 +1,4 @@
-export function normalizeError(error) {
+export function normalizeError(error, domain) {
   if (!error) {
     return error;
   }
@@ -94,7 +94,10 @@ export function normalizeError(error) {
       description: error.description
     };
   }
-  if (error.error === 'access_denied' || error.code === 'access_denied') {
+  if (
+    window.location.host !== domain &&
+    (error.error === 'access_denied' || error.code === 'access_denied')
+  ) {
     return {
       code: 'invalid_user_password',
       error: 'invalid_user_password',
@@ -111,10 +114,10 @@ export function normalizeError(error) {
   return result.error === undefined && result.description === undefined ? error : result;
 }
 
-export function loginCallback(redirect, cb) {
+export function loginCallback(redirect, domain, cb) {
   return redirect
-    ? error => cb(normalizeError(error))
-    : (error, result) => cb(normalizeError(error), result);
+    ? error => cb(normalizeError(error, domain))
+    : (error, result) => cb(normalizeError(error, domain), result);
 }
 
 export function normalizeAuthParams({ popup, ...authParams }) {

--- a/src/core/web_api/p2_api.js
+++ b/src/core/web_api/p2_api.js
@@ -60,7 +60,7 @@ class Auth0APIClient {
   logIn(options, authParams, cb) {
     // TODO: for passwordless only, try to clean in auth0.js
     // client._shouldRedirect = redirect || responseType === "code" || !!redirectUrl;
-    const f = loginCallback(false, cb);
+    const f = loginCallback(false, this.domain, cb);
     const loginOptions = normalizeAuthParams({ ...options, ...this.authOpt, ...authParams });
 
     if (!options.username && !options.email) {


### PR DESCRIPTION
Fix issue with incorrect error message mapping in case of session timeout. The returned payload is:

```
{
  "statusCode": 403,
  "description": "Invalid state",
  "name": "AnomalyDetected",
  "code": "access_denied"
}
```

Currently this kind of error is mapped to `invalid_user_password` which causes UX regression to one of our customers. 

@luisrudge suggested we could fix this issue by preventing the mapping in Hosted Login Pages environment.