### PR TITLE
Reset .auth0-lock-form display to 'initial' for iPhone

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -1348,3 +1348,10 @@ input[type="button"]
 _:-ms-fullscreen, :root .auth0-lock.auth0-lock .auth0-lock-content-wrapper
   flex-basis: auto !important
   max-height: 70vh
+
+// iPhone display fix - https://github.com/auth0/lock/issues/1588
+.auth0-lock-iphone.auth0-lock .auth0-lock-form
+  display: initial;
+
+.auth0-lock-iphone.auth0-lock .auth0-lock-content
+  padding: 20px;


### PR DESCRIPTION

### Changes

Reset the `display` property on `.auth0-lock-form` when on iPhone. Also reset padding on the content element, as `initial` removes this when applied.

This should fix an issue where the form isn't displayed properly when first displayed on the screen, as verified using a sample repo kindly provided by @ajmueller (https://github.com/auth0/lock/issues/1588#issuecomment-537199399).

Fixes #1588 

### References

* #1588
* https://github.com/auth0/lock/issues/1588#issuecomment-537199399

### Testing

Tested using the iPhone simulator running the sample repo provided for this issue.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
