### PR TITLE
[SDK-1191] Lock social buttons now render as links instead of buttons

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -488,6 +488,7 @@ loadingSize = 30px
     height 40px
     -webkit-transition background-color .2s ease-in-out
     transition background-color .2s ease-in-out
+    cursor: pointer
 
     &[data-provider^=google]
       .auth0-lock-social-button-icon

--- a/src/__tests__/__snapshots__/auth_button.test.jsx.snap
+++ b/src/__tests__/__snapshots__/auth_button.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AuthButton renders correctly 1`] = `
-<button
+<a
   className="auth0-lock-social-button auth0-lock-social-big-button"
   data-provider="strategy"
   onClick={[Function]}
@@ -18,11 +18,11 @@ exports[`AuthButton renders correctly 1`] = `
   >
     label
   </div>
-</button>
+</a>
 `;
 
 exports[`AuthButton renders with style customizations 1`] = `
-<button
+<a
   className="auth0-lock-social-button auth0-lock-social-big-button"
   data-provider="strategy"
   onClick={[Function]}
@@ -51,5 +51,5 @@ exports[`AuthButton renders with style customizations 1`] = `
   >
     label
   </div>
-</button>
+</a>
 `;

--- a/src/__tests__/auth_button.test.jsx
+++ b/src/__tests__/auth_button.test.jsx
@@ -26,7 +26,7 @@ describe('AuthButton', () => {
   });
   it('should trigger onClick when clicked', () => {
     const wrapper = mount(<AuthButton {...defaultProps} />);
-    wrapper.find('button').simulate('click');
+    wrapper.find('a').simulate('click');
     expect(defaultProps.onClick.mock.calls.length).toBe(1);
   });
 });

--- a/src/ui/button/auth_button.jsx
+++ b/src/ui/button/auth_button.jsx
@@ -9,7 +9,7 @@ const AuthButton = props => {
   const iconStyle = icon ? { backgroundImage: `url('${icon}')` } : {};
 
   return (
-    <button
+    <a
       className="auth0-lock-social-button auth0-lock-social-big-button"
       data-provider={strategy}
       onClick={onClick}
@@ -20,7 +20,7 @@ const AuthButton = props => {
       <div className="auth0-lock-social-button-text" style={foregroundStyle}>
         {label}
       </div>
-    </button>
+    </a>
   );
 };
 


### PR DESCRIPTION
### Changes

Lock social buttons now render as links instead of buttons. This is to fix an issue with LastPass not attaching its buttons to the input boxes on load.

I believe this is a security issue with LastPass (see [security considerations](https://hiddedevries.nl/en/blog/2018-01-13-making-password-managers-play-ball-with-your-login-form) on this doc). It won't initialize the extension on the form fields until some user interaction has happened, because there are button tags within the form (the social buttons). If a site hosting Lock was vulnerable to XSS attacks, they could potentially post login information to a malicious location if LastPass did actually pre-fill those form fields on page load.

Changing these buttons to links (without affecting the styles, other than providing an affordance that was normally provided by the browser) solves the issue.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] All code quality tools/guidelines have been run/followed
* [X] All relevant assets have been compiled
* [X] All active GitHub checks have passed
