### PR TITLE
Remove fbjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "auth0-js": "^9.8.2",
     "auth0-password-policies": "^1.0.2",
     "blueimp-md5": "2.3.1",
-    "fbjs": "^0.3.1",
     "immutable": "^3.7.3",
     "jsonp": "^0.2.0",
     "password-sheriff": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3800,17 +3800,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.3.2.tgz#033a540595084b5de3509a405d06f1a2a8e5b9fb"
-  integrity sha1-AzpUBZUIS13jUJpAXQbxoqjlufs=
-  dependencies:
-    core-js "^1.0.0"
-    loose-envify "^1.0.0"
-    promise "^7.0.3"
-    ua-parser-js "^0.7.9"
-    whatwg-fetch "^0.9.0"
-
 fbjs@^0.8.16, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
@@ -7906,7 +7895,7 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
   integrity sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=
 
-promise@^7.0.3, promise@^7.1.1:
+promise@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   integrity sha1-SJZUxpJha4qlWwck+oCbt9tJxb8=
@@ -10130,11 +10119,6 @@ whatwg-fetch@>=0.10.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
   integrity sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=
-
-whatwg-fetch@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
-  integrity sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA=
 
 whatwg-url@^4.3.0:
   version "4.5.1"


### PR DESCRIPTION
### Changes

This change removes the dependency on an outdated version of fbjs@0.3.2. React-DOM relies on a newer version of fbjs. Before this change, lock was bundling both those versions, as well as an unused reference to `whatwg-fetch`.

Currently, the following modules still rely on `fbjs/lib/CSSCore`

  - ui/box/multisize_slide.js
  - ui/box.js

As a result, these modules will require CSSCore from whichever version React-DOM is requiring. If this is not acceptable, there are a couple alternatives:
  - Include CSSCore.js inside the lock library. It's very small and unlikely to change.
  - Add the dependency back to fbjs, but to the current version.

### References

This PR closes issue: #1582 

### Testing

This change passes `test:cli  and `test:jest`.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] All code quality tools/guidelines have been run/followed
* [X] All relevant assets have been compiled
* [X] All active GitHub checks have passed
