### PR TITLE
Fix CDN dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "i18n:translate": "grunt dist && node scripts/complete-translations.js"
   },
   "devDependencies": {
+    "@auth0/component-cdn-uploader": "^2.2.2",
     "babel-core": "^6.17.0",
     "babel-eslint": "^7.2.2",
     "babel-loader": "^6.2.5",
@@ -50,7 +51,6 @@
     "babel-preset-stage-0": "^6.3.13",
     "babelify": "^7.2.0",
     "bump-version": "^0.5.0",
-    "component-cdn-uploader": "auth0/component-cdn-uploader#v2.2.1",
     "cross-env": "^3.1.4",
     "css-loader": "^0.26.1",
     "dotenv": "^8.0.0",
@@ -94,7 +94,6 @@
     "zuul-ngrok": "4.0.0"
   },
   "dependencies": {
-    "@auth0/component-cdn-uploader": "auth0/component-cdn-uploader#v2.2.2",
     "auth0-js": "^9.11.2",
     "auth0-password-policies": "^1.0.2",
     "blueimp-md5": "2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,10 @@
 # yarn lockfile v1
 
 
-"@auth0/component-cdn-uploader@auth0/component-cdn-uploader#v2.2.2":
+"@auth0/component-cdn-uploader@^2.2.2":
   version "2.2.2"
-  resolved "https://codeload.github.com/auth0/component-cdn-uploader/tar.gz/c86a1f043b9f30b3a3407b19b2e6cd9f1ccdc21b"
+  resolved "https://registry.yarnpkg.com/@auth0/component-cdn-uploader/-/component-cdn-uploader-2.2.2.tgz#1370e95c4b17bce845c2d4ea7b12eab2dfb46c67"
+  integrity sha512-6GXasElepXnic/QuJyIZAgG0eSLHzXxo+Nv4yoDgtltCx0BTpX9hSlhxZaI8PUxKb64PeTxJ26z6ZbGqILipSA==
   dependencies:
     "@auth0/s3" "^1.0.0"
     chalk "^1.1.3"
@@ -662,9 +663,9 @@ autoprefixer@^6.3.1:
     postcss-value-parser "^3.2.3"
 
 aws-sdk@^2.346.0:
-  version "2.484.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.484.0.tgz#ec1039f0fae688eb120729ca35f0c686043199df"
-  integrity sha512-zGWbN9okRRSXvJDYXLdPGuSri+w6X7Fp5MxztlkXWsS6GCm7Lya8Iiti1cYa3/S4PgprmScHSCk+sFcwGRLBfw==
+  version "2.496.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.496.0.tgz#073bf36ed868891a656a895bf2c548b2d0bc3588"
+  integrity sha512-6xZ//phdvp7/dUZjOdDsorl+xehhkAgxOMber9vUlMO9ckBOeufIvED7oKF0NvSlfG8laHK4JprXKQvhXqVLqA==
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -2568,20 +2569,6 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
-
-component-cdn-uploader@auth0/component-cdn-uploader#v2.2.1:
-  version "2.2.1"
-  uid db92e90770ec4cd9d59f88db881cfea5c1a5d9af
-  resolved "https://codeload.github.com/auth0/component-cdn-uploader/tar.gz/db92e90770ec4cd9d59f88db881cfea5c1a5d9af"
-  dependencies:
-    "@auth0/s3" "^1.0.0"
-    chalk "^1.1.3"
-    meow "^3.7.0"
-    mime "^2.3.1"
-    request "^2.78.0"
-    rx "^4.1.0"
-    semver "^5.3.0"
-    walk "^2.3.9"
 
 component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.3.0"


### PR DESCRIPTION
fix https://github.com/auth0/lock/issues/1703

### Changes

For some reason, we were using the github version of the lib and this fails in some cases (when the machine doesn't have git installed etc). This PR changes the dependency to load from npm.