### PR TITLE
Fix destroying lock instance

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,7 +7,9 @@ export function observe(key, id, f) {
   subscribe(`${key}-${id}`, (_, oldState, newState) => {
     const m = getEntity(newState, 'lock', id);
     const oldM = getEntity(oldState, 'lock', id);
-    if (m != oldM) f(m);
+    if (m && !m.equals(oldM)) {
+      f(m);
+    }
   });
 }
 


### PR DESCRIPTION
fix #907, https://github.com/auth0/lock/issues/1090, https://github.com/auth0/lock/pull/1091

### Changes

This is a copy of https://github.com/auth0/lock/pull/1091, but I couldn't rebase because the original branch was removed.

This fixes a case where lock couldn't be destroyed `lock.destroy()`.