### PR TITLE
updated lock-cred-pane

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -138,6 +138,7 @@ loadingSize = 30px
     flex-direction: column
     border-radius 6px
     position relative
+    white-space: nowrap
 
     &.horizontal-fade-exit
       .auth0-lock-content, .auth0-lock-terms


### PR DESCRIPTION
### Changes

Minor cosmetic changes.  When logging in with Firefox (tested on latest, 63.0.1), the error tooltips wrap and overlap.  This adds `white-space: nowrap` to the outer lock-cred-pane to prevent the error tooltips from wrapping.

![screen shot 2018-11-08 at 10 06 49 am](https://user-images.githubusercontent.com/4993074/48287941-2a0f2980-e430-11e8-8c9b-849ecfe9d72a.png)

![screen shot 2018-11-13 at 10 41 46 am](https://user-images.githubusercontent.com/4993074/48428524-d1da6f00-e730-11e8-9944-d24be6917717.png)


### References

SF Support Case

### Testing

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] All code quality tools/guidelines have been run/followed
* [X] All relevant assets have been compiled
* [X] All active GitHub checks have passed
