### PR TITLE
Update ja.js containsAtLeast text

### DIFF
--- a/src/i18n/ja.js
+++ b/src/i18n/ja.js
@@ -70,7 +70,7 @@ export default {
   notYourAccountAction: 'これはあなたのアカウントではありませんか？',
   passwordInputPlaceholder: 'パスワード',
   passwordStrength: {
-    containsAtLeast: '次の%d文字のうちが%d文字以上が含まれる必要があります:',
+    containsAtLeast: '下記の%dつのうち%dつ以上含んでください:',
     identicalChars: '連続して同じ文字を%d個以上入力できません（例: "%s" は使用できません）',
     nonEmpty: 'パスワードは必須です',
     numbers: '数字 (0-9)',


### PR DESCRIPTION
Hideya Furuta requested this change through a support ticket.

He said: Please modify the letters for 2nd line: 3 が含まれています: 4 to 下記の 4 つのうち 3 つ以上含んでください.
Current configuration 3 が含まれている: 4 is not match for Japanese sentence, and customers claimed they couldn't understand the meanings.