### PR TITLE
Use span for icon buttons

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -179,6 +179,7 @@ tabsHeight = 40px
     line-height 0
     
     &:focus
+      outline: none
       box-shadow 0 3px 3px rgba(0,0,0,.3)
 
     svg

--- a/src/ui/box/button.jsx
+++ b/src/ui/box/button.jsx
@@ -9,12 +9,20 @@ const svgs = {
 };
 
 const IconButton = ({ name, onClick, svg }) => (
-  <button
+  <span
+    role="button"
+    tabIndex={0}
     className={`auth0-lock-${name}-button`}
     dangerouslySetInnerHTML={{ __html: svg }}
     onClick={e => {
       e.preventDefault();
       onClick();
+    }}
+    onKeyPress={e => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        onClick();
+      }
     }}
     aria-label={name}
   />


### PR DESCRIPTION
Fixes regression in v11.9.0

In 11.9.0, for accessibility, some 'span' tags were switched to 'button'.
However hitting the enter key triggers the onClick on buttons. (not sure where this is in the code, but it might be worth changing)
So switching back to 'span' for now.