### PR TITLE
use --trace when uploading to the cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,15 @@
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",
-  "keywords": ["auth0", "auth", "openid", "authentication", "passwordless", "browser", "jwt"],
+  "keywords": [
+    "auth0",
+    "auth",
+    "openid",
+    "authentication",
+    "passwordless",
+    "browser",
+    "jwt"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/auth0/lock"
@@ -20,16 +28,13 @@
     "precommit": "lint-staged",
     "lint": "eslint --ext .jsx,.js src/",
     "test": "cross-env BABEL_ENV=test zuul -- test/**/*.test.js",
-    "test:browser":
-      "cross-env BABEL_ENV=test zuul --local 8080 --disable-tunnel -- test/**/*.test.js",
-    "test:cli":
-      "cross-env BABEL_ENV=test mochify --extension=.jsx --transform=babelify ./test/setup.js test/**/*.test.js",
-    "test:watch":
-      "cross-env BABEL_ENV=test mochify --watch --extension=.jsx --transform=babelify ./test/setup.js test/**/*.test.js",
+    "test:browser": "cross-env BABEL_ENV=test zuul --local 8080 --disable-tunnel -- test/**/*.test.js",
+    "test:cli": "cross-env BABEL_ENV=test mochify --extension=.jsx --transform=babelify ./test/setup.js test/**/*.test.js",
+    "test:watch": "cross-env BABEL_ENV=test mochify --watch --extension=.jsx --transform=babelify ./test/setup.js test/**/*.test.js",
     "test:jest": "jest --coverage --runInBand",
     "test:jest:watch": "jest --watch --coverage",
     "test:es-check": "es-check es5 'build/*.js'",
-    "publish:cdn": "ccu",
+    "publish:cdn": "ccu --trace",
     "release": "scripts/release.sh",
     "i18n:translate": "grunt dist && node scripts/complete-translations.js"
   },
@@ -45,7 +50,7 @@
     "babel-preset-stage-0": "^6.3.13",
     "babelify": "^7.2.0",
     "bump-version": "^0.5.0",
-    "component-cdn-uploader": "auth0/component-cdn-uploader#v1.3.0",
+    "component-cdn-uploader": "auth0/component-cdn-uploader#v2.2.1",
     "cross-env": "^3.1.4",
     "css-loader": "^0.26.1",
     "dotenv": "^4.0.0",
@@ -111,8 +116,13 @@
     "localPath": "build"
   },
   "jest": {
-    "modulePaths": ["<rootDir>/src/", "<rootDir>/src/__tests__"],
-    "setupFiles": ["<rootDir>/src/__tests__/setup-tests.js"],
+    "modulePaths": [
+      "<rootDir>/src/",
+      "<rootDir>/src/__tests__"
+    ],
+    "setupFiles": [
+      "<rootDir>/src/__tests__/setup-tests.js"
+    ],
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "<rootDir>/test/",
@@ -127,10 +137,18 @@
       "<rootDir>/src/__tests__/testUtils.js",
       "<rootDir>/src/__tests__/setup-tests.js"
     ],
-    "coverageReporters": ["lcov", "text-summary"]
+    "coverageReporters": [
+      "lcov",
+      "text-summary"
+    ]
   },
   "lint-staged": {
-    "*.{js,jsx}": ["npm run lint"],
-    "*.{js,jsx,json}": ["prettier --write --print-width 100 --single-quote", "git add"]
+    "*.{js,jsx}": [
+      "npm run lint"
+    ],
+    "*.{js,jsx,json}": [
+      "prettier --write --print-width 100 --single-quote",
+      "git add"
+    ]
   }
 }


### PR DESCRIPTION
### Description

This will make the logs in our build server to display more information about the cdn upload

(the package was also auto formatted)