### PR TITLE
Fixed handling of sign up errors

### DIFF
--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -145,6 +145,7 @@ export function signUpError(id, error) {
 
   const errorMessage =
     i18n.html(m, ['error', 'signUp', errorKey]) ||
+    i18n.html(m, ['error', 'singUp', error.code]) ||
     i18n.html(m, ['error', 'signUp', 'lock.fallback']);
 
   l.emitEvent(m, 'signup error', error);

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -145,7 +145,7 @@ export function signUpError(id, error) {
 
   const errorMessage =
     i18n.html(m, ['error', 'signUp', errorKey]) ||
-    i18n.html(m, ['error', 'singUp', error.code]) ||
+    i18n.html(m, ['error', 'signUp', error.code]) ||
     i18n.html(m, ['error', 'signUp', 'lock.fallback']);
 
   l.emitEvent(m, 'signup error', error);


### PR DESCRIPTION
### Changes

Updated handling of sign up errors to use the server returned error code before failing over to the fallback.

### References

Fixes issue https://github.com/auth0/lock/issues/603 with sign up error messages only working for password errors, and showing the fallback message for any duplicate user error.

### Testing

Attempt to create a user with a duplicate email/username. The correct error message should be shown rather than the fallback message.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
