### PR TITLE
Fix cropped avatar

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -210,11 +210,11 @@ loadingSize = 30px
     left 14px
 
   .auth0-lock-header-avatar
-    height 80px
-    width 80px
+    height 70px
+    width 70px
     display block
     border-radius 100px
-    margin -16px auto 0
+    margin 5px auto 0
     position absolute
     left 0
     right 0


### PR DESCRIPTION
### Changes

Moved the avatar inside the Widget so it doesn't get cropped after the Firefox fix (https://github.com/auth0/lock/pull/1594)

![image](https://user-images.githubusercontent.com/941075/53595199-64d1d480-3b7b-11e9-95c3-c6ef6666359e.png)


