### PR TITLE
Fixed missing scroll issue for sign up

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -76,7 +76,7 @@ loadingSize = 30px
   font-family "Avenir Next", Avenir, -apple-system, BlinkMacSystemFont, Roboto, Helvetica, sans-serif
   text-rendering optimizeLegibility
   pointer-events none
-  position fixed
+  position absolute
   bottom 0
   left 0
   width 100%


### PR DESCRIPTION
### Changes

Fixed CSS issue that was affecting firefox, users can't scroll the page on sign up.
This was initially reported by linuxfoundation

### References

Expected behaviour: (Chrome)
![chrome](https://user-images.githubusercontent.com/4001529/50010247-e22b7700-ff86-11e8-8ee7-64bcf76ac060.gif)

Current behaviour: (Firefox)
User can't scroll down in user sign up option.
![firefox](https://user-images.githubusercontent.com/4001529/50010250-e48dd100-ff86-11e8-9d37-3afe292a8956.gif)

### Testing

See screenshots above in order to test it.
