### PR TITLE
Map password_expired to password_change_required

### DIFF
--- a/src/__tests__/core/index.test.js
+++ b/src/__tests__/core/index.test.js
@@ -1,6 +1,6 @@
 import Immutable from 'immutable';
 import { dataFns } from '../../utils/data_utils';
-import { clientID, domain } from '../../core/index';
+import { clientID, domain, loginErrorMessage } from '../../core/index';
 import { initI18n } from '../../i18n';
 import { setURL } from '../testUtils';
 
@@ -12,7 +12,8 @@ let mockSet;
 let mockInit;
 
 jest.mock('i18n', () => ({
-  initI18n: jest.fn()
+  initI18n: jest.fn(),
+  html: jest.fn()
 }));
 
 jest.mock('utils/data_utils', () => ({
@@ -90,5 +91,17 @@ describe('setResolvedConnection', () => {
     setResolvedConnection(mockLock, { type: 'database', name: 'bar' });
     expect(mockSet.mock.calls.length).toBe(1);
     expect(Immutable.Map.isMap(mockSet.mock.calls[0][2])).toBe(true);
+  });
+});
+
+describe('loginErrorMessage', () => {
+  it('maps `password_expired` to `password_change_required`', () => {
+    loginErrorMessage(mockLock, { code: 'password_expired' }, 'type');
+
+    expect(require('i18n').html).toHaveBeenCalledWith(mockLock, [
+      'error',
+      'login',
+      'password_change_required'
+    ]);
   });
 });

--- a/src/__tests__/core/index.test.js
+++ b/src/__tests__/core/index.test.js
@@ -13,7 +13,7 @@ let mockInit;
 
 jest.mock('i18n', () => ({
   initI18n: jest.fn(),
-  html: jest.fn()
+  html: (...keys) => keys.join()
 }));
 
 jest.mock('utils/data_utils', () => ({
@@ -96,12 +96,8 @@ describe('setResolvedConnection', () => {
 
 describe('loginErrorMessage', () => {
   it('maps `password_expired` to `password_change_required`', () => {
-    loginErrorMessage(mockLock, { code: 'password_expired' }, 'type');
+    const result = loginErrorMessage(mockLock, { code: 'password_expired' }, 'type');
 
-    expect(require('i18n').html).toHaveBeenCalledWith(mockLock, [
-      'error',
-      'login',
-      'password_change_required'
-    ]);
+    expect(result).toBe([mockLock, 'error', 'login', 'password_change_required'].join());
   });
 });

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -154,7 +154,9 @@ export function stopRendering(m) {
 function extractUIOptions(id, options) {
   const closable = options.container
     ? false
-    : undefined === options.closable ? true : !!options.closable;
+    : undefined === options.closable
+    ? true
+    : !!options.closable;
   const theme = options.theme || {};
   const { labeledSubmitButton, hideMainScreenTitle, logo, primaryColor, authButtons } = theme;
 
@@ -527,6 +529,9 @@ export function loginErrorMessage(m, error, type) {
 
   if (code === 'a0.mfa_invalid_code') {
     code = 'lock.mfa_invalid_code';
+  }
+  if (code === 'password_expired') {
+    code = 'password_change_required';
   }
 
   return (


### PR DESCRIPTION
### Changes

This PRs fixes an error mapping (from `password_expired` to `password_change_required`) in order to provide a better error message for end users.

### References

Fix https://github.com/auth0/lock/issues/1719

### Testing

* [x] This change adds unit test coverage