### PR TITLE
[Sustainment] Fixed Reset Password Avatar/Enterprise Issue

### DIFF
--- a/src/__tests__/connection/database/reset_password.test.jsx
+++ b/src/__tests__/connection/database/reset_password.test.jsx
@@ -35,9 +35,11 @@ describe('ResetPasswordScreen', () => {
     }));
   });
   it('isSubmitDisabled returns true when `isEnterpriseDomain` is true', () => {
+    jest.useFakeTimers();
     require('connection/enterprise').isEnterpriseDomain = () => true;
     const screen = getScreen();
     expect(screen.isSubmitDisabled()).toBe(true);
+    jest.runTimersToTime(50);
     expect(require('store/index').swap.mock.calls[0]).toMatchSnapshot();
   });
   it('isSubmitDisabled returns false when `isEnterpriseDomain` is false', () => {

--- a/src/connection/database/reset_password.jsx
+++ b/src/connection/database/reset_password.jsx
@@ -46,13 +46,15 @@ export default class ResetPassword extends Screen {
       databaseUsernameValue(m, { emailFirst: true })
     );
     if (tryingToResetPasswordWithEnterpriseEmail) {
-      swap(
-        updateEntity,
-        'lock',
-        l.id(m),
-        l.setGlobalError,
-        i18n.str(m, ['error', 'forgotPassword', 'enterprise_email'])
-      );
+      setTimeout(() => {
+        swap(
+          updateEntity,
+          'lock',
+          l.id(m),
+          l.setGlobalError,
+          i18n.str(m, ['error', 'forgotPassword', 'enterprise_email'])
+        );
+      }, 50);
     } else {
       swap(updateEntity, 'lock', l.id(m), l.clearGlobalError);
     }


### PR DESCRIPTION
**Description**
When `avatar: null` is specified in the the Lock configuration options, reset password will not display the enterprise error when an enterprise domain is detected. 

![avatar_null](https://user-images.githubusercontent.com/928115/46797655-aafed680-cd47-11e8-9dfb-29e18c8d627a.gif)

**References**
ZD #48775

**Notes**
This is a hot patch, I feel a more complete solution that addresses the root cause that is rapid duplicate calls to the [isSubmitDisabled](https://github.com/auth0/lock/blob/fixed-enterprise-null-avatar/src/connection/database/reset_password.jsx#L43) method should be looked at. Although this requires more in depth platform knowledge.
