### PR TITLE
Applied overflow style only on mobile views

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -183,6 +183,9 @@ loadingSize = 30px
     -webkit-overflow-scrolling touch;
     overflow-x: auto;
 
+    @media screen and (min-width: 481px)
+      overflow-x: inherit;
+
   .auth0-lock-close-button, .auth0-lock-back-button
     -webkit-box-sizing content-box !important
     -moz-box-sizing content-box !important


### PR DESCRIPTION
### Changes

Ensures that the `overflow-x: auto` style is only applied to mobile views (< 480px). Otherwise, it breaks the password strength popup on desktop views, as the wrapper can hide the top portion of it.

However, the overflow style is needed to fix the "submit" button on mobile views.

**Before**

![image](https://user-images.githubusercontent.com/766403/69818083-f007f580-11f3-11ea-8162-88316312be76.png)

**After**

![image](https://user-images.githubusercontent.com/766403/69817987-b636ef00-11f3-11ea-970d-d7c57049a9ff.png)

### References

Fixes #1756 
Fixes #1705 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [X] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
