### PR TITLE
Add default message for Sign-Up Terms & Privacity Policity

### DIFF
--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -103,7 +103,8 @@ export default {
   signUpTitle: 'Sign Up',
   signUpLabel: 'Sign Up',
   signUpSubmitLabel: 'Sign Up',
-  signUpTerms: '',
+  signUpTerms:
+    'By signing up, you agree to our <a href="https://auth0.com/terms" target="_new">terms of service</a> and <a href="https://auth0.com/privacy" target="_new">privacy policy</a>',
   signUpWithLabel: 'Sign up with %s',
   socialLoginInstructions: '',
   socialSignUpInstructions: '',


### PR DESCRIPTION
Fixes #1482. I am trying to generate the translations but the command is failing with `UnhandledPromiseRejectionWarning: Error: Service Unavailable`, it didn't translated for `ro` and bellow, I will try again later.

On a side note: I have been looking for ways to add customizable address on the message (just like Android) but this would require creating a default config file (for fallbacks) and I am not sure where this should go (maybe `./src/defaultOptions.js`?)