### PR TITLE
Prevent form submit when password is empty

### DIFF
--- a/src/__tests__/field/password.test.js
+++ b/src/__tests__/field/password.test.js
@@ -8,6 +8,10 @@ describe('field/password', () => {
     passwordField = require('field/password');
   });
   describe('validatePassword()', () => {
+    it(`returns false when there is no password`, () => {
+      const value = passwordField.validatePassword('');
+      expect(value).toBe(false);
+    });
     it(`returns true when there is no policy`, () => {
       const value = passwordField.validatePassword('the-password');
       expect(value).toBe(true);

--- a/src/field/password.js
+++ b/src/field/password.js
@@ -2,6 +2,9 @@ import PasswordPolicy from 'password-sheriff/lib/policy';
 import { setField } from './index';
 
 export function validatePassword(password, policy) {
+  if (!password) {
+    return false;
+  }
   if (!policy) {
     return true;
   }


### PR DESCRIPTION
fix https://github.com/auth0/lock/issues/1282

### Changes

Always set the password to invalid when there's no password