### PR TITLE
Add a Lock event 'sso login'

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Lock will emit events during its lifecycle.
 - `signup submit`: emitted when the user clicks on the submit button of the "Sign up" screen.
 - `signup error`: emitted when signup fails. Has the error as an argument.
 - `federated login`: emitted when the user clicks on a social connection button. Has the connection name and the strategy as arguments.
+- `sso login`: emitted when the user clicks on an enterprise SSO connection button. Has the lock ID, connection object, and field name as arguments.
 
 ### show(options)
 

--- a/src/connection/enterprise/actions.js
+++ b/src/connection/enterprise/actions.js
@@ -64,6 +64,11 @@ function logInActiveFlow(id) {
 function logInSSO(id, connection) {
   const m = read(getEntity, 'lock', id);
   const field = databaseLogInWithEmail(m) ? 'email' : 'username';
+  l.emitEvent(m, 'sso login', {
+    lockID: id,
+    connection: connection,
+    field: field
+  });
   coreLogIn(id, [field], {
     connection: connection.get('name'),
     login_hint: getFieldValue(m, field)


### PR DESCRIPTION
### Changes

This extends the existing event emitter pattern with a new event, called `sso login` (casing & spacing follows the existing `federated login` event name for social).

Our current use case for this is to make some adjustments (which have to be pre-login) based on our enterprise clients with their own IdPs logging in by doing our own lookup of the client's configuration.

### References

This will help with a support ticket on my company's account: https://support.auth0.com/tickets/00439926

### Testing

The existing `npm run test:cli` passes. I do not see any unit test cases currently existing for event emitters such as `federated login` so it doesn't appear to be a pattern now. I don't have access to Saucelabs to run the default `npm test`.

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
