### PR TITLE
Upgrade Auth0.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "zuul-ngrok": "4.0.0"
   },
   "dependencies": {
-    "auth0-js": "^9.7.3",
+    "auth0-js": "^9.8.0",
     "auth0-password-policies": "auth0/auth0-password-policies#v1.0.1",
     "blueimp-md5": "2.3.1",
     "fbjs": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "dependencies": {
     "auth0-js": "^9.8.0",
-    "auth0-password-policies": "auth0/auth0-password-policies#v1.0.1",
+    "auth0-password-policies": "^1.0.1",
     "blueimp-md5": "2.3.1",
     "fbjs": "^0.3.1",
     "immutable": "^3.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,9 +392,9 @@ atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
 
-auth0-js@^9.7.3:
-  version "9.7.3"
-  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.7.3.tgz#5d09a703e3758d50ee95d57d05b7f31271c1c821"
+auth0-js@^9.8.0:
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.8.0.tgz#512a79d27b48ab7535130f67b9cd797eea40468e"
   dependencies:
     base64-js "^1.2.0"
     idtoken-verifier "^1.2.0"
@@ -402,7 +402,7 @@ auth0-js@^9.7.3:
     qs "^6.4.0"
     superagent "^3.8.2"
     url-join "^1.1.0"
-    winchan "^0.2.0"
+    winchan "^0.2.1"
 
 auth0-password-policies@auth0/auth0-password-policies#v1.0.1:
   version "1.0.1"
@@ -8657,9 +8657,9 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.1"
 
-winchan@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/winchan/-/winchan-0.2.0.tgz#3863028e7f974b0da1412f28417ba424972abd94"
+winchan@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/winchan/-/winchan-0.2.1.tgz#19b334e49f7c07c0849f921f405fad87dfc8a1da"
 
 window-size@0.1.0:
   version "0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,9 +404,9 @@ auth0-js@^9.8.0:
     url-join "^1.1.0"
     winchan "^0.2.1"
 
-auth0-password-policies@auth0/auth0-password-policies#v1.0.1:
+auth0-password-policies@^1.0.1:
   version "1.0.1"
-  resolved "https://codeload.github.com/auth0/auth0-password-policies/tar.gz/0b3da9b369b122a8b294d496143abfd33311e6b2"
+  resolved "https://registry.yarnpkg.com/auth0-password-policies/-/auth0-password-policies-1.0.1.tgz#d00420b9bd5ac81d37790b1f5c83e5b8a47e9d12"
   dependencies:
     password-sheriff "^1.1.0"
 


### PR DESCRIPTION
Upgrade to 9.8.0 with the new cookie storage approach: https://github.com/auth0/auth0.js/blob/master/CHANGELOG.md#v980-2018-09-26

Also add a dependency to [auth0-password-policies](http://npm.im/auth0-password-policies) so it fixes a few issues with customers' ci builds (#1475, https://github.com/auth0/auth0-password-policies/issues/1).