### PR TITLE
Added promotion flag and serialization of fields marked with is_promo…

### DIFF
--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -63,11 +63,16 @@ export function signUp(id) {
 
     if (!additionalSignUpFields(m).isEmpty()) {
       params.user_metadata = {};
+      params.user_metadata.promotion = {};
       additionalSignUpFields(m).forEach(x => {
-        params.user_metadata[x.get('name')] = c.getFieldValue(m, x.get('name'));
+        if (x.get('is_promotion')) {
+          params.user_metadata.promotion[x.get('name')] = c.getFieldValue(m, x.get('name'));
+        } else {
+          params.user_metadata[x.get('name')] = c.getFieldValue(m, x.get('name'));
+        }
       });
     }
-
+    params.user_metadata.promotion = JSON.stringify(params.user_metadata.promotion);
     webApi.signUp(id, params, (error, result, popupHandler, ...args) => {
       if (error) {
         if (!!popupHandler) {

--- a/src/connection/database/index.js
+++ b/src/connection/database/index.js
@@ -90,7 +90,7 @@ function processDatabaseOptions(opts) {
     additionalSignUpFields = undefined;
   } else if (additionalSignUpFields) {
     additionalSignUpFields = additionalSignUpFields.reduce((r, x) => {
-      let { icon, name, options, placeholder, prefill, type, validator, value } = x;
+      let { icon, name, options, placeholder, prefill, type, validator, value, is_promotion } = x;
       let filter = true;
 
       const reservedNames = ['email', 'username', 'password'];
@@ -190,7 +190,9 @@ function processDatabaseOptions(opts) {
       }
 
       return filter
-        ? r.concat([{ icon, name, options, placeholder, prefill, type, validator, value }])
+        ? r.concat([
+            { icon, name, options, placeholder, prefill, type, validator, value, is_promotion }
+          ])
         : r;
     }, []);
 


### PR DESCRIPTION
Added promotion flag and serialization of fields marked with is_promotion into the promotion field. Requires an unpacking rule in Auth0.

It works like this: When setting additional sign-up fields in the lock widgets configuration,
a field can be flagged with is_promotion: true and before the request to signup i sent, those fields are packed, serialized and put in a promotion field and not available directly as a field. 

The lock fields can later be unpacked and processed using a Auth0 Rule 