### PR TITLE
Fix password policy when using tenant connections

### DIFF
--- a/src/__tests__/core/__snapshots__/tenant.test.js.snap
+++ b/src/__tests__/core/__snapshots__/tenant.test.js.snap
@@ -8,7 +8,11 @@ Object {
         "allowForgot": true,
         "allowSignup": true,
         "name": "test-connection-database",
-        "passwordPolicy": "none",
+        "passwordPolicy": Object {
+          "length": Object {
+            "minLength": 1,
+          },
+        },
         "requireUsername": false,
         "strategy": "auth0",
         "type": "database",
@@ -32,12 +36,15 @@ Object {
         "allowForgot": false,
         "allowSignup": false,
         "name": "test-connection-database",
-        "passwordPolicy": "test-passwordPolicy",
+        "passwordPolicy": Object {
+          "length": Object {
+            "minLength": 1,
+          },
+        },
         "requireUsername": true,
         "strategy": "auth0",
         "type": "database",
         "validation": Object {
-          "passwordPolicy": "test-passwordPolicy",
           "username": Object {
             "max": 15,
             "min": 1,
@@ -62,12 +69,15 @@ Object {
         "allowForgot": false,
         "allowSignup": false,
         "name": "test-connection-database",
-        "passwordPolicy": "test-passwordPolicy",
+        "passwordPolicy": Object {
+          "length": Object {
+            "minLength": 1,
+          },
+        },
         "requireUsername": true,
         "strategy": "auth0",
         "type": "database",
         "validation": Object {
-          "passwordPolicy": "test-passwordPolicy",
           "username": Object {
             "max": 15,
             "min": 1,
@@ -92,12 +102,15 @@ Object {
         "allowForgot": false,
         "allowSignup": false,
         "name": "test-connection-database",
-        "passwordPolicy": "test-passwordPolicy",
+        "passwordPolicy": Object {
+          "length": Object {
+            "minLength": 1,
+          },
+        },
         "requireUsername": true,
         "strategy": "auth0",
         "type": "database",
         "validation": Object {
-          "passwordPolicy": "test-passwordPolicy",
           "username": Object {
             "max": 5,
             "min": 4,
@@ -122,11 +135,49 @@ Object {
         "allowForgot": true,
         "allowSignup": true,
         "name": "test-connection-database",
-        "passwordPolicy": "none",
+        "passwordPolicy": Object {
+          "length": Object {
+            "minLength": 1,
+          },
+        },
         "requireUsername": false,
         "strategy": "auth0",
         "type": "database",
         "validation": null,
+      },
+    ],
+    "enterprise": Array [],
+    "passwordless": Array [],
+    "social": Array [],
+    "unknown": Array [],
+  },
+  "defaultDirectory": null,
+}
+`;
+
+exports[`initTenant() with database connection maps password policy correctly 1`] = `
+Object {
+  "connections": Object {
+    "database": Array [
+      Object {
+        "allowForgot": false,
+        "allowSignup": false,
+        "name": "test-connection-database",
+        "passwordPolicy": Object {
+          "length": Object {
+            "minLength": 6,
+          },
+        },
+        "requireUsername": true,
+        "strategy": "auth0",
+        "type": "database",
+        "validation": Object {
+          "passwordPolicy": "low",
+          "username": Object {
+            "max": 5,
+            "min": 4,
+          },
+        },
       },
     ],
     "enterprise": Array [],

--- a/src/__tests__/core/tenant.test.js
+++ b/src/__tests__/core/tenant.test.js
@@ -53,7 +53,29 @@ describe('initTenant()', () => {
               requiresUsername: true,
               strategy: 'auth0',
               validation: {
-                passwordPolicy: 'test-passwordPolicy',
+                username: {
+                  min: 4,
+                  max: 5
+                }
+              }
+            }
+          ]
+        }
+      };
+      runTest(initTenant, mockDataFns, client);
+    });
+    it('maps password policy correctly', () => {
+      const client = {
+        connections: {
+          database: [
+            {
+              allowForgot: false,
+              allowSignup: false,
+              name: 'test-connection-database',
+              requiresUsername: true,
+              strategy: 'auth0',
+              validation: {
+                passwordPolicy: 'low', //minLength: 6
                 username: {
                   min: 4,
                   max: 5
@@ -76,7 +98,6 @@ describe('initTenant()', () => {
               requiresUsername: true,
               strategy: 'auth0',
               validation: {
-                passwordPolicy: 'test-passwordPolicy',
                 username: {
                   min: 'foo',
                   max: 'bar'
@@ -99,7 +120,6 @@ describe('initTenant()', () => {
               requiresUsername: true,
               strategy: 'auth0',
               validation: {
-                passwordPolicy: 'test-passwordPolicy',
                 username: {
                   min: 5,
                   max: 4

--- a/src/core/tenant/index.js
+++ b/src/core/tenant/index.js
@@ -1,4 +1,6 @@
 import Immutable, { List, Map } from 'immutable';
+import passwordPolicies from 'auth0-password-policies';
+
 import { dataFns } from '../../utils/data_utils';
 import * as l from '../index';
 
@@ -80,7 +82,7 @@ function formatTenantConnection(connectionType, connection) {
       result.passwordPolicy = connection.validation.passwordPolicy;
     }
 
-    result.passwordPolicy = result.passwordPolicy || 'none';
+    result.passwordPolicy = passwordPolicies[result.passwordPolicy || 'none'];
 
     result.allowSignup =
       typeof connection.allowSignup === 'boolean' ? connection.allowSignup : true;


### PR DESCRIPTION
fix https://github.com/auth0/lock/issues/1612

### Changes

We changed password policies to objects a while ago (policies here https://github.com/auth0/auth0-password-policies), but the tenant connections didn't get the update.

### Testing

* [x] This change adds unit test coverage