### PR TITLE
added a link to intro video justification in the extended description

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 # Lock
 
 [Auth0](https://auth0.com) is an authentication broker that supports both social and enterprise identity providers, including Active Directory, LDAP, Google Apps, and Salesforce.
+Auth0’s Universal Identity Platform for web, mobile and IoT can handle any of them — B2C, B2B, B2E, or a combination.
+Check out your intro video by clicking on the key emoji [:key:](https://fast.wistia.com/embed/iframe/fu7ww3h1yx?autoPlay=true&controlsVisibleOnLoad=true&popover=true&version=v1&videoHeight=360&videoWidth=640)
 
 ## Table of Contents
 1. [Install](#install)


### PR DESCRIPTION
I felt that a link to your into video on your GitHub repo readme page would help out some beginners who stumble upon your repo to understand what the auth0 really does.
added a link in the form of key emoji(to the readme) to the into video so as to keep with the pace of today's world of emoji communication and the key was chosen because for obvious reason(You work on authentication).
feel free to change out the font or wordings and spacing but I think a link to intro video is very useful