### PR TITLE
Fix layout when using big string for terms

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -1028,7 +1028,6 @@ loadingSize = 30px
     .auth0-lock-terms
       @media screen and (max-width: 480px)
         position absolute
-        bottom -42px
         width 100%
         left 0
         -webkit-box-sizing border-box


### PR DESCRIPTION
### Changes

Fix an UI issue when using a big string in the 'accept terms' area.
### References

### Before
![image](https://user-images.githubusercontent.com/941075/55898316-b74dda00-5b98-11e9-96ca-98c5962d1931.png)

![image](https://user-images.githubusercontent.com/941075/55898295-ab621800-5b98-11e9-96d7-1ba7b57eb266.png)

![image](https://user-images.githubusercontent.com/941075/55898353-c7fe5000-5b98-11e9-9fa6-d33aba2e39f9.png)


## After

![image](https://user-images.githubusercontent.com/941075/55898197-7b1a7980-5b98-11e9-85a5-366017715b80.png)
![image](https://user-images.githubusercontent.com/941075/55898222-88376880-5b98-11e9-8f07-54ba366f1bca.png)
![image](https://user-images.githubusercontent.com/941075/55898238-8cfc1c80-5b98-11e9-8a96-e48f178cf590.png)
![image](https://user-images.githubusercontent.com/941075/55898254-95545780-5b98-11e9-9c07-5d9afb95136c.png)
