### PR TITLE
Changes german translation of 'sign up' from 'Anmelden' to 'Registrieren;

### DIFF
--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -104,7 +104,7 @@ export default {
   retryLabel: 'Wiederholen',
   sentLabel: 'Gesendet!',
   showPassword: 'Passwort anzeigen',
-  signUpTitle: 'Anmelden',
+  signUpTitle: 'Registrieren',
   signUpLabel: 'Registrieren',
   signUpSubmitLabel: 'Registrieren',
   signUpWithLabel: 'Registrieren mit %s',


### PR DESCRIPTION
'Sign up' in German is 'Registrieren', not 'Anmelden'.