### PR TITLE
Handle HTML in the `invalidHint` better

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -1296,7 +1296,7 @@ tabsHeight = 40px
     top 1px
     display inline-table
 
-    span
+    .auth0-lock-error-invalid-hint
       background white
       padding 12px 15px
       display block

--- a/src/ui/input/input_wrap.jsx
+++ b/src/ui/input/input_wrap.jsx
@@ -31,7 +31,7 @@ export default class InputWrap extends React.Component {
     const errorTooltip =
       !isValid && invalidHint ? (
         <div role="alert" id={`auth0-lock-error-msg-${name}`} className="auth0-lock-error-msg">
-          <span>{invalidHint}</span>
+          {invalidHint}
         </div>
       ) : null;
 
@@ -55,7 +55,7 @@ InputWrap.propTypes = {
     PropTypes.arrayOf(PropTypes.element).isRequired
   ]),
   focused: PropTypes.bool,
-  invalidHint: PropTypes.string,
+  invalidHint: PropTypes.node,
   isValid: PropTypes.bool.isRequired,
   name: PropTypes.string.isRequired,
   svg: PropTypes.string

--- a/src/ui/input/input_wrap.jsx
+++ b/src/ui/input/input_wrap.jsx
@@ -55,7 +55,7 @@ InputWrap.propTypes = {
     PropTypes.arrayOf(PropTypes.element).isRequired
   ]),
   focused: PropTypes.bool,
-  invalidHint: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
+  invalidHint: PropTypes.node,
   isValid: PropTypes.bool.isRequired,
   name: PropTypes.string.isRequired,
   svg: PropTypes.string

--- a/src/ui/input/input_wrap.jsx
+++ b/src/ui/input/input_wrap.jsx
@@ -31,11 +31,7 @@ export default class InputWrap extends React.Component {
     const errorTooltip =
       !isValid && invalidHint ? (
         <div role="alert" id={`auth0-lock-error-msg-${name}`} className="auth0-lock-error-msg">
-          {typeof invalidHint === 'string' ? (
-            <span dangerouslySetInnerHTML={{ __html: invalidHint }} />
-          ) : (
-            invalidHint
-          )}
+          <div className="auth0-lock-error-invalid-hint">{invalidHint}</div>
         </div>
       ) : null;
 

--- a/src/ui/input/input_wrap.jsx
+++ b/src/ui/input/input_wrap.jsx
@@ -31,7 +31,11 @@ export default class InputWrap extends React.Component {
     const errorTooltip =
       !isValid && invalidHint ? (
         <div role="alert" id={`auth0-lock-error-msg-${name}`} className="auth0-lock-error-msg">
-          {invalidHint}
+          {typeof invalidHint === 'string' ? (
+            <span dangerouslySetInnerHTML={{ __html: invalidHint }} />
+          ) : (
+            invalidHint
+          )}
         </div>
       ) : null;
 
@@ -55,7 +59,7 @@ InputWrap.propTypes = {
     PropTypes.arrayOf(PropTypes.element).isRequired
   ]),
   focused: PropTypes.bool,
-  invalidHint: PropTypes.node,
+  invalidHint: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   isValid: PropTypes.bool.isRequired,
   name: PropTypes.string.isRequired,
   svg: PropTypes.string


### PR DESCRIPTION
The "hrd.not_matching_email" `invalidHint` is coming into `InputWrap` as HTML, presumably as intended, but the `InputWrap` component is not expecting that. This causes a couple things:

- Locally, it throws an exception, because the PropType of `string` is violated occasionally.
- Because the component is otherwise unaware that HTML might be coming in, the css was written with a generic selector (`span`) to apply box/border styling. This causes double padding if HTML comes in pre-packaged as a span.

This PR gives that component some flexibility to deal with the possibility that fully formed html might be coming in.

It looks like most, if not all, of the `<input>_pane` components could be updated to always pass html to be consistent. `CustomInput` would need some love, too. 💭 

(Before) Double padding around the Hint:
<img width="604" alt="screen shot 2018-10-19 at 11 31 42 am" src="https://user-images.githubusercontent.com/587702/47229086-db242600-d394-11e8-9507-49c82725b5cf.png">

(Before) Exception:
<img width="723" alt="screen shot 2018-10-19 at 11 31 47 am" src="https://user-images.githubusercontent.com/587702/47229100-e414f780-d394-11e8-83f3-38c7611462b5.png">

(After) Consistent padding:
<img width="606" alt="screen shot 2018-10-19 at 11 27 59 am" src="https://user-images.githubusercontent.com/587702/47229120-f2631380-d394-11e8-88de-ba0f7536e6ff.png">

<img width="443" alt="screen shot 2018-10-19 at 11 27 52 am" src="https://user-images.githubusercontent.com/587702/47229153-0f97e200-d395-11e8-8bb7-0bbe9dccea2d.png">



