### PR TITLE
Add a new type of additionalSignUpField: hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,20 @@ var options = {
 }
 ```
 
+##### Hidden field
+
+To specify a hidden field use: `type: "hidden"`. The `value` property is required.
+
+```js
+var options = {
+  additionalSignUpFields: [{
+    type: "hidden",
+    name: "signup_code",
+    value: "foobar123"
+  }]
+}
+```
+
 #### Avatar provider
 
 Lock can show avatars fetched from anywhere. A custom avatar provider can be specified with the `avatar` option by passing an object with the keys `url` and `displayName`. Both properties are functions that take an email and a callback function.

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ var options = {
 
 ##### Hidden field
 
-To specify a hidden field use: `type: "hidden"`. The `value` property is required.
+To specify a hidden field use: `type: "hidden"`. Both the `value` and `name` properties are required.
 
 ```js
 var options = {

--- a/src/__tests__/connection/database/index.test.js
+++ b/src/__tests__/connection/database/index.test.js
@@ -1,60 +1,101 @@
 import Immutable, { List, Map } from 'immutable';
-import { databaseUsernameValue } from '../../../connection/database';
+import { databaseUsernameValue, initDatabase } from '../../../connection/database';
 
-describe('databaseUsernameValue', () => {
-  const getModel = (email, username, usernameRequired) =>
-    Immutable.fromJS({
-      field: {
-        email: {
-          value: email
+describe('database/index.js', () => {
+  describe('databaseUsernameValue', () => {
+    const getModel = (email, username, usernameRequired) =>
+      Immutable.fromJS({
+        field: {
+          email: {
+            value: email
+          },
+          username: {
+            value: username
+          }
         },
-        username: {
-          value: username
-        }
-      },
-      core: {
-        transient: {
-          connections: {
-            database: [
-              {
-                requireUsername: usernameRequired
-              }
-            ]
+        core: {
+          transient: {
+            connections: {
+              database: [
+                {
+                  requireUsername: usernameRequired
+                }
+              ]
+            }
           }
         }
-      }
+      });
+
+    beforeEach(() => {
+      jest.resetAllMocks();
     });
 
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
+    describe('for database connection without username required', () => {
+      const model = getModel('user@contoso.com', null, false);
 
-  describe('for database connection without username required', () => {
-    const model = getModel('user@contoso.com', null, false);
-
-    it('should get the email', () => {
-      expect(databaseUsernameValue(model)).toEqual('user@contoso.com');
-    });
-  });
-
-  describe('for database connection with username required', () => {
-    const model = getModel('user@contoso.com', 'user', true);
-
-    it('should get the username when `emailFirst` is not set', () => {
-      expect(databaseUsernameValue(model)).toEqual('user');
-    });
-    it('should get the username when `emailFirst` is false', () => {
-      expect(databaseUsernameValue(model, { emailFirst: false })).toEqual('user');
-    });
-    it('should get the email when `emailFirst` is true', () => {
-      expect(databaseUsernameValue(model, { emailFirst: true })).toEqual('user@contoso.com');
-    });
-
-    describe('and only email address is filled in', () => {
-      const model = getModel('user@contoso.com', null, true);
-
-      it('should get the email address', () => {
+      it('should get the email', () => {
         expect(databaseUsernameValue(model)).toEqual('user@contoso.com');
+      });
+    });
+
+    describe('for database connection with username required', () => {
+      const model = getModel('user@contoso.com', 'user', true);
+
+      it('should get the username when `emailFirst` is not set', () => {
+        expect(databaseUsernameValue(model)).toEqual('user');
+      });
+      it('should get the username when `emailFirst` is false', () => {
+        expect(databaseUsernameValue(model, { emailFirst: false })).toEqual('user');
+      });
+      it('should get the email when `emailFirst` is true', () => {
+        expect(databaseUsernameValue(model, { emailFirst: true })).toEqual('user@contoso.com');
+      });
+
+      describe('and only email address is filled in', () => {
+        const model = getModel('user@contoso.com', null, true);
+
+        it('should get the email address', () => {
+          expect(databaseUsernameValue(model)).toEqual('user@contoso.com');
+        });
+      });
+    });
+  });
+  describe('initDatabase', () => {
+    describe('calls initNS with the correct additionalSignUpFields', () => {
+      describe('with a valid hidden field', () => {
+        const model = Immutable.fromJS({});
+        const modelOut = initDatabase(model, {
+          additionalSignUpFields: [
+            {
+              type: 'hidden',
+              name: 'hidden_field',
+              value: 'hidden_value'
+            }
+          ]
+        });
+        const modelOutJS = modelOut.toJS();
+        expect(modelOutJS.field).toEqual({
+          hidden_field: { showInvalid: false, valid: true, value: 'hidden_value' }
+        });
+        expect(modelOutJS.database.additionalSignUpFields).toEqual([
+          {
+            name: 'hidden_field',
+            type: 'hidden',
+            value: 'hidden_value'
+          }
+        ]);
+      });
+      describe('with a hidden field without a value', () => {
+        const model = Immutable.fromJS({});
+        const modelOut = initDatabase(model, {
+          additionalSignUpFields: [
+            {
+              type: 'hidden',
+              name: 'hidden_field'
+            }
+          ]
+        });
+        expect(modelOut.toJS().database.additionalSignUpFields.length).toBe(0);
       });
     });
   });

--- a/src/__tests__/connection/database/index.test.js
+++ b/src/__tests__/connection/database/index.test.js
@@ -79,8 +79,8 @@ describe('database/index.js', () => {
         });
         expect(modelOutJS.database.additionalSignUpFields).toEqual([
           {
-            name: 'hidden_field',
             type: 'hidden',
+            name: 'hidden_field',
             value: 'hidden_value'
           }
         ]);

--- a/src/__tests__/connection/database/index.test.js
+++ b/src/__tests__/connection/database/index.test.js
@@ -31,15 +31,15 @@ describe('database/index.js', () => {
     });
 
     describe('for database connection without username required', () => {
-      const model = getModel('user@contoso.com', null, false);
+      const model = getModel('user@auth0.com', null, false);
 
       it('should get the email', () => {
-        expect(databaseUsernameValue(model)).toEqual('user@contoso.com');
+        expect(databaseUsernameValue(model)).toEqual('user@auth0.com');
       });
     });
 
     describe('for database connection with username required', () => {
-      const model = getModel('user@contoso.com', 'user', true);
+      const model = getModel('user@auth0.com', 'user', true);
 
       it('should get the username when `emailFirst` is not set', () => {
         expect(databaseUsernameValue(model)).toEqual('user');
@@ -48,14 +48,14 @@ describe('database/index.js', () => {
         expect(databaseUsernameValue(model, { emailFirst: false })).toEqual('user');
       });
       it('should get the email when `emailFirst` is true', () => {
-        expect(databaseUsernameValue(model, { emailFirst: true })).toEqual('user@contoso.com');
+        expect(databaseUsernameValue(model, { emailFirst: true })).toEqual('user@auth0.com');
       });
 
       describe('and only email address is filled in', () => {
-        const model = getModel('user@contoso.com', null, true);
+        const model = getModel('user@auth0.com', null, true);
 
         it('should get the email address', () => {
-          expect(databaseUsernameValue(model)).toEqual('user@contoso.com');
+          expect(databaseUsernameValue(model)).toEqual('user@auth0.com');
         });
       });
     });

--- a/src/__tests__/engine/classic/__snapshots__/sign_up_pane.test.jsx.snap
+++ b/src/__tests__/engine/classic/__snapshots__/sign_up_pane.test.jsx.snap
@@ -105,6 +105,7 @@ exports[`SignUpPane onlyEmail is false shows custom fields when additionalSignUp
     data-placeholder="placeholder1"
     data-type="type1"
     data-validator="validator1"
+    data-value="value1"
   />
   <div
     data-__type="custom_input"
@@ -115,6 +116,7 @@ exports[`SignUpPane onlyEmail is false shows custom fields when additionalSignUp
     data-placeholder="placeholder2"
     data-type="type2"
     data-validator="validator2"
+    data-value="value2"
   />
 </div>
 `;

--- a/src/__tests__/field/__snapshots__/custom_input.test.jsx.snap
+++ b/src/__tests__/field/__snapshots__/custom_input.test.jsx.snap
@@ -22,6 +22,14 @@ exports[`CustomInput when type == checkbox renders correctly as a CheckBoxInput 
 </div>
 `;
 
+exports[`CustomInput when type == hidden renders correctly as a input[type=hidden] 1`] = `
+<input
+  name="custom_input"
+  type="hidden"
+  value="hidden_value"
+/>
+`;
+
 exports[`CustomInput when type == input calls \`changeField\` when changed 1`] = `
 Array [
   1,

--- a/src/__tests__/field/custom_input.test.jsx
+++ b/src/__tests__/field/custom_input.test.jsx
@@ -101,4 +101,15 @@ describe('CustomInput', () => {
       expectComponent(<CustomInput {...defaultProps} />).toMatchSnapshot();
     });
   });
+  describe('when type == hidden', () => {
+    beforeEach(() => {
+      defaultProps.type = 'hidden';
+      defaultProps.value = 'hidden_value';
+    });
+    it('renders correctly as a input[type=hidden]', () => {
+      const CustomInput = getComponent();
+
+      expectComponent(<CustomInput {...defaultProps} />).toMatchSnapshot();
+    });
+  });
 });

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -111,7 +111,7 @@ function processDatabaseOptions(opts) {
       if (type !== 'hidden' && (typeof placeholder != 'string' || !placeholder)) {
         l.warn(
           opts,
-          'Ignoring an element of `additionalSignUpFields` because it does not contain a valid `placeholder` property. Every element of `additionalSignUpFields` must have a `placeholder` property that is a non-empty string.'
+          `Ignoring an element of \`additionalSignUpFields\` (${name}) because it does not contain a valid \`placeholder\` property. Every element of \`additionalSignUpFields\` must have a \`placeholder\` property that is a non-empty string.`
         );
         filter = false;
       }
@@ -177,14 +177,14 @@ function processDatabaseOptions(opts) {
       ) {
         l.warn(
           opts,
-          'Ignoring an element of `additionalSignUpFields` because it has a "select" `type` but does not specify an `options` property that is an Array or a function.'
+          `Ignoring an element of \`additionalSignUpFields\` (${name}) because it has a "select" \`type\` but does not specify an \`options\` property that is an Array or a function.`
         );
         filter = false;
       }
       if (type === 'hidden' && !value) {
         l.warn(
           opts,
-          'Ignoring an element of `additionalSignUpFields` because it has a "hidden" `type` but does not specify a `value` string'
+          `Ignoring an element of \`additionalSignUpFields\` (${name}) because it has a "hidden" \`type\` but does not specify a \`value\` string.`
         );
         filter = false;
       }

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -489,6 +489,5 @@ function resolveAdditionalSignUpTextField(m, x) {
 }
 
 function resolveAdditionalSignUpHiddenField(m, x) {
-  const name = x.get('name');
-  return setField(m, name, x.get('value'));
+  return setField(m, x.get('name'), x.get('value'));
 }

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -411,8 +411,7 @@ export function toggleTermsAcceptance(m) {
 
 export function resolveAdditionalSignUpFields(m) {
   return additionalSignUpFields(m).reduce((r, x) => {
-    const type = x.get('type');
-    switch (type) {
+    switch (x.get('type')) {
       case 'select':
         return resolveAdditionalSignUpSelectField(r, x);
       case 'hidden':

--- a/src/engine/classic/sign_up_pane.jsx
+++ b/src/engine/classic/sign_up_pane.jsx
@@ -47,6 +47,7 @@ export default class SignUpPane extends React.Component {
           placeholder={x.get('placeholder')}
           type={x.get('type')}
           validator={x.get('validator')}
+          value={x.get('value')}
         />
       ));
 

--- a/src/field/custom_input.jsx
+++ b/src/field/custom_input.jsx
@@ -6,7 +6,7 @@ import SelectInput from '../ui/input/select_input';
 import CheckboxInput from '../ui/input/checkbox_input';
 import * as l from '../core/index';
 
-const CustomInput = ({ iconUrl, model, name, placeholder, type, validator }) => {
+const CustomInput = ({ iconUrl, model, name, placeholder, type, validator, value }) => {
   const props = {
     iconUrl,
     isValid: !isFieldVisiblyInvalid(model, name),
@@ -31,6 +31,8 @@ const CustomInput = ({ iconUrl, model, name, placeholder, type, validator }) => 
           {...props}
         />
       );
+    case 'hidden':
+      return <input type="hidden" value={value} name={name} />;
     default:
       return (
         <TextInput


### PR DESCRIPTION
fix #1324 

adds a new type (hidden) of custom signup fields:

##### Hidden field
 To specify a hidden field use: `type: "hidden"`. Both the `value` and `name` properties are required.
 ```js
var options = {
  additionalSignUpFields: [{
    type: "hidden",
    name: "signup_code",
    value: "foobar123"
  }]
}
```
