### PR TITLE
Warn when `auth.redirectUri` is sent as an option

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -251,7 +251,6 @@ function extractAuthOptions(options) {
     params,
     autoParseHash,
     redirect,
-    redirectUri, //invalid prop. it's only here to show a warning
     redirectUrl,
     responseMode,
     responseType,
@@ -259,7 +258,7 @@ function extractAuthOptions(options) {
     state,
     nonce
   } = options.auth || {};
-  if (redirectUri) {
+  if (options.auth && options.auth.redirectUri) {
     console.warn(
       "You're sending an `auth` option named `redirectUri`. This option will be ignored. Use `redirectUrl` instead."
     );

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -257,8 +257,12 @@ function extractAuthOptions(options) {
     sso,
     state,
     nonce
-  } =
-    options.auth || {};
+  } = options.auth || {};
+  if (options.auth.redirectUri) {
+    console.warn(
+      "You're sending an `auth` option named `redirectUri`. This option will be ignored. Use `redirectUrl` instead."
+    );
+  }
 
   audience = typeof audience === 'string' ? audience : undefined;
   connectionScopes = typeof connectionScopes === 'object' ? connectionScopes : {};

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -251,6 +251,7 @@ function extractAuthOptions(options) {
     params,
     autoParseHash,
     redirect,
+    redirectUri, //invalid prop. it's only here to show a warning
     redirectUrl,
     responseMode,
     responseType,
@@ -258,7 +259,7 @@ function extractAuthOptions(options) {
     state,
     nonce
   } = options.auth || {};
-  if (options.auth.redirectUri) {
+  if (redirectUri) {
     console.warn(
       "You're sending an `auth` option named `redirectUri`. This option will be ignored. Use `redirectUrl` instead."
     );


### PR DESCRIPTION
### Changes

Make sure devs copying/pasting code from auth0.js get a warning because both options have very similar names