### PR TITLE
Remove socialButtonStyle option to use small icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,13 +322,6 @@ var options = {
 - **sso {Boolean}**:  Determines whether Single Sign-On is enabled or not in **Lock**. The Auth0 SSO session will be created regardless of this option if SSO is enabled for your application or tenant.
 - **connectionScopes {Object}**:  Allows you to set scopes to be sent to the oauth2/social connection for authentication.
 
-#### Social options
-
-- **socialButtonStyle {String}**: Determines the size of the buttons for the social providers. Possible values are `"big"` and `"small"`. The default style depends on the connections that are available:
-  - If only social connections are available, it will default to `"big"` when there are 5 connections at most, and default to `"small"` otherwise.
-  - If connections from types other than social are also available, it will default to `"big"` when there are 3 social connections at most, and default to `"small"` otherwise.
-  - Keep in mind that some branding guidelines don’t allow the use of icon by itself to represent sign in. If you want to be compliant with those guidelines, make sure you pick the right style for your application.
-
 #### Database options
 
 - **additionalSignUpFields {Array}**: Allows you to provide extra input fields during sign up. See [below](#additional-sign-up-fields) more for details. Defaults to `[]`.

--- a/src/__tests__/__snapshots__/auth_button.test.jsx.snap
+++ b/src/__tests__/__snapshots__/auth_button.test.jsx.snap
@@ -22,28 +22,6 @@ exports[`AuthButton renders correctly 1`] = `
 </button>
 `;
 
-exports[`AuthButton renders when \`big\` is false 1`] = `
-<button
-  className="auth0-lock-social-button"
-  data-provider="strategy"
-  disabled={false}
-  onClick={[Function]}
-  style={Object {}}
-  type="button"
->
-  <div
-    className="auth0-lock-social-button-icon"
-    style={Object {}}
-  />
-  <div
-    className="auth0-lock-social-button-text"
-    style={Object {}}
-  >
-    label
-  </div>
-</button>
-`;
-
 exports[`AuthButton renders with style customizations 1`] = `
 <button
   className="auth0-lock-social-button auth0-lock-social-big-button"

--- a/src/__tests__/auth_button.test.jsx
+++ b/src/__tests__/auth_button.test.jsx
@@ -24,9 +24,6 @@ describe('AuthButton', () => {
       />
     ).toMatchSnapshot();
   });
-  it('renders when `big` is false', () => {
-    expectComponent(<AuthButton {...defaultProps} isBig={false} />).toMatchSnapshot();
-  });
   it('should trigger onClick when clicked', () => {
     const wrapper = mount(<AuthButton {...defaultProps} />);
     wrapper.find('button').simulate('click');

--- a/src/__tests__/engine/classic/__snapshots__/login.test.jsx.snap
+++ b/src/__tests__/engine/classic/__snapshots__/login.test.jsx.snap
@@ -172,7 +172,6 @@ exports[`LoginScreen renders SocialButtonsPane when has social connections 1`] =
   <div>
     <div
       data-__type="social_buttons_pane"
-      data-bigButtons={false}
       data-instructions="socialLoginInstructions"
       data-labelFn={[Function]}
       data-lock="model"

--- a/src/__tests__/engine/classic/__snapshots__/sign_up_screen.test.jsx.snap
+++ b/src/__tests__/engine/classic/__snapshots__/sign_up_screen.test.jsx.snap
@@ -5,7 +5,6 @@ exports[`SignUpScreen disables SocialButtonsPane when terms were not accepted 1`
   <div>
     <div
       data-__type="social_buttons_pane"
-      data-bigButtons={false}
       data-disabled={true}
       data-instructions="socialSignUpInstructions"
       data-labelFn={[Function]}
@@ -92,7 +91,6 @@ exports[`SignUpScreen renders SocialButtonsPane when has social connections 1`] 
   <div>
     <div
       data-__type="social_buttons_pane"
-      data-bigButtons={false}
       data-disabled={false}
       data-instructions="socialSignUpInstructions"
       data-labelFn={[Function]}

--- a/src/__tests__/engine/classic/login.test.jsx
+++ b/src/__tests__/engine/classic/login.test.jsx
@@ -50,8 +50,7 @@ describe('LoginScreen', () => {
 
     jest.mock('engine/classic', () => ({
       hasOnlyClassicConnections: () => false,
-      isSSOEnabled: () => false,
-      useBigSocialButtons: () => false
+      isSSOEnabled: () => false
     }));
 
     jest.mock('i18n', () => ({ str: (_, keys) => keys.join(',') }));

--- a/src/__tests__/engine/classic/sign_up_screen.test.jsx
+++ b/src/__tests__/engine/classic/sign_up_screen.test.jsx
@@ -45,8 +45,7 @@ describe('SignUpScreen', () => {
       isSSOEnabled: (model, options) => {
         expect(options.emailFirst).toBe(true);
         return false;
-      },
-      useBigSocialButtons: () => false
+      }
     }));
     jest.mock('core/signed_in_confirmation', () => ({
       renderSignedInConfirmation: jest.fn()

--- a/src/__tests__/field/__snapshots__/social_buttons_pane.test.jsx.snap
+++ b/src/__tests__/field/__snapshots__/social_buttons_pane.test.jsx.snap
@@ -32,7 +32,6 @@ exports[`SocialButtonsPane disables social buttons when disabled === true 1`] = 
       data-disabled={true}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
-      data-isBig={false}
       data-label="loginWithLabel,authButtonsTheme-displayName"
       data-onClick={[Function]}
       data-primaryColor="authButtonsTheme-primaryColor"
@@ -43,40 +42,6 @@ exports[`SocialButtonsPane disables social buttons when disabled === true 1`] = 
       data-disabled={true}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
-      data-isBig={false}
-      data-label="loginWithLabel,authButtonsTheme-displayName"
-      data-onClick={[Function]}
-      data-primaryColor="authButtonsTheme-primaryColor"
-      data-strategy="socialConnections2-strategy"
-    />
-  </div>
-</div>
-`;
-
-exports[`SocialButtonsPane renders big buttons when bigButtons === true 1`] = `
-<div
-  className="auth-lock-social-buttons-pane"
->
-  <div
-    className="auth0-lock-social-buttons-container"
-  >
-    <div
-      data-__type="auth_button"
-      data-disabled={false}
-      data-foregroundColor="authButtonsTheme-foregroundColor"
-      data-icon="authButtonsTheme-icon"
-      data-isBig={true}
-      data-label="loginWithLabel,authButtonsTheme-displayName"
-      data-onClick={[Function]}
-      data-primaryColor="authButtonsTheme-primaryColor"
-      data-strategy="socialConnections1-strategy"
-    />
-    <div
-      data-__type="auth_button"
-      data-disabled={false}
-      data-foregroundColor="authButtonsTheme-foregroundColor"
-      data-icon="authButtonsTheme-icon"
-      data-isBig={true}
       data-label="loginWithLabel,authButtonsTheme-displayName"
       data-onClick={[Function]}
       data-primaryColor="authButtonsTheme-primaryColor"
@@ -98,7 +63,6 @@ exports[`SocialButtonsPane renders correctly 1`] = `
       data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
-      data-isBig={false}
       data-label="loginWithLabel,authButtonsTheme-displayName"
       data-onClick={[Function]}
       data-primaryColor="authButtonsTheme-primaryColor"
@@ -109,7 +73,6 @@ exports[`SocialButtonsPane renders correctly 1`] = `
       data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
-      data-isBig={false}
       data-label="loginWithLabel,authButtonsTheme-displayName"
       data-onClick={[Function]}
       data-primaryColor="authButtonsTheme-primaryColor"
@@ -134,7 +97,6 @@ exports[`SocialButtonsPane shows header when instructions are available 1`] = `
       data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
-      data-isBig={false}
       data-label="loginWithLabel,authButtonsTheme-displayName"
       data-onClick={[Function]}
       data-primaryColor="authButtonsTheme-primaryColor"
@@ -145,7 +107,6 @@ exports[`SocialButtonsPane shows header when instructions are available 1`] = `
       data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
-      data-isBig={false}
       data-label="loginWithLabel,authButtonsTheme-displayName"
       data-onClick={[Function]}
       data-primaryColor="authButtonsTheme-primaryColor"
@@ -167,7 +128,6 @@ exports[`SocialButtonsPane shows loading when showLoading === true 1`] = `
       data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
-      data-isBig={false}
       data-label="loginWithLabel,authButtonsTheme-displayName"
       data-onClick={[Function]}
       data-primaryColor="authButtonsTheme-primaryColor"
@@ -178,7 +138,6 @@ exports[`SocialButtonsPane shows loading when showLoading === true 1`] = `
       data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
-      data-isBig={false}
       data-label="loginWithLabel,authButtonsTheme-displayName"
       data-onClick={[Function]}
       data-primaryColor="authButtonsTheme-primaryColor"

--- a/src/__tests__/field/social_buttons_pane.test.jsx
+++ b/src/__tests__/field/social_buttons_pane.test.jsx
@@ -10,7 +10,6 @@ const getComponent = () => require('field/social/social_buttons_pane').default;
 describe('SocialButtonsPane', () => {
   const defaultProps = {
     lock: {},
-    bigButtons: false,
     labelFn: (...keys) => keys.join(','),
     showLoading: false,
     signUp: false,
@@ -46,10 +45,6 @@ describe('SocialButtonsPane', () => {
   it('renders correctly', () => {
     const SocialButtonsPane = getComponent();
     expectComponent(<SocialButtonsPane {...defaultProps} />).toMatchSnapshot();
-  });
-  it('renders big buttons when bigButtons === true', () => {
-    const SocialButtonsPane = getComponent();
-    expectComponent(<SocialButtonsPane {...defaultProps} bigButtons />).toMatchSnapshot();
   });
   it('disables social buttons when disabled === true', () => {
     const SocialButtonsPane = getComponent();

--- a/src/connection/social/index.js
+++ b/src/connection/social/index.js
@@ -1,6 +1,4 @@
-import Immutable from 'immutable';
 import * as l from '../../core/index';
-import { dataFns } from '../../utils/data_utils';
 
 // TODO: Android version also has "unknonwn-social", "evernote" and
 // "evernote-sandbox""evernote" in the list, considers "google-openid"
@@ -48,29 +46,11 @@ export const STRATEGIES = {
   weibo: '新浪微博'
 };
 
-const { get, tget, initNS } = dataFns(['social']);
-
-export function initSocial(m, options) {
-  return initNS(m, Immutable.fromJS(processSocialOptions(options)));
-}
-
 export function displayName(connection) {
   if (['oauth1', 'oauth2'].indexOf(connection.get('strategy')) !== -1) {
     return connection.get('name');
   }
   return STRATEGIES[connection.get('strategy')];
-}
-
-export function processSocialOptions(options) {
-  const result = {};
-  const { socialButtonStyle } = options;
-
-  // TODO: emit warnings
-  if (['big', 'small'].indexOf(socialButtonStyle) > -1) {
-    result.socialButtonStyle = socialButtonStyle;
-  }
-
-  return result;
 }
 
 export function socialConnections(m) {
@@ -79,9 +59,4 @@ export function socialConnections(m) {
 
 export function authButtonsTheme(m) {
   return l.ui.authButtonsTheme(m);
-}
-
-export function useBigButtons(m, notFoundLimit) {
-  const style = tget(m, 'socialButtonStyle') || get(m, 'socialButtonStyle');
-  return style ? style === 'big' : l.connections(m, 'social').count() <= notFoundLimit;
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -7,12 +7,9 @@ import * as i18n from '../i18n';
 import trim from 'trim';
 import * as gp from '../avatar/gravatar_provider';
 import { dataFns } from '../utils/data_utils';
-import { processSocialOptions } from '../connection/social/index';
 import { clientConnections, hasFreeSubscription } from './client/index';
 
 const { get, init, remove, reset, set, tget, tset, tremove } = dataFns(['core']);
-
-const { tset: tsetSocial } = dataFns(['social']);
 
 export function setup(id, clientID, domain, options, hookRunner, emitEventFn) {
   let m = init(
@@ -157,9 +154,7 @@ export function stopRendering(m) {
 function extractUIOptions(id, options) {
   const closable = options.container
     ? false
-    : undefined === options.closable
-      ? true
-      : !!options.closable;
+    : undefined === options.closable ? true : !!options.closable;
   const theme = options.theme || {};
   const { labeledSubmitButton, hideMainScreenTitle, logo, primaryColor, authButtons } = theme;
 
@@ -577,11 +572,6 @@ export function overrideOptions(m, opts) {
 
   if (opts.allowedConnections) {
     m = tset(m, 'allowedConnections', Immutable.fromJS(opts.allowedConnections));
-  }
-
-  if (opts.socialButtonStyle) {
-    let curated = processSocialOptions(opts);
-    m = tsetSocial(m, 'socialButtonStyle', curated.socialButtonStyle);
   }
 
   if (opts.flashMessage) {

--- a/src/core/sso/last_login_screen.jsx
+++ b/src/core/sso/last_login_screen.jsx
@@ -5,8 +5,7 @@ import { logIn, checkSession, skipQuickAuth } from '../../quick-auth/actions';
 import { lastUsedConnection, lastUsedUsername } from './index';
 import * as l from '../index';
 import { renderSignedInConfirmation } from '../signed_in_confirmation';
-import { STRATEGIES as SOCIAL_STRATEGIES } from '../../connection/social/index';
-import { authButtonsTheme } from '../../connection/social/index';
+import { STRATEGIES as SOCIAL_STRATEGIES, authButtonsTheme } from '../../connection/social/index';
 
 // TODO: handle this from CSS
 function icon(strategy) {

--- a/src/engine/classic.js
+++ b/src/engine/classic.js
@@ -28,7 +28,6 @@ import {
   quickAuthConnection
 } from '../connection/enterprise';
 import { defaultDirectory, defaultDirectoryName } from '../core/tenant';
-import { initSocial, useBigButtons } from '../connection/social/index';
 import { setEmail } from '../field/email';
 import { setUsername } from '../field/username';
 import * as l from '../core/index';
@@ -58,10 +57,6 @@ export function usernameStyle(m) {
 
 export function hasOnlyClassicConnections(m, type = undefined, ...strategies) {
   return l.hasOnlyConnections(m, type, ...strategies) && !l.hasSomeConnections(m, 'passwordless');
-}
-
-export function useBigSocialButtons(m) {
-  return useBigButtons(m, hasOnlyClassicConnections(m, 'social') ? 5 : 3);
 }
 
 function validateAllowedConnections(m) {
@@ -138,7 +133,6 @@ class Classic {
   };
 
   didInitialize(model, options) {
-    model = initSocial(model, options);
     model = initDatabase(model, options);
     model = initEnterprise(model, options);
 

--- a/src/engine/classic/login.jsx
+++ b/src/engine/classic/login.jsx
@@ -23,7 +23,7 @@ import {
   isHRDDomain
 } from '../../connection/enterprise';
 import SingleSignOnNotice from '../../connection/enterprise/single_sign_on_notice';
-import { hasOnlyClassicConnections, isSSOEnabled, useBigSocialButtons } from '../classic';
+import { hasOnlyClassicConnections, isSSOEnabled } from '../classic';
 import * as i18n from '../../i18n';
 
 function shouldRenderTabs(m) {
@@ -49,7 +49,6 @@ const Component = ({ i18n, model }) => {
 
   const social = l.hasSomeConnections(model, 'social') && (
     <SocialButtonsPane
-      bigButtons={useBigSocialButtons(model)}
       instructions={i18n.html('socialLoginInstructions')}
       labelFn={i18n.str}
       lock={model}

--- a/src/engine/classic/sign_up_screen.jsx
+++ b/src/engine/classic/sign_up_screen.jsx
@@ -8,7 +8,7 @@ import {
   termsAccepted
 } from '../../connection/database/index';
 import { signUp, toggleTermsAcceptance } from '../../connection/database/actions';
-import { hasOnlyClassicConnections, isSSOEnabled, useBigSocialButtons } from '../classic';
+import { hasOnlyClassicConnections, isSSOEnabled } from '../classic';
 import { renderSignedInConfirmation } from '../../core/signed_in_confirmation';
 import { renderSignedUpConfirmation } from '../../connection/database/signed_up_confirmation';
 import { renderOptionSelection } from '../../field/index';
@@ -41,7 +41,6 @@ const Component = ({ i18n, model }) => {
 
   const social = l.hasSomeConnections(model, 'social') && (
     <SocialButtonsPane
-      bigButtons={useBigSocialButtons(model)}
       instructions={i18n.html('socialSignUpInstructions')}
       labelFn={i18n.str}
       lock={model}

--- a/src/engine/passwordless.js
+++ b/src/engine/passwordless.js
@@ -11,7 +11,6 @@ import {
   isSendLink,
   passwordlessStarted
 } from '../connection/passwordless/index';
-import { initSocial } from '../connection/social/index';
 import { isDone, isSuccess } from '../sync';
 import * as l from '../core/index';
 import { hasSkippedQuickAuth } from '../quick_auth';
@@ -32,7 +31,6 @@ const setPrefill = m => {
 
 class Passwordless {
   didInitialize(m, opts) {
-    m = initSocial(m, opts);
     m = initPasswordless(m, opts);
 
     return m;

--- a/src/engine/passwordless/social_or_email_login_screen.jsx
+++ b/src/engine/passwordless/social_or_email_login_screen.jsx
@@ -8,20 +8,13 @@ import { toggleTermsAcceptance } from '../../connection/passwordless/actions';
 import { requestPasswordlessEmail } from '../../connection/passwordless/actions';
 import { renderEmailSentConfirmation } from '../../connection/passwordless/email_sent_confirmation';
 import { renderSignedInConfirmation } from '../../core/signed_in_confirmation';
-import { useBigButtons } from '../../connection/social/index';
 import * as l from '../../core/index';
 
 import SignUpTerms from '../../connection/database/sign_up_terms';
 
-const useSocialBigButtons = m => {
-  const limit = l.connections(m, 'passwordless', 'email').count() === 0 ? 5 : 3;
-  return useBigButtons(m, limit);
-};
-
 const Component = ({ i18n, model }) => {
   const social = l.hasSomeConnections(model, 'social') ? (
     <SocialButtonsPane
-      bigButtons={useSocialBigButtons(model)}
       instructions={i18n.html('socialLoginInstructions')}
       labelFn={i18n.str}
       lock={model}

--- a/src/engine/passwordless/social_or_phone_number_login_screen.jsx
+++ b/src/engine/passwordless/social_or_phone_number_login_screen.jsx
@@ -5,7 +5,6 @@ import PhoneNumberPane from '../../field/phone-number/phone_number_pane';
 import SocialButtonsPane from '../../field/social/social_buttons_pane';
 import { renderSignedInConfirmation } from '../../core/signed_in_confirmation';
 import PaneSeparator from '../../core/pane_separator';
-import { useBigButtons } from '../../connection/social/index';
 import * as l from '../../core/index';
 
 import { renderOptionSelection } from '../../field/index';
@@ -13,15 +12,9 @@ import { mustAcceptTerms, termsAccepted } from '../../connection/passwordless/in
 import { toggleTermsAcceptance } from '../../connection/passwordless/actions';
 import SignUpTerms from '../../connection/database/sign_up_terms';
 
-const useSocialBigButtons = m => {
-  const limit = l.connections(m, 'passwordless', 'sms').count() === 0 ? 5 : 3;
-  return useBigButtons(m, limit);
-};
-
 const Component = ({ i18n, model }) => {
   const social = l.hasSomeConnections(model, 'social') ? (
     <SocialButtonsPane
-      bigButtons={useSocialBigButtons(model)}
       instructions={i18n.html('socialLoginInstructions')}
       labelFn={i18n.str}
       lock={model}

--- a/src/field/social/social_buttons_pane.jsx
+++ b/src/field/social/social_buttons_pane.jsx
@@ -15,7 +15,7 @@ export default class SocialButtonsPane extends React.Component {
   render() {
     // TODO: i don't like that it receives the instructions tanslated
     // but it also takes the t fn
-    const { bigButtons, instructions, labelFn, lock, showLoading, signUp, disabled } = this.props;
+    const { instructions, labelFn, lock, showLoading, signUp, disabled } = this.props;
 
     const headerText = instructions || null;
     const header = headerText && <p>{headerText}</p>;
@@ -31,7 +31,6 @@ export default class SocialButtonsPane extends React.Component {
 
       return (
         <AuthButton
-          isBig={bigButtons}
           key={x.get('name')}
           label={labelFn(
             signUp ? 'signUpWithLabel' : 'loginWithLabel',
@@ -64,7 +63,6 @@ export default class SocialButtonsPane extends React.Component {
 }
 
 SocialButtonsPane.propTypes = {
-  bigButtons: PropTypes.bool.isRequired,
   instructions: PropTypes.any,
   labelFn: PropTypes.func.isRequired,
   lock: PropTypes.object.isRequired,

--- a/src/ui/button/auth_button.jsx
+++ b/src/ui/button/auth_button.jsx
@@ -4,15 +4,13 @@ import React from 'react';
 const AuthButton = props => {
   const { disabled, label, onClick, strategy, icon, primaryColor, foregroundColor } = props;
 
-  let className = 'auth0-lock-social-button auth0-lock-social-big-button';
-
   const backgroundStyle = primaryColor ? { backgroundColor: primaryColor } : {};
   const foregroundStyle = foregroundColor ? { color: foregroundColor } : {};
   const iconStyle = icon ? { backgroundImage: `url('${icon}')` } : {};
 
   return (
     <button
-      className={className}
+      className="auth0-lock-social-button auth0-lock-social-big-button"
       data-provider={strategy}
       disabled={disabled}
       onClick={onClick}

--- a/src/ui/button/auth_button.jsx
+++ b/src/ui/button/auth_button.jsx
@@ -2,10 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 const AuthButton = props => {
-  const { disabled, isBig, label, onClick, strategy, icon, primaryColor, foregroundColor } = props;
+  const { disabled, label, onClick, strategy, icon, primaryColor, foregroundColor } = props;
 
-  let className = 'auth0-lock-social-button';
-  if (isBig) className += ' auth0-lock-social-big-button';
+  let className = 'auth0-lock-social-button auth0-lock-social-big-button';
 
   const backgroundStyle = primaryColor ? { backgroundColor: primaryColor } : {};
   const foregroundStyle = foregroundColor ? { color: foregroundColor } : {};
@@ -30,7 +29,6 @@ const AuthButton = props => {
 
 AuthButton.propTypes = {
   disabled: PropTypes.bool.isRequired,
-  isBig: PropTypes.bool.isRequired,
   label: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
   strategy: PropTypes.string.isRequired,
@@ -40,8 +38,7 @@ AuthButton.propTypes = {
 };
 
 AuthButton.defaultProps = {
-  disabled: false,
-  isBig: true
+  disabled: false
 };
 
 export default AuthButton;

--- a/support/design/index.html
+++ b/support/design/index.html
@@ -535,8 +535,7 @@ body {
    allowedConnections: ["facebook", "twitter", "github", "google-oauth2"],
    auth: { redirect: false },
    container: "social-container",
-   rememberLastLogin: false,
-   socialButtonStyle: "big"
+   rememberLastLogin: false
  }).show();
 
  // new Auth0LockPasswordless(cid, domain, {

--- a/support/design/modal.html
+++ b/support/design/modal.html
@@ -127,8 +127,7 @@ addLockPasswordless("sms", {
 addLockClassic("social", {
   allowedConnections: ["facebook", "twitter", "github", "google-oauth2"],
   auth: { redirect: false },
-  rememberLastLogin: false,
-  socialButtonStyle: "big"
+  rememberLastLogin: false
 });
 
 addLockClassic("terms", {

--- a/support/index.html
+++ b/support/index.html
@@ -120,7 +120,6 @@
         email: 'luis@luisrudge.net'
       },
       passwordlessMethod: 'code',
-      allowedConnections: ['email', 'acme', 'google-oauth2', 'contoso-ad'],
       auth: {
         params: {
           nonce: 'foo',

--- a/support/playground/index.html
+++ b/support/playground/index.html
@@ -251,15 +251,6 @@
                           </span>
                         </label>
                       </div>
-
-                      <div class="col-xs-12 col-sm-6 col-md-6 form-group-checkbox">
-                        <input type="checkbox" name="socialBigButtons">
-                        <label class="control-label">Social Big Buttons
-                          <span class="help tip-right" rel="tooltip" data-original-title="Determines the size of the buttons for the social providers specified in the 'socialConnections' option. It defaults to 'true' when the 'socialConnections' option contains at most tree providers, otherwise it defaults to 'false'.">
-                            <i class="fa fa-question-circle">&nbsp;</i>
-                          </span>
-                        </label>
-                      </div>
                     </div>
 
                     <div class="form-group">

--- a/support/playground/index.js
+++ b/support/playground/index.js
@@ -6,22 +6,28 @@ var CONTAINERS = {
 var currentLockContainerSelector;
 var remember;
 
-function bindEvents () {
+function bindEvents() {
   hljs.configure({
     classPrefix: ''
   });
 
-  $('form input, form textarea').on('change keydown keypress keyup mousedown click mouseup', function() {
-    updateShownLock();
-  });
+  $('form input, form textarea').on(
+    'change keydown keypress keyup mousedown click mouseup',
+    function() {
+      updateShownLock();
+    }
+  );
 
   $('form select').on('change', function() {
     updateShownLock();
   });
 
-  $('input[name=container]').on('change keydown keypress keyup mousedown click mouseup', function() {
+  $('input[name=container]').on(
+    'change keydown keypress keyup mousedown click mouseup',
+    function() {
       updateTargetContainer($(this).val());
-  });
+    }
+  );
 
   $('#show-lock').on('click', showLockHandler);
 
@@ -38,7 +44,7 @@ function bindEvents () {
   // a location, ESC will close the selector. So, we use the close button as a
   // flag.
   $('body').on('keydown', function(ev) {
-    if(ev.keyCode === 27 && $('.auth0-lock-opened .auth0-lock-close-button').length) {
+    if (ev.keyCode === 27 && $('.auth0-lock-opened .auth0-lock-close-button').length) {
       showLockHandler();
     }
   });
@@ -51,81 +57,88 @@ function updateShownLock() {
 }
 
 function showLockHandler(ev) {
-    if(ev) {
-      ev.preventDefault();
+  if (ev) {
+    ev.preventDefault();
+  }
+
+  var method = $('[name="method"]').val();
+  var clientID = $('[name="clientID"]').val();
+  var domain = $('[name="domain"]').val();
+
+  try {
+    if ($('.auth0-lock').length) {
+      window.lock.close();
     }
 
-    var method = $('[name="method"]').val();
-    var clientID = $('[name="clientID"]').val();
-    var domain = $('[name="domain"]').val();
+    window.lock = new Auth0LockPasswordless(clientID, domain);
 
-    try {
-      if ($('.auth0-lock').length) {
-        window.lock.close();
-      }
+    var options = getOptions();
 
-      window.lock = new Auth0LockPasswordless(clientID, domain);
+    if (ev) {
+      delete options.container;
+    } else {
+      options.container = 'container';
+    }
 
-      var options = getOptions();
-
-      if (ev) {
-        delete options.container;
-      } else {
-        options.container = "container";
-      }
-
-      // Execute Lock with options
-      lock[method](options, function (err, profile, id_token, access_token, state, refresh_token) {
-        showContainer(CONTAINERS.OUTPUT);
-        $('#output code').removeClass('text-danger');
-        $('#output code').text('');
-
-        if (err) {
-          $('#output code').removeClass('text-danger');
-          $('#output code').text('Lock encountered an error' + (err.description ? ':\n' + err.description : '.'));
-          return;
-        }
-
-        if (method === 'magiclink') {
-          $('#output code').text('Email sent to ' + profile);
-        } else {
-          $('#output code').text('{\n  access_token: "' + access_token + '",\n  id_token: "' + id_token + '"\n}');
-          hljs.highlightBlock(outputContainer.get(0));
-        }
-      });
-
-      setTimeout(function () {
-        remember.except('.auth0-lock-input');
-      }, 0);
-
-
-    } catch (e) {
-      $('#output code').text(e.message);
-      $('#output code').addClass('text-danger');
+    // Execute Lock with options
+    lock[method](options, function(err, profile, id_token, access_token, state, refresh_token) {
       showContainer(CONTAINERS.OUTPUT);
-    }
-}
+      $('#output code').removeClass('text-danger');
+      $('#output code').text('');
 
-function showContainer (container) {
-  switch (container) {
-  case CONTAINERS.CODE: $('#output-tabs a[href="#lock-code-panel"]').tab('show'); break;
-  case CONTAINERS.OUTPUT: $('#output-tabs a[href="#output-panel"]').tab('show'); break;
-  default: break;
+      if (err) {
+        $('#output code').removeClass('text-danger');
+        $('#output code').text(
+          'Lock encountered an error' + (err.description ? ':\n' + err.description : '.')
+        );
+        return;
+      }
+
+      if (method === 'magiclink') {
+        $('#output code').text('Email sent to ' + profile);
+      } else {
+        $('#output code').text(
+          '{\n  access_token: "' + access_token + '",\n  id_token: "' + id_token + '"\n}'
+        );
+        hljs.highlightBlock(outputContainer.get(0));
+      }
+    });
+
+    setTimeout(function() {
+      remember.except('.auth0-lock-input');
+    }, 0);
+  } catch (e) {
+    $('#output code').text(e.message);
+    $('#output code').addClass('text-danger');
+    showContainer(CONTAINERS.OUTPUT);
   }
 }
 
-function updateTargetContainer (selector) {
-  var sanitizedSelector = (selector ? selector.replace("#", "") : '') || 'container';
+function showContainer(container) {
+  switch (container) {
+    case CONTAINERS.CODE:
+      $('#output-tabs a[href="#lock-code-panel"]').tab('show');
+      break;
+    case CONTAINERS.OUTPUT:
+      $('#output-tabs a[href="#output-panel"]').tab('show');
+      break;
+    default:
+      break;
+  }
+}
+
+function updateTargetContainer(selector) {
+  var sanitizedSelector = (selector ? selector.replace('#', '') : '') || 'container';
   $('.lock-container').prop('id', sanitizedSelector);
   currentLockContainerSelector = sanitizedSelector;
 }
 
-function updateLockInitializationCode () {
-   $('#lock-code code').text(getLockInitializationCode());
-   hljs.highlightBlock($('#lock-code code').get(0));
+function updateLockInitializationCode() {
+  $('#lock-code code').text(getLockInitializationCode());
+  hljs.highlightBlock($('#lock-code code').get(0));
 }
 
-function getLockInitializationCode () {
+function getLockInitializationCode() {
   var template = $('#lock-init-template').val();
   var templateValues = {};
 
@@ -137,7 +150,7 @@ function getLockInitializationCode () {
   return Mustache.render(template, templateValues);
 }
 
-function getOptions (container) {
+function getOptions(container) {
   var options = {};
 
   // Strings
@@ -160,35 +173,67 @@ function getOptions (container) {
   options.loginAfterSignUp = !!$('[name="loginAfterSignUp"]:checked').val();
   options.popup = !!$('[name="popup"]:checked').val();
   options.rememberLastLogin = !!$('[name="rememberLastLogin"]:checked').val();
-  options.socialBigButtons = !!$('[name="socialBigButtons"]:checked').val();
 
   // Textareas + parsings
-  try { options.dict = JSON.parse($('[name="dict"]').val()); } catch (e) {}
-  try { options.authParams = JSON.parse($('[name="authParams"]').val() ); } catch (e) {}
-  try { options.popupOptions = JSON.parse($('[name="popupOptions"]').val() ); } catch (e) {}
-  try { options.socialConnections = JSON.parse($('[name="socialConnections"]').val()); } catch (e) {}
+  try {
+    options.dict = JSON.parse($('[name="dict"]').val());
+  } catch (e) {}
+  try {
+    options.authParams = JSON.parse($('[name="authParams"]').val());
+  } catch (e) {}
+  try {
+    options.popupOptions = JSON.parse($('[name="popupOptions"]').val());
+  } catch (e) {}
+  try {
+    options.socialConnections = JSON.parse($('[name="socialConnections"]').val());
+  } catch (e) {}
 
   options = removeDefaultOptions(options);
   return options;
 }
 
 function removeKeys(object, keys, evalFunction) {
-  $.each(keys, function (i, key) {
+  $.each(keys, function(i, key) {
     if (evalFunction(object[key])) {
       delete object[key];
     }
   });
 }
 
-function removeDefaultOptions (options) {
+function removeDefaultOptions(options) {
   // remove keys whit default value true
-  removeKeys(options, ['closable', 'focusInput', 'gravatar', 'loginAfterSignUp', 'rememberLastLogin'], function (value) { return value === true; });
+  removeKeys(
+    options,
+    ['closable', 'focusInput', 'gravatar', 'loginAfterSignUp', 'rememberLastLogin'],
+    function(value) {
+      return value === true;
+    }
+  );
 
   // remove keys whit default value false
-  removeKeys(options, ['autoclose', 'disableWarnings', 'forceJSONP'], function (value) { return value === false; });
+  removeKeys(options, ['autoclose', 'disableWarnings', 'forceJSONP'], function(value) {
+    return value === false;
+  });
 
   // remove keys whit default value empty
-  removeKeys(options, ['container', 'databaseConnection', 'socialConnections', 'dict', 'icon', 'primaryColor', 'authParams', 'callbackURL', 'defaultLocation', 'usernameStyle'], function (value) { return !value; });
+  removeKeys(
+    options,
+    [
+      'container',
+      'databaseConnection',
+      'socialConnections',
+      'dict',
+      'icon',
+      'primaryColor',
+      'authParams',
+      'callbackURL',
+      'defaultLocation',
+      'usernameStyle'
+    ],
+    function(value) {
+      return !value;
+    }
+  );
 
   if (options.defaultLocation && options.defaultLocation.toLowerCase() === 'us') {
     delete options.defaultLocation;
@@ -197,7 +242,7 @@ function removeDefaultOptions (options) {
   return options;
 }
 
-function renderAuthenticationSuccessMessage (authResponse) {
+function renderAuthenticationSuccessMessage(authResponse) {
   var template = $('#authentication-success-template').val();
   var templateValues = {};
 
@@ -213,7 +258,7 @@ function renderAuthenticationSuccessMessage (authResponse) {
   showContainer(CONTAINERS.OUTPUT);
 }
 
-function tryDisplayAuthenticatedFeedback () {
+function tryDisplayAuthenticatedFeedback() {
   var clientID = $('[name="clientID"]').val();
   var domain = $('[name="domain"]').val();
 
@@ -237,13 +282,13 @@ $(function() {
   bindEvents();
   showContainer(CONTAINERS.CODE);
 
-  setTimeout(function () {
+  setTimeout(function() {
     updateLockInitializationCode();
     showLockHandler();
   }, 500);
 
   remember.except('input[name=container]');
-  $("[rel=tooltip]").tooltip({ placement: 'right'});
+  $('[rel=tooltip]').tooltip({ placement: 'right' });
 
   if (window.location.hash) {
     setTimeout(tryDisplayAuthenticatedFeedback, 500);


### PR DESCRIPTION
### Changes

Removes the `socialButtonStyle` option. This will remove the option to use `small` icons.

#### Before (`socialButtonStyle: 'small')`
![image](https://user-images.githubusercontent.com/941075/56612745-7966a200-65eb-11e9-9924-5d6b36a43397.png)


#### After
![image](https://user-images.githubusercontent.com/941075/56612726-6f44a380-65eb-11e9-8f64-1caba78df02b.png)
