### PR TITLE
Relaxing the email validation

### DIFF
--- a/src/__tests__/field/email.test.js
+++ b/src/__tests__/field/email.test.js
@@ -6,12 +6,14 @@ describe('field/email', () => {
       expect(isEmail('test@test.com')).toBe(true);
       expect(isEmail('test@test.com.br')).toBe(true);
       expect(isEmail('test@移动.移动')).toBe(true);
+      expect(isEmail('test@test.com ')).toBe(true);
+      expect(isEmail(' test@test.com')).toBe(true);
       expect(isEmail(1)).toBe(false);
       expect(isEmail('test@testcom')).toBe(false);
       expect(isEmail('test.test.com')).toBe(false);
     });
-    it('returns false when there is a white space', () => {
-      expect(isEmail('test@test.com ')).toBe(false);
+    it('returns false when there is a white space in the middle of the string', () => {
+      expect(isEmail('test@test. com')).toBe(false);
     });
   });
   describe('emailDomain', () => {

--- a/src/__tests__/field/email.test.js
+++ b/src/__tests__/field/email.test.js
@@ -1,0 +1,27 @@
+import { isEmail, emailDomain } from '../../field/email';
+
+describe('field/email', () => {
+  describe('isEmail', () => {
+    it('validates correctly', () => {
+      expect(isEmail('test@test.com')).toBe(true);
+      expect(isEmail('test@test.com.br')).toBe(true);
+      expect(isEmail('test@移动.移动')).toBe(true);
+      expect(isEmail(1)).toBe(false);
+      expect(isEmail('test@testcom')).toBe(false);
+      expect(isEmail('test.test.com')).toBe(false);
+    });
+    it('returns false when there is a white space', () => {
+      expect(isEmail('test@test.com ')).toBe(false);
+    });
+  });
+  describe('emailDomain', () => {
+    it('extracts email domain correctly', () => {
+      expect(emailDomain('test@test.com')).toBe('test.com');
+      expect(emailDomain('test@test.com.br')).toBe('test.com.br');
+      expect(emailDomain('test@移动.移动')).toBe('移动.移动');
+      expect(emailDomain(1)).toBe('');
+      expect(emailDomain('test@testcom')).toBe('');
+      expect(emailDomain('test.test.com')).toBe('');
+    });
+  });
+});

--- a/src/field/email.js
+++ b/src/field/email.js
@@ -1,3 +1,5 @@
+import trim from 'trim';
+
 import { setField } from './index';
 import { isHRDEmailValid } from '../connection/enterprise';
 import * as i18n from '../i18n';
@@ -7,12 +9,11 @@ export function validateEmail(str) {
 }
 
 export function isEmail(str) {
-  return (
-    typeof str === 'string' &&
-    str.indexOf('@') >= 0 &&
-    str.indexOf('.') >= 0 &&
-    str.indexOf(' ') === -1
-  );
+  if (typeof str !== 'string') {
+    return false;
+  }
+  const trimmed = trim(str);
+  return trimmed.indexOf('@') >= 0 && trimmed.indexOf('.') >= 0 && trimmed.indexOf(' ') === -1;
 }
 
 export function setEmail(m, str) {

--- a/src/field/email.js
+++ b/src/field/email.js
@@ -1,18 +1,18 @@
-import trim from 'trim';
 import { setField } from './index';
-import { endsWith } from '../utils/string_utils';
 import { isHRDEmailValid } from '../connection/enterprise';
 import * as i18n from '../i18n';
-
-const regExp = /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
 export function validateEmail(str) {
   return isEmail(str);
 }
 
 export function isEmail(str) {
-  const result = regExp.exec(trim(str.toLowerCase()));
-  return !!result && result[0] !== null;
+  return (
+    typeof str === 'string' &&
+    str.indexOf('@') >= 0 &&
+    str.indexOf('.') >= 0 &&
+    str.indexOf(' ') === -1
+  );
 }
 
 export function setEmail(m, str) {
@@ -27,8 +27,10 @@ export function setEmail(m, str) {
 }
 
 export function emailDomain(str) {
-  const result = regExp.exec(trim(str.toLowerCase()));
-  return result ? result.slice(-2)[0] : '';
+  if (!isEmail(str)) {
+    return '';
+  }
+  return str.split('@')[1].toLowerCase();
 }
 
 export function emailLocalPart(str) {

--- a/src/ui/input/email_input.jsx
+++ b/src/ui/input/email_input.jsx
@@ -37,7 +37,8 @@ export default class EmailInput extends React.Component {
         <input
           id={`${lockId}-email`}
           ref="input"
-          type="email"
+          type="text"
+          inputMode="email"
           name="email"
           className="auth0-lock-input"
           placeholder="yours@example.com"


### PR DESCRIPTION
### Changes

To better handle unicode values in the domain part, we need to relax the email validation. After some internal discussions, I decided that it's easier to let the server decide if the email is valid or not. This PR only validates that the email:
- is a string
- has a `@`
- has a `.`
- doesn't have a ` ` (white space)

I think this is all that is right amount of balance between the user experience and actual email validation

### References

ESD-2239

### Testing

* [x] This change adds unit test coverage
