### PR TITLE
Fix social button interactions when terms have not been accepted

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -181,6 +181,7 @@ loadingSize = 30px
     flex-shrink: 1
     flex-basis: auto;
     -webkit-overflow-scrolling touch;
+    overflow-x: auto;
 
   .auth0-lock-close-button, .auth0-lock-back-button
     -webkit-box-sizing content-box !important

--- a/src/__tests__/__snapshots__/auth_button.test.jsx.snap
+++ b/src/__tests__/__snapshots__/auth_button.test.jsx.snap
@@ -4,7 +4,6 @@ exports[`AuthButton renders correctly 1`] = `
 <button
   className="auth0-lock-social-button auth0-lock-social-big-button"
   data-provider="strategy"
-  disabled={false}
   onClick={[Function]}
   style={Object {}}
   type="button"
@@ -26,7 +25,6 @@ exports[`AuthButton renders with style customizations 1`] = `
 <button
   className="auth0-lock-social-button auth0-lock-social-big-button"
   data-provider="strategy"
-  disabled={false}
   onClick={[Function]}
   style={
     Object {

--- a/src/__tests__/engine/classic/__snapshots__/sign_up_screen.test.jsx.snap
+++ b/src/__tests__/engine/classic/__snapshots__/sign_up_screen.test.jsx.snap
@@ -5,7 +5,6 @@ exports[`SignUpScreen disables SocialButtonsPane when terms were not accepted 1`
   <div>
     <div
       data-__type="social_buttons_pane"
-      data-disabled={true}
       data-instructions="socialSignUpInstructions"
       data-labelFn={[Function]}
       data-lock="model"
@@ -91,7 +90,6 @@ exports[`SignUpScreen renders SocialButtonsPane when has social connections 1`] 
   <div>
     <div
       data-__type="social_buttons_pane"
-      data-disabled={false}
       data-instructions="socialSignUpInstructions"
       data-labelFn={[Function]}
       data-lock="model"

--- a/src/__tests__/field/__snapshots__/social_buttons_pane.test.jsx.snap
+++ b/src/__tests__/field/__snapshots__/social_buttons_pane.test.jsx.snap
@@ -20,35 +20,13 @@ Array [
 ]
 `;
 
-exports[`SocialButtonsPane disables social buttons when disabled === true 1`] = `
-<div
-  className="auth-lock-social-buttons-pane"
->
-  <div
-    className="auth0-lock-social-buttons-container"
-  >
-    <div
-      data-__type="auth_button"
-      data-disabled={true}
-      data-foregroundColor="authButtonsTheme-foregroundColor"
-      data-icon="authButtonsTheme-icon"
-      data-label="loginWithLabel,authButtonsTheme-displayName"
-      data-onClick={[Function]}
-      data-primaryColor="authButtonsTheme-primaryColor"
-      data-strategy="socialConnections1-strategy"
-    />
-    <div
-      data-__type="auth_button"
-      data-disabled={true}
-      data-foregroundColor="authButtonsTheme-foregroundColor"
-      data-icon="authButtonsTheme-icon"
-      data-label="loginWithLabel,authButtonsTheme-displayName"
-      data-onClick={[Function]}
-      data-primaryColor="authButtonsTheme-primaryColor"
-      data-strategy="socialConnections2-strategy"
-    />
-  </div>
-</div>
+exports[`SocialButtonsPane calls signUpError when isSignUp===true and terms were not accepted 1`] = `
+Array [
+  "lock-id-1",
+  Object {
+    "code": "social_signup_needs_terms_acception",
+  },
+]
 `;
 
 exports[`SocialButtonsPane renders correctly 1`] = `
@@ -60,7 +38,6 @@ exports[`SocialButtonsPane renders correctly 1`] = `
   >
     <div
       data-__type="auth_button"
-      data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
       data-label="loginWithLabel,authButtonsTheme-displayName"
@@ -70,7 +47,6 @@ exports[`SocialButtonsPane renders correctly 1`] = `
     />
     <div
       data-__type="auth_button"
-      data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
       data-label="loginWithLabel,authButtonsTheme-displayName"
@@ -94,7 +70,6 @@ exports[`SocialButtonsPane shows header when instructions are available 1`] = `
   >
     <div
       data-__type="auth_button"
-      data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
       data-label="loginWithLabel,authButtonsTheme-displayName"
@@ -104,7 +79,6 @@ exports[`SocialButtonsPane shows header when instructions are available 1`] = `
     />
     <div
       data-__type="auth_button"
-      data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
       data-label="loginWithLabel,authButtonsTheme-displayName"
@@ -125,7 +99,6 @@ exports[`SocialButtonsPane shows loading when showLoading === true 1`] = `
   >
     <div
       data-__type="auth_button"
-      data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
       data-label="loginWithLabel,authButtonsTheme-displayName"
@@ -135,7 +108,6 @@ exports[`SocialButtonsPane shows loading when showLoading === true 1`] = `
     />
     <div
       data-__type="auth_button"
-      data-disabled={false}
       data-foregroundColor="authButtonsTheme-foregroundColor"
       data-icon="authButtonsTheme-icon"
       data-label="loginWithLabel,authButtonsTheme-displayName"

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -129,7 +129,7 @@ function signUpSuccess(id, result, popupHandler) {
   }
 }
 
-function signUpError(id, error) {
+export function signUpError(id, error) {
   const m = read(getEntity, 'lock', id);
 
   const invalidPasswordKeys = {

--- a/src/engine/classic/sign_up_screen.jsx
+++ b/src/engine/classic/sign_up_screen.jsx
@@ -29,15 +29,14 @@ const Component = ({ i18n, model }) => {
   const sso = isSSOEnabled(model, { emailFirst: true }) && hasScreen(model, 'login');
   const ssoNotice = sso && <SingleSignOnNotice>{i18n.str('ssoEnabled')}</SingleSignOnNotice>;
 
-  const tabs = !sso &&
-    hasScreen(model, 'login') && (
-      <LoginSignUpTabs
-        key="loginsignup"
-        lock={model}
-        loginLabel={i18n.str('loginLabel')}
-        signUpLabel={i18n.str('signUpLabel')}
-      />
-    );
+  const tabs = !sso && hasScreen(model, 'login') && (
+    <LoginSignUpTabs
+      key="loginsignup"
+      lock={model}
+      loginLabel={i18n.str('loginLabel')}
+      signUpLabel={i18n.str('signUpLabel')}
+    />
+  );
 
   const social = l.hasSomeConnections(model, 'social') && (
     <SocialButtonsPane
@@ -45,7 +44,6 @@ const Component = ({ i18n, model }) => {
       labelFn={i18n.str}
       lock={model}
       signUp={true}
-      disabled={!termsAccepted(model)}
     />
   );
 

--- a/src/engine/passwordless/social_or_email_login_screen.jsx
+++ b/src/engine/passwordless/social_or_email_login_screen.jsx
@@ -18,8 +18,7 @@ const Component = ({ i18n, model }) => {
       instructions={i18n.html('socialLoginInstructions')}
       labelFn={i18n.str}
       lock={model}
-      signUp={false}
-      disabled={!termsAccepted(model)}
+      signUp={true}
     />
   ) : null;
 

--- a/src/engine/passwordless/social_or_phone_number_login_screen.jsx
+++ b/src/engine/passwordless/social_or_phone_number_login_screen.jsx
@@ -18,8 +18,7 @@ const Component = ({ i18n, model }) => {
       instructions={i18n.html('socialLoginInstructions')}
       labelFn={i18n.str}
       lock={model}
-      signUp={false}
-      disabled={!termsAccepted(model)}
+      signUp={true}
     />
   ) : null;
 

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -44,8 +44,7 @@ export default {
       password_strength_error: 'Password is too weak.',
       user_exists: 'The user already exists.',
       username_exists: 'The username already exists.',
-      social_signup_needs_terms_acception:
-        'Use the checkbox below to indicate that you have read and agree to our terms of service and privacy policy.'
+      social_signup_needs_terms_acception: 'Please agree to the Terms of Service below to continue.'
     }
   },
   success: {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -43,7 +43,9 @@ export default {
       password_no_user_info_error: 'Password is based on user information.',
       password_strength_error: 'Password is too weak.',
       user_exists: 'The user already exists.',
-      username_exists: 'The username already exists.'
+      username_exists: 'The username already exists.',
+      social_signup_needs_terms_acception:
+        'Use the checkbox below to indicate that you have read and agree to our terms of service and privacy policy.'
     }
   },
   success: {

--- a/src/ui/button/auth_button.jsx
+++ b/src/ui/button/auth_button.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 const AuthButton = props => {
-  const { disabled, label, onClick, strategy, icon, primaryColor, foregroundColor } = props;
+  const { label, onClick, strategy, icon, primaryColor, foregroundColor } = props;
 
   const backgroundStyle = primaryColor ? { backgroundColor: primaryColor } : {};
   const foregroundStyle = foregroundColor ? { color: foregroundColor } : {};
@@ -12,7 +12,6 @@ const AuthButton = props => {
     <button
       className="auth0-lock-social-button auth0-lock-social-big-button"
       data-provider={strategy}
-      disabled={disabled}
       onClick={onClick}
       style={backgroundStyle}
       type="button"

--- a/support/index.html
+++ b/support/index.html
@@ -122,6 +122,8 @@
       var clientId = 'BWDP9XS89CJq1w6Nzq7iFOHsTh6ChS2b';
       var domain = 'brucke.auth0.com';
       var defaultOptions = {
+        mustAcceptTerms: true,
+        initialScreen: 'signUp',
         allowShowPassword: true,
         usernameStyle: 'email',
         defaultDatabaseConnection: 'acme',


### PR DESCRIPTION
### Changes

Today, if social providers are enabled, the buttons are greyed out until the user accepts the TOS.The TOS checkbox is presented at the bottom, so it is hardly visible, leaving the end-user wondering if the social login buttons are broken or not working for another reason.

This PR adds an error box when the social button is clicked but the terms haven't been accepted:

![image](https://user-images.githubusercontent.com/941075/65636709-31441500-dfb9-11e9-8709-59ead0fae59d.png)

The final copy can be changed, that's why I haven't translated all the files yet (will have to do before merging).


### References

https://auth0team.atlassian.net/browse/SDK-751
Please note any links that are not publicly accessible.

### Testing

* [x] This change adds unit test coverage