### PR TITLE
Fix lock center position with scroll across browsers

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -76,7 +76,7 @@ loadingSize = 30px
   font-family "Avenir Next", Avenir, -apple-system, BlinkMacSystemFont, Roboto, Helvetica, sans-serif
   text-rendering optimizeLegibility
   pointer-events none
-  position absolute
+  position fixed
   bottom 0
   left 0
   width 100%
@@ -122,7 +122,8 @@ loadingSize = 30px
     margin 0 auto
     border-radius 5px
     max-height 100vh
-    
+    overflow-x auto
+
     +breakpoint("mobile")
       -webkit-transition -webkit-transform .4s, opacity .3s
       transition transform .4s, opacity .3s


### PR DESCRIPTION
fix #1591 
also revers and fixes #1566

### Changes

- Set position to `fixed` to make sure it's always centered in the screen
- Set overflow-x to `auto` to make sure lock always scrolls when the signup form is bigger than the viewport

### References

#1591 
#1566 



### Fix for #1591 
![fix1](https://user-images.githubusercontent.com/941075/51698628-def9c100-1ff1-11e9-8daf-2d42073d1cc7.gif)


### Fix for #1566 
![fix2](https://user-images.githubusercontent.com/941075/51698812-5d566300-1ff2-11e9-9085-15e82fe4b1b8.gif)
