### PR TITLE
Added Email confirmation input 

### DIFF
--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -47,6 +47,7 @@ export function signUp(id) {
   const m = read(getEntity, 'lock', id);
   const fields = ['email', 'password'];
   if (databaseConnectionRequiresUsername(m)) fields.push('username');
+  if (l.confirmEmailInput(m)) fields.push('confirmEmail');
   additionalSignUpFields(m).forEach(x => fields.push(x.get('name')));
 
   validateAndSubmit(id, fields, m => {
@@ -59,6 +60,10 @@ export function signUp(id) {
 
     if (databaseConnectionRequiresUsername(m)) {
       params.username = c.getFieldValue(m, 'username');
+    }
+
+    if (l.confirmEmailInput(m)) {
+      params.confirmEmail = c.getFieldValue(m, 'confirmEmail');
     }
 
     if (!additionalSignUpFields(m).isEmpty()) {

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -14,6 +14,7 @@ import * as l from './index';
 import { img as preload } from '../utils/preload_utils';
 import { defaultProps } from '../ui/box/container';
 import { isFieldValid, showInvalidField, hideInvalidFields, clearFields } from '../field/index';
+import * as c from '../field';
 
 export function setupLock(id, clientID, domain, options, hookRunner, emitEventFn) {
   let m = l.setup(id, clientID, domain, options, hookRunner, emitEventFn);
@@ -166,7 +167,13 @@ export function unpinLoadingPane(id) {
 
 export function validateAndSubmit(id, fields = [], f) {
   swap(updateEntity, 'lock', id, m => {
-    const allFieldsValid = fields.reduce((r, x) => r && isFieldValid(m, x), true);
+    let allFieldsValid = fields.reduce((r, x) => r && isFieldValid(m, x), true);
+
+    if (l.confirmEmailInput(m)) {
+      allFieldsValid =
+        allFieldsValid && c.getFieldValue(m, 'email') === c.getFieldValue(m, 'confirmEmail');
+    }
+
     return allFieldsValid
       ? l.setSubmitting(m, true)
       : fields.reduce((r, x) => showInvalidField(r, x), m);

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -33,7 +33,8 @@ export function setup(id, clientID, domain, options, hookRunner, emitEventFn) {
       defaultADUsernameFromEmailPrefix:
         options.defaultADUsernameFromEmailPrefix === false ? false : true,
       prefill: options.prefill || {},
-      connectionResolver: options.connectionResolver
+      connectionResolver: options.connectionResolver,
+      confirmEmailInput: options.confirmEmailInput
     })
   );
 
@@ -157,9 +158,7 @@ export function stopRendering(m) {
 function extractUIOptions(id, options) {
   const closable = options.container
     ? false
-    : undefined === options.closable
-      ? true
-      : !!options.closable;
+    : undefined === options.closable ? true : !!options.closable;
   const theme = options.theme || {};
   const { labeledSubmitButton, hideMainScreenTitle, logo, primaryColor, authButtons } = theme;
 
@@ -401,6 +400,10 @@ export function defaultADUsernameFromEmailPrefix(m) {
 
 export function prefill(m) {
   return get(m, 'prefill', {});
+}
+
+export function confirmEmailInput(m) {
+  return get(m, 'confirmEmailInput', {});
 }
 
 export function warn(x, str) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -34,7 +34,7 @@ export function setup(id, clientID, domain, options, hookRunner, emitEventFn) {
         options.defaultADUsernameFromEmailPrefix === false ? false : true,
       prefill: options.prefill || {},
       connectionResolver: options.connectionResolver,
-      confirmEmailInput: options.confirmEmailInput
+      confirmEmailInput: !!options.confirmEmailInput
     })
   );
 

--- a/src/engine/classic/sign_up_pane.jsx
+++ b/src/engine/classic/sign_up_pane.jsx
@@ -19,7 +19,8 @@ export default class SignUpPane extends React.Component {
       onlyEmail,
       passwordInputPlaceholder,
       passwordStrengthMessages,
-      usernameInputPlaceholder
+      usernameInputPlaceholder,
+      confirmEmailInput
     } = this.props;
 
     const headerText = instructions || null;
@@ -64,7 +65,12 @@ export default class SignUpPane extends React.Component {
     return (
       <div>
         {header}
-        <EmailPane i18n={i18n} lock={model} placeholder={emailInputPlaceholder} />
+        <EmailPane
+          i18n={i18n}
+          lock={model}
+          placeholder={emailInputPlaceholder}
+          confirmEmailInput={confirmEmailInput}
+        />
         {usernamePane}
         {passwordPane}
         {fields}

--- a/src/engine/classic/sign_up_pane.jsx
+++ b/src/engine/classic/sign_up_pane.jsx
@@ -19,8 +19,7 @@ export default class SignUpPane extends React.Component {
       onlyEmail,
       passwordInputPlaceholder,
       passwordStrengthMessages,
-      usernameInputPlaceholder,
-      confirmEmailInput
+      usernameInputPlaceholder
     } = this.props;
 
     const headerText = instructions || null;
@@ -65,12 +64,7 @@ export default class SignUpPane extends React.Component {
     return (
       <div>
         {header}
-        <EmailPane
-          i18n={i18n}
-          lock={model}
-          placeholder={emailInputPlaceholder}
-          confirmEmailInput={confirmEmailInput}
-        />
+        <EmailPane i18n={i18n} lock={model} placeholder={emailInputPlaceholder} />
         {usernamePane}
         {passwordPane}
         {fields}

--- a/src/engine/classic/sign_up_screen.jsx
+++ b/src/engine/classic/sign_up_screen.jsx
@@ -60,6 +60,7 @@ const Component = ({ i18n, model }) => {
       passwordInputPlaceholder={i18n.str('passwordInputPlaceholder')}
       passwordStrengthMessages={i18n.group('passwordStrength')}
       usernameInputPlaceholder={i18n.str('usernameInputPlaceholder')}
+      confirmEmailInput={l.confirmEmailInput(model)}
     />
   );
 

--- a/src/engine/classic/sign_up_screen.jsx
+++ b/src/engine/classic/sign_up_screen.jsx
@@ -60,7 +60,6 @@ const Component = ({ i18n, model }) => {
       passwordInputPlaceholder={i18n.str('passwordInputPlaceholder')}
       passwordStrengthMessages={i18n.group('passwordStrength')}
       usernameInputPlaceholder={i18n.str('usernameInputPlaceholder')}
-      confirmEmailInput={l.confirmEmailInput(model)}
     />
   );
 

--- a/src/field/email.js
+++ b/src/field/email.js
@@ -26,6 +26,17 @@ export function setEmail(m, str) {
   });
 }
 
+export function setConfirmEmail(m, str) {
+  return setField(m, 'confirmEmail', str.trim(), str => {
+    const validHRDEMail = isHRDEmailValid(m, str);
+
+    return {
+      valid: validateEmail(str) && validHRDEMail,
+      hint: !validHRDEMail ? i18n.html(m, ['error', 'login', 'hrd.not_matching_email']) : undefined
+    };
+  });
+}
+
 export function emailDomain(str) {
   const result = regExp.exec(trim(str.toLowerCase()));
   return result ? result.slice(-2)[0] : '';

--- a/src/field/email/email_pane.jsx
+++ b/src/field/email/email_pane.jsx
@@ -25,7 +25,13 @@ export default class EmailPane extends React.Component {
   }
 
   render() {
-    const { i18n, lock, placeholder, forceInvalidVisibility = false } = this.props;
+    const {
+      i18n,
+      lock,
+      placeholder,
+      forceInvalidVisibility = false,
+      confirmEmailInput
+    } = this.props;
     const allowAutocomplete = l.ui.allowAutocomplete(lock);
 
     const field = c.getField(lock, 'email');
@@ -37,14 +43,26 @@ export default class EmailPane extends React.Component {
     const isValid = (!forceInvalidVisibility || valid) && !c.isFieldVisiblyInvalid(lock, 'email');
 
     return (
-      <EmailInput
-        value={value}
-        invalidHint={invalidHint}
-        isValid={isValid}
-        onChange={::this.handleChange}
-        placeholder={placeholder}
-        autoComplete={allowAutocomplete}
-      />
+      <div>
+        <EmailInput
+          value={value}
+          invalidHint={invalidHint}
+          isValid={isValid}
+          onChange={::this.handleChange}
+          placeholder={placeholder}
+          autoComplete={allowAutocomplete}
+        />
+        {confirmEmailInput && (
+          <EmailInput
+            value={value}
+            invalidHint={invalidHint}
+            isValid={isValid}
+            onChange={::this.handleChange}
+            placeholder={placeholder}
+            autoComplete={allowAutocomplete}
+          />
+        )}
+      </div>
     );
   }
 }

--- a/src/field/email/email_pane.jsx
+++ b/src/field/email/email_pane.jsx
@@ -24,14 +24,13 @@ export default class EmailPane extends React.Component {
     swap(updateEntity, 'lock', l.id(lock), setEmail, e.target.value);
   }
 
+  validateEmails(e) {
+    this.confirmedValid = e.target.value === this.refs.mainEmailInput.props.value;
+    console.log(this.confirmedValid);
+  }
+
   render() {
-    const {
-      i18n,
-      lock,
-      placeholder,
-      forceInvalidVisibility = false,
-      confirmEmailInput
-    } = this.props;
+    const { i18n, lock, placeholder, forceInvalidVisibility = false } = this.props;
     const allowAutocomplete = l.ui.allowAutocomplete(lock);
 
     const field = c.getField(lock, 'email');
@@ -51,15 +50,15 @@ export default class EmailPane extends React.Component {
           onChange={::this.handleChange}
           placeholder={placeholder}
           autoComplete={allowAutocomplete}
+          ref="mainEmailInput"
         />
-        {confirmEmailInput && (
+        {l.confirmEmailInput(lock) && (
           <EmailInput
-            value={value}
             invalidHint={invalidHint}
             isValid={isValid}
-            onChange={::this.handleChange}
             placeholder={placeholder}
-            autoComplete={allowAutocomplete}
+            onChange={::this.validateEmails}
+            // confirmedValid={this.confirmedValid}
           />
         )}
       </div>

--- a/src/field/email/email_pane.jsx
+++ b/src/field/email/email_pane.jsx
@@ -29,7 +29,8 @@ export default class EmailPane extends React.Component {
   compareEmails(e) {
     const { lock } = this.props;
     swap(updateEntity, 'lock', l.id(lock), setConfirmEmail, e.target.value);
-    this.confirmedValid = e.target.value === this.refs.primaryEmailInput.props.value;
+    this.confirmedValid =
+      e.target.value === '' || e.target.value === this.refs.primaryEmailInput.props.value;
   }
 
   render() {
@@ -45,27 +46,33 @@ export default class EmailPane extends React.Component {
     const isValid = (!forceInvalidVisibility || valid) && !c.isFieldVisiblyInvalid(lock, 'email');
     const confirmValidity = isValid && this.confirmedValid;
 
-    return (
-      <div>
-        <EmailInput
-          value={value}
-          invalidHint={invalidHint}
-          isValid={isValid}
-          onChange={::this.handleChange}
-          placeholder={placeholder}
-          autoComplete={allowAutocomplete}
-          ref="primaryEmailInput"
-        />
-        {l.confirmEmailInput(lock) && (
+    let emailInputs = (
+      <EmailInput
+        value={value}
+        invalidHint={invalidHint}
+        isValid={isValid}
+        onChange={::this.handleChange}
+        placeholder={placeholder}
+        autoComplete={allowAutocomplete}
+        ref="primaryEmailInput"
+      />
+    );
+
+    if (l.confirmEmailInput(lock)) {
+      emailInputs = (
+        <div className={'auth0-lock-input-block'}>
+          {emailInputs}
           <EmailInput
             invalidHint={invalidHint}
             isValid={confirmValidity}
             placeholder={placeholder}
             onChange={::this.compareEmails}
           />
-        )}
-      </div>
-    );
+        </div>
+      );
+    }
+
+    return emailInputs;
   }
 }
 

--- a/src/field/email/email_pane.jsx
+++ b/src/field/email/email_pane.jsx
@@ -24,11 +24,6 @@ export default class EmailPane extends React.Component {
     swap(updateEntity, 'lock', l.id(lock), setEmail, e.target.value);
   }
 
-  validateEmails(e) {
-    this.confirmedValid = e.target.value === this.refs.mainEmailInput.props.value;
-    console.log(this.confirmedValid);
-  }
-
   render() {
     const { i18n, lock, placeholder, forceInvalidVisibility = false } = this.props;
     const allowAutocomplete = l.ui.allowAutocomplete(lock);
@@ -50,7 +45,6 @@ export default class EmailPane extends React.Component {
           onChange={::this.handleChange}
           placeholder={placeholder}
           autoComplete={allowAutocomplete}
-          ref="mainEmailInput"
         />
         {l.confirmEmailInput(lock) && (
           <EmailInput

--- a/src/field/email/email_pane.jsx
+++ b/src/field/email/email_pane.jsx
@@ -51,7 +51,6 @@ export default class EmailPane extends React.Component {
             invalidHint={invalidHint}
             isValid={isValid}
             placeholder={placeholder}
-            onChange={::this.validateEmails}
             // confirmedValid={this.confirmedValid}
           />
         )}

--- a/src/field/email/email_pane.jsx
+++ b/src/field/email/email_pane.jsx
@@ -34,7 +34,13 @@ export default class EmailPane extends React.Component {
   }
 
   render() {
-    const { i18n, lock, placeholder, forceInvalidVisibility = false } = this.props;
+    const {
+      i18n,
+      lock,
+      placeholder,
+      forceInvalidVisibility = false,
+      confirmEmailInput
+    } = this.props;
     const allowAutocomplete = l.ui.allowAutocomplete(lock);
 
     const field = c.getField(lock, 'email');
@@ -58,7 +64,7 @@ export default class EmailPane extends React.Component {
       />
     );
 
-    if (l.confirmEmailInput(lock)) {
+    if (confirmEmailInput) {
       emailInputs = (
         <div className={'auth0-lock-input-block'}>
           {emailInputs}

--- a/src/field/email/email_pane.jsx
+++ b/src/field/email/email_pane.jsx
@@ -4,10 +4,12 @@ import EmailInput from '../../ui/input/email_input';
 import * as c from '../index';
 import { swap, updateEntity } from '../../store/index';
 import * as l from '../../core/index';
-import { setEmail } from '../email';
+import { setEmail, setConfirmEmail } from '../email';
 import { debouncedRequestAvatar, requestAvatar } from '../../avatar';
 
 export default class EmailPane extends React.Component {
+  confirmedValid = true;
+
   componentDidMount() {
     const { lock } = this.props;
     if (l.ui.avatar(lock) && c.email(lock)) {
@@ -24,6 +26,12 @@ export default class EmailPane extends React.Component {
     swap(updateEntity, 'lock', l.id(lock), setEmail, e.target.value);
   }
 
+  compareEmails(e) {
+    const { lock } = this.props;
+    swap(updateEntity, 'lock', l.id(lock), setConfirmEmail, e.target.value);
+    this.confirmedValid = e.target.value === this.refs.primaryEmailInput.props.value;
+  }
+
   render() {
     const { i18n, lock, placeholder, forceInvalidVisibility = false } = this.props;
     const allowAutocomplete = l.ui.allowAutocomplete(lock);
@@ -35,6 +43,7 @@ export default class EmailPane extends React.Component {
       field.get('invalidHint') || i18n.str(value ? 'invalidErrorHint' : 'blankErrorHint');
 
     const isValid = (!forceInvalidVisibility || valid) && !c.isFieldVisiblyInvalid(lock, 'email');
+    const confirmValidity = isValid && this.confirmedValid;
 
     return (
       <div>
@@ -45,13 +54,14 @@ export default class EmailPane extends React.Component {
           onChange={::this.handleChange}
           placeholder={placeholder}
           autoComplete={allowAutocomplete}
+          ref="primaryEmailInput"
         />
         {l.confirmEmailInput(lock) && (
           <EmailInput
             invalidHint={invalidHint}
-            isValid={isValid}
+            isValid={confirmValidity}
             placeholder={placeholder}
-            // confirmedValid={this.confirmedValid}
+            onChange={::this.compareEmails}
           />
         )}
       </div>

--- a/src/ui/box/container.jsx
+++ b/src/ui/box/container.jsx
@@ -99,7 +99,7 @@ export default class Container extends React.Component {
 
   handleSubmit(e) {
     e.preventDefault();
-
+    console.log('Submission');
     this.checkConnectionResolver(() => {
       const { submitHandler } = this.props;
       if (submitHandler) {
@@ -287,9 +287,9 @@ export const defaultProps = (Container.defaultProps = {
   isMobile: false,
   isSubmitting: false,
   language: 'en',
-  logo: `${
-    isFileProtocol ? 'https:' : ''
-  }//cdn.auth0.com/styleguide/components/1.0.8/media/logos/img/badge.png`,
+  logo: `${isFileProtocol
+    ? 'https:'
+    : ''}//cdn.auth0.com/styleguide/components/1.0.8/media/logos/img/badge.png`,
   primaryColor: '#ea5323',
   showBadge: true,
   scrollGlobalMessagesIntoView: true

--- a/src/ui/box/container.jsx
+++ b/src/ui/box/container.jsx
@@ -99,7 +99,6 @@ export default class Container extends React.Component {
 
   handleSubmit(e) {
     e.preventDefault();
-    console.log('Submission');
     this.checkConnectionResolver(() => {
       const { submitHandler } = this.props;
       if (submitHandler) {

--- a/support/index.html
+++ b/support/index.html
@@ -126,13 +126,13 @@
     };
     function initLock() {
       var lock = new Auth0Lock(clientId, domain, defaultOptions);
-      window.localStorage.lastUsed = 'lock'
+      window.localStorage.lastUsed = 'lock';
       subscribeToEvents(lock);
       return lock;
     }
     function initPasswordless() {
       var lockPasswordless = new Auth0LockPasswordless(clientId, domain, defaultOptions);
-      window.localStorage.lastUsed = 'passwordless'
+      window.localStorage.lastUsed = 'passwordless';
       subscribeToEvents(lockPasswordless);
       return lockPasswordless;
     }

--- a/support/index.html
+++ b/support/index.html
@@ -120,7 +120,9 @@
         email: 'johnfoo@gmail.com'
       },
       passwordlessMethod: 'code',
-      allowedConnections: ['email', 'acme', 'twitter']
+      allowedConnections: ['email', 'acme', 'twitter'],
+      allowLogin: false,
+      confirmEmailInput: true
     };
     function initLock() {
       var lock = new Auth0Lock(clientId, domain, defaultOptions);

--- a/support/index.html
+++ b/support/index.html
@@ -121,7 +121,6 @@
       },
       passwordlessMethod: 'code',
       allowedConnections: ['email', 'acme', 'twitter'],
-      allowLogin: false,
       confirmEmailInput: true
     };
     function initLock() {


### PR DESCRIPTION
This PR is to allow users to repeat their email address when signing up as a way of confirmation/validation. We found that a lot of our users are prone to mis-typing their email addresses and this can take a lot of work to resolve. Our fix for this was to add an `additionalSignUpField` with a custom validator but this was a bit of a hack and needed funky css to change the ordering, so we thought we'd do it the right way. :) 

While the functionality is there in a basic form, we're aware that we need to add some tests and it might need a bit of a tidy. Your thoughts would be very much appreciated. Thanks!