### PR TITLE
[CAUTH-277] prevent posting when captcha is required and empty

### DIFF
--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -28,8 +28,9 @@ export function logIn(id, needsMFA = false) {
 
   const fields = [usernameField, 'password'];
 
-  const captcha = c.getFieldValue(m, 'captcha');
-  if (captcha) {
+  const isCaptchaRequired = l.captcha(m) && l.captcha(m).get('required');
+  if (isCaptchaRequired) {
+    const captcha = c.getFieldValue(m, 'captcha');
     params['captcha'] = captcha;
     fields.push('captcha');
   }

--- a/src/field/captcha/captcha_pane.jsx
+++ b/src/field/captcha/captcha_pane.jsx
@@ -34,6 +34,7 @@ const Captcha = ({ lock, i18n, onReload }) => {
       onChange={handleChange}
       onReload={onReload}
       value={value}
+      invalidHint={i18n.str('blankErrorHint')}
     />
   );
 };

--- a/test/captcha.test.js
+++ b/test/captcha.test.js
@@ -39,8 +39,9 @@ describe('captcha', function() {
     it('should require another challenge when clicking the refresh button', function(done) {
       h.clickRefreshCaptchaButton(this.lock);
       setTimeout(() => {
-        expect(h.q(this.lock, '.auth0-lock-captcha-image').style.backgroundImage)
-          .to.equal(`url("${requiredResponse2.image}")`);
+        expect(h.q(this.lock, '.auth0-lock-captcha-image').style.backgroundImage).to.equal(
+          `url("${requiredResponse2.image}")`
+        );
         done();
       }, 200);
     });
@@ -48,6 +49,11 @@ describe('captcha', function() {
     it('should submit the captcha provided by the user', function() {
       h.logInWithEmailPasswordAndCaptcha(this.lock);
       expect(h.wasLoginAttemptedWith({ captcha: 'captchaValue' })).to.be.ok();
+    });
+
+    it('should not submit the form if the captcha is not provided', function() {
+      h.logInWithEmailAndPassword(this.lock);
+      expect(h.wasLoginAttemptedWith({})).to.not.be.ok();
     });
   });
 


### PR DESCRIPTION
### Changes

Do not post the login form when captcha is **required** but is **empty**.

### References

- Jira CAUTH-277

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
