### PR TITLE
Emit authorization_error event on passwordless error

### DIFF
--- a/src/__tests__/connection/passwordless/__snapshots__/passwordless.actions.test.js.snap
+++ b/src/__tests__/connection/passwordless/__snapshots__/passwordless.actions.test.js.snap
@@ -35,7 +35,14 @@ Array [
 ]
 `;
 
-exports[`passwordless actions login() on webApi.passwordlessVerify() callback formats error when there is an error  1`] = `
+exports[`passwordless actions login() on webApi.passwordlessVerify() callback when there is an eror emits the "authorization_error" event 1`] = `
+Array [
+  "model",
+  [Error: foobar],
+]
+`;
+
+exports[`passwordless actions login() on webApi.passwordlessVerify() callback when there is an eror formats the error 1`] = `
 Array [
   "updateEntity",
   "lock",
@@ -45,7 +52,7 @@ Array [
 ]
 `;
 
-exports[`passwordless actions login() on webApi.passwordlessVerify() callback formats error when there is an error  2`] = `
+exports[`passwordless actions login() on webApi.passwordlessVerify() callback when there is an eror formats the error 2`] = `
 Array [
   "updateEntity",
   "lock",

--- a/src/__tests__/connection/passwordless/__snapshots__/passwordless.actions.test.js.snap
+++ b/src/__tests__/connection/passwordless/__snapshots__/passwordless.actions.test.js.snap
@@ -35,14 +35,14 @@ Array [
 ]
 `;
 
-exports[`passwordless actions login() on webApi.passwordlessVerify() callback when there is an eror emits the "authorization_error" event 1`] = `
+exports[`passwordless actions login() on webApi.passwordlessVerify() callback when there is an error emits the "authorization_error" event 1`] = `
 Array [
   "model",
   [Error: foobar],
 ]
 `;
 
-exports[`passwordless actions login() on webApi.passwordlessVerify() callback when there is an eror formats the error 1`] = `
+exports[`passwordless actions login() on webApi.passwordlessVerify() callback when there is an error formats the error 1`] = `
 Array [
   "updateEntity",
   "lock",
@@ -52,7 +52,7 @@ Array [
 ]
 `;
 
-exports[`passwordless actions login() on webApi.passwordlessVerify() callback when there is an eror formats the error 2`] = `
+exports[`passwordless actions login() on webApi.passwordlessVerify() callback when there is an error formats the error 2`] = `
 Array [
   "updateEntity",
   "lock",

--- a/src/__tests__/connection/passwordless/passwordless.actions.test.js
+++ b/src/__tests__/connection/passwordless/passwordless.actions.test.js
@@ -209,7 +209,7 @@ describe('passwordless actions', () => {
     });
 
     describe('on webApi.passwordlessVerify() callback', () => {
-      describe('when there is an eror', () => {
+      describe('when there is an error', () => {
         it('formats the error', () => {
           actions.logIn('id');
 

--- a/src/__tests__/connection/passwordless/passwordless.actions.test.js
+++ b/src/__tests__/connection/passwordless/passwordless.actions.test.js
@@ -1,6 +1,5 @@
 import passwordless from 'connection/passwordless/actions';
 import { expectMockToMatch } from 'testUtils';
-import { emitAuthorizationErrorEvent } from '../../../core';
 
 jest.useFakeTimers();
 

--- a/src/connection/passwordless/actions.js
+++ b/src/connection/passwordless/actions.js
@@ -141,6 +141,7 @@ export function logIn(id) {
       if (error.logToConsole) {
         console.error(error.description);
       }
+      l.emitAuthorizationErrorEvent(m, error);
       return swap(updateEntity, 'lock', id, l.setSubmitting, false, errorMessage);
     } else {
       return logInSuccess(id, result);

--- a/yarn.lock
+++ b/yarn.lock
@@ -609,7 +609,7 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-auth0-js@^9.12.1:
+auth0-js@^9.12.2:
   version "9.12.2"
   resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.12.2.tgz#8227259a94e8a47eecf8d7a630d99669049833a6"
   integrity sha512-0VfPu5UcgkGKQc7Q8KPqgkqqhLgXGsDCro2tde7hHPYK9JEzOyq82v0szUTHWlwQE1VT8K2/qZAsGDf7hFjI7g==


### PR DESCRIPTION
### Changes

With this PR, the `authorization_error` event is now emitted when an error occurs while submitting a code in the passwordless flow.

### References

Originated from an internal service desk ticket.1

### Testing

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
