### PR TITLE
Fix `lock is undefined` error in non-redirect scenarios

### DIFF
--- a/src/__tests__/connection/database/__snapshots__/password_reset_confirmation.test.jsx.snap
+++ b/src/__tests__/connection/database/__snapshots__/password_reset_confirmation.test.jsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PasswordResetConfirmation renders correctly 1`] = `
+<div
+  className="auth0-lock-confirmation"
+>
+  <div
+    className="auth0-lock-confirmation-content"
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<svg focusable=\\"false\\" width=\\"56px\\" height=\\"56px\\" viewBox=\\"0 0 52 52\\" version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\" class=\\"checkmark\\"> <circle cx=\\"26\\" cy=\\"26\\" r=\\"25\\" fill=\\"none\\" class=\\"checkmark__circle\\"></circle> <path fill=\\"none\\" d=\\"M14.1 27.2l7.1 7.2 16.7-16.8\\" class=\\"checkmark__check\\"></path> </svg>",
+        }
+      }
+    />
+    <p />
+  </div>
+</div>
+`;

--- a/src/__tests__/connection/database/__snapshots__/signed_up_confirmation.test.jsx.snap
+++ b/src/__tests__/connection/database/__snapshots__/signed_up_confirmation.test.jsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SignedUpConfirmation renders correctly 1`] = `
+<div
+  className="auth0-lock-confirmation"
+>
+  <div
+    className="auth0-lock-confirmation-content"
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<svg focusable=\\"false\\" width=\\"56px\\" height=\\"56px\\" viewBox=\\"0 0 52 52\\" version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\" class=\\"checkmark\\"> <circle cx=\\"26\\" cy=\\"26\\" r=\\"25\\" fill=\\"none\\" class=\\"checkmark__circle\\"></circle> <path fill=\\"none\\" d=\\"M14.1 27.2l7.1 7.2 16.7-16.8\\" class=\\"checkmark__check\\"></path> </svg>",
+        }
+      }
+    />
+    <p />
+  </div>
+</div>
+`;

--- a/src/__tests__/connection/database/password_reset_confirmation.test.jsx
+++ b/src/__tests__/connection/database/password_reset_confirmation.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import I from 'immutable';
+
+import { expectComponent } from 'testUtils';
+
+import PasswordResetConfirmation from '../../../connection/database/password_reset_confirmation';
+
+const lock = I.fromJS({ id: '__lock-id__' });
+
+describe('PasswordResetConfirmation', () => {
+  it('renders correctly', async () => {
+    expectComponent(<PasswordResetConfirmation lock={lock} />).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/connection/database/signed_up_confirmation.test.jsx
+++ b/src/__tests__/connection/database/signed_up_confirmation.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import I from 'immutable';
+
+import { expectComponent } from 'testUtils';
+
+import SignedUpConfirmation from '../../../connection/database/signed_up_confirmation';
+
+const lock = I.fromJS({ id: '__lock-id__' });
+
+describe('SignedUpConfirmation', () => {
+  it('renders correctly', async () => {
+    expectComponent(<SignedUpConfirmation lock={lock} />).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/connection/passwordless/__snapshots__/email_sent_confirmation.test.jsx.snap
+++ b/src/__tests__/connection/passwordless/__snapshots__/email_sent_confirmation.test.jsx.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EmailSentConfirmation renders correctly 1`] = `
+<div
+  className="auth0-lock-confirmation"
+>
+  <span
+    aria-label="back"
+    className="auth0-lock-back-button"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" enable-background=\\"new 0 0 24 24\\" version=\\"1.0\\" viewBox=\\"0 0 24 24\\" xml:space=\\"preserve\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"> <polyline fill=\\"none\\" points=\\"12.5,21 3.5,12 12.5,3 \\" stroke=\\"#000000\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\"></polyline> <line fill=\\"none\\" stroke=\\"#000000\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\" x1=\\"22\\" x2=\\"3.5\\" y1=\\"12\\" y2=\\"12\\"></line> </svg>",
+      }
+    }
+    id="__lock-id__-back-button"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    tabIndex={0}
+  />
+  <div
+    className="auth0-lock-confirmation-content"
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<svg focusable=\\"false\\" width=\\"56px\\" height=\\"56px\\" viewBox=\\"0 0 52 52\\" version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\" class=\\"checkmark\\"> <circle cx=\\"26\\" cy=\\"26\\" r=\\"25\\" fill=\\"none\\" class=\\"checkmark__circle\\"></circle> <path fill=\\"none\\" d=\\"M14.1 27.2l7.1 7.2 16.7-16.8\\" class=\\"checkmark__check\\"></path> </svg>",
+        }
+      }
+    />
+    <p>
+      <span
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": " ",
+          }
+        }
+      />
+    </p>
+    <span>
+      <a
+        className="auth0-lock-resend-link"
+        href="javascript:void(0)"
+        onClick={[Function]}
+      >
+        
+         
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<svg focusable=\\"false\\" height=\\"32px\\" style=\\"enable-background:new 0 0 32 32;\\" version=\\"1.1\\" viewBox=\\"0 0 32 32\\" width=\\"32px\\" xml:space=\\"preserve\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"> <path d=\\"M27.877,19.662c0.385-1.23,0.607-2.531,0.607-3.884c0-7.222-5.83-13.101-13.029-13.194v4.238    c4.863,0.093,8.793,4.071,8.793,8.956c0,0.678-0.088,1.332-0.232,1.966l-3.963-1.966l2.76,8.199l8.197-2.762L27.877,19.662z\\"></path> <path d=\\"M7.752,16.222c0-0.678,0.088-1.332,0.232-1.967l3.963,1.967l-2.76-8.199L0.99,10.785l3.133,1.553    c-0.384,1.23-0.607,2.531-0.607,3.885c0,7.223,5.83,13.1,13.03,13.194v-4.238C11.682,25.086,7.752,21.107,7.752,16.222z\\"></path> </svg>",
+            }
+          }
+        />
+      </a>
+    </span>
+  </div>
+</div>
+`;

--- a/src/__tests__/connection/passwordless/email_sent_confirmation.test.jsx
+++ b/src/__tests__/connection/passwordless/email_sent_confirmation.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import I from 'immutable';
+
+import { expectComponent } from 'testUtils';
+
+import EmailSentConfirmation from '../../../connection/passwordless/email_sent_confirmation';
+
+const lock = I.fromJS({ id: '__lock-id__' });
+
+describe('EmailSentConfirmation', () => {
+  it('renders correctly', async () => {
+    expectComponent(<EmailSentConfirmation lock={lock} />).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/core/__snapshots__/signed_in_confirmation.test.jsx.snap
+++ b/src/__tests__/core/__snapshots__/signed_in_confirmation.test.jsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SignedInConfirmation renders correctly 1`] = `
+<div
+  className="auth0-lock-confirmation"
+>
+  <div
+    className="auth0-lock-confirmation-content"
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<svg focusable=\\"false\\" width=\\"56px\\" height=\\"56px\\" viewBox=\\"0 0 52 52\\" version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\" class=\\"checkmark\\"> <circle cx=\\"26\\" cy=\\"26\\" r=\\"25\\" fill=\\"none\\" class=\\"checkmark__circle\\"></circle> <path fill=\\"none\\" d=\\"M14.1 27.2l7.1 7.2 16.7-16.8\\" class=\\"checkmark__check\\"></path> </svg>",
+        }
+      }
+    />
+    <p />
+  </div>
+</div>
+`;

--- a/src/__tests__/core/signed_in_confirmation.test.jsx
+++ b/src/__tests__/core/signed_in_confirmation.test.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import I from 'immutable';
+
+import { expectComponent } from 'testUtils';
+
+import SignedInConfirmation from '../../core/signed_in_confirmation';
+
+const lock = I.fromJS({ id: '__lock-id__' });
+
+describe('SignedInConfirmation', () => {
+  it('renders correctly', async () => {
+    expectComponent(<SignedInConfirmation lock={lock} />).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/ui/box/__snapshots__/confirmation_pane.test.jsx.snap
+++ b/src/__tests__/ui/box/__snapshots__/confirmation_pane.test.jsx.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfirmationPane renders correctly 1`] = `
+<div
+  className="auth0-lock-confirmation"
+>
+  <span
+    aria-label="close"
+    className="auth0-lock-close-button"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" enable-background=\\"new 0 0 128 128\\" version=\\"1.1\\" viewBox=\\"0 0 128 128\\" xml:space=\\"preserve\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"><g><polygon fill=\\"#373737\\" points=\\"123.5429688,11.59375 116.4765625,4.5185547 64.0019531,56.9306641 11.5595703,4.4882813     4.4882813,11.5595703 56.9272461,63.9970703 4.4570313,116.4052734 11.5244141,123.4814453 63.9985352,71.0683594     116.4423828,123.5117188 123.5126953,116.4414063 71.0732422,64.0019531   \\"></polygon></g></svg>",
+      }
+    }
+    id="__lock-id__-close-button"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    tabIndex={0}
+  />
+  <span
+    aria-label="back"
+    className="auth0-lock-back-button"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" enable-background=\\"new 0 0 24 24\\" version=\\"1.0\\" viewBox=\\"0 0 24 24\\" xml:space=\\"preserve\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"> <polyline fill=\\"none\\" points=\\"12.5,21 3.5,12 12.5,3 \\" stroke=\\"#000000\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\"></polyline> <line fill=\\"none\\" stroke=\\"#000000\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\" x1=\\"22\\" x2=\\"3.5\\" y1=\\"12\\" y2=\\"12\\"></line> </svg>",
+      }
+    }
+    id="__lock-id__-back-button"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    tabIndex={0}
+  />
+  <div
+    className="auth0-lock-confirmation-content"
+  >
+    <span
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": <svg>
+            svg
+          </svg>,
+        }
+      }
+    />
+    <span>
+      test
+    </span>
+  </div>
+</div>
+`;

--- a/src/__tests__/ui/box/confirmation_pane.test.jsx
+++ b/src/__tests__/ui/box/confirmation_pane.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import I from 'immutable';
+
+import { expectComponent } from 'testUtils';
+
+import ConfirmationPane from '../../../ui/box/confirmation_pane';
+
+const defaultProps = {
+  lock: I.fromJS({ id: '__lock-id__' }),
+  backHandler: () => {},
+  closeHandler: () => {},
+  children: <span>test</span>,
+  svg: <svg>svg</svg>
+};
+
+describe('ConfirmationPane', () => {
+  it('renders correctly', async () => {
+    expectComponent(<ConfirmationPane {...defaultProps} />).toMatchSnapshot();
+  });
+});

--- a/src/connection/database/password_reset_confirmation.jsx
+++ b/src/connection/database/password_reset_confirmation.jsx
@@ -16,7 +16,7 @@ export default class PasswordResetConfirmation extends React.Component {
     const closeHandler = l.ui.closable(lock) ? ::this.handleClose : undefined;
 
     return (
-      <SuccessPane closeHandler={closeHandler}>
+      <SuccessPane lock={lock} closeHandler={closeHandler}>
         <p>{i18n.html(this.props.lock, ['success', 'forgotPassword'])}</p>
       </SuccessPane>
     );

--- a/src/connection/database/signed_up_confirmation.jsx
+++ b/src/connection/database/signed_up_confirmation.jsx
@@ -17,7 +17,7 @@ export default class SignedUpConfirmation extends React.Component {
     const closeHandler = l.ui.closable(lock) ? ::this.handleClose : undefined;
 
     return (
-      <SuccessPane closeHandler={closeHandler}>
+      <SuccessPane lock={lock} closeHandler={closeHandler}>
         <p>{i18n.html(lock, ['success', 'signUp'])}</p>
       </SuccessPane>
     );

--- a/src/connection/passwordless/email_sent_confirmation.jsx
+++ b/src/connection/passwordless/email_sent_confirmation.jsx
@@ -75,7 +75,7 @@ export default class EmailSentConfirmation extends React.Component {
     };
 
     return (
-      <SuccessPane backHandler={::this.handleBack} closeHandler={closeHandler}>
+      <SuccessPane lock={lock} backHandler={::this.handleBack} closeHandler={closeHandler}>
         <p>{i18n.html(lock, ['success', 'magicLink'], c.email(lock))}</p>
         <Resend labels={labels} lock={lock} />
       </SuccessPane>

--- a/src/core/signed_in_confirmation.jsx
+++ b/src/core/signed_in_confirmation.jsx
@@ -16,7 +16,7 @@ export default class SignedInConfirmation extends React.Component {
     const closeHandler = l.ui.closable(lock) ? ::this.handleClose : undefined;
 
     return (
-      <SuccessPane closeHandler={closeHandler}>
+      <SuccessPane lock={lock} closeHandler={closeHandler}>
         <p>{i18n.html(lock, ['success', 'logIn'])}</p>
       </SuccessPane>
     );

--- a/src/ui/box/confirmation_pane.jsx
+++ b/src/ui/box/confirmation_pane.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { BackButton, CloseButton } from './button';
 import * as l from '../../core/index';
 
-const ConfirmationPane = ({ backHandler, children, closeHandler, svg }) => (
+const ConfirmationPane = ({ lock, backHandler, children, closeHandler, svg }) => (
   <div className="auth0-lock-confirmation">
     {closeHandler && <CloseButton lockId={l.id(lock)} onClick={closeHandler} />}
     {backHandler && <BackButton lockId={l.id(lock)} onClick={backHandler} />}


### PR DESCRIPTION
fix https://github.com/auth0/lock/issues/1556

### Changes

Passing the lock instance as props so the confirmation pane (only shown when redirect:false) doesn't throw an error.

### References

https://github.com/auth0/lock/issues/1556