### PR TITLE
Fix for login button being cut off on some mobile devices

### DIFF
--- a/css/_mixins&keyframes.styl
+++ b/css/_mixins&keyframes.styl
@@ -75,3 +75,11 @@ breakpoint(point, value = 0)
 @-webkit-keyframes rotate
   0%{-webkit-transform: rotate(0deg);}
   100%{-webkit-transform: rotate(360deg);}
+
+/*
+  Calculates container height based on --vh :root property, set using JavaScript.
+  Includes a fallback to 100vh for browsers that don't support custom properties.
+*/
+calculateHeight()
+  height 100vh
+  height calc(var(--vh, 1vh) * 100)

--- a/css/index.styl
+++ b/css/index.styl
@@ -148,7 +148,8 @@ loadingSize = 30px
   .auth0-lock-cred-pane-internal-wrapper
     display: flex
     flex-direction: column
-    height 100vh
+    height 100vh  /* Support browsers where custom properties are not supported */
+    height calc(var(--vh, 1vh) * 100)
     max-height auto
     +breakpoint("mobile")
       max-height: calc(100vh - 40px)
@@ -1048,7 +1049,8 @@ loadingSize = 30px
     .auth0-lock-widget-container
       //mobile view
       @media screen and (max-width: 480px)
-        height 100%
+        height 100vh  /* Support browsers where custom properties are not supported */
+        height calc(var(--vh, 1vh) * 100)
 
     .auth0-lock-cred-pane
       //mobile view

--- a/css/index.styl
+++ b/css/index.styl
@@ -148,8 +148,7 @@ loadingSize = 30px
   .auth0-lock-cred-pane-internal-wrapper
     display: flex
     flex-direction: column
-    height 100vh  /* Support browsers where custom properties are not supported */
-    height calc(var(--vh, 1vh) * 100)
+    calculateHeight()
     max-height auto
     +breakpoint("mobile")
       max-height: calc(100vh - 40px)
@@ -1049,8 +1048,7 @@ loadingSize = 30px
     .auth0-lock-widget-container
       //mobile view
       @media screen and (max-width: 480px)
-        height 100vh  /* Support browsers where custom properties are not supported */
-        height calc(var(--vh, 1vh) * 100)
+        calculateHeight()
 
     .auth0-lock-cred-pane
       //mobile view

--- a/src/core.js
+++ b/src/core.js
@@ -224,3 +224,15 @@ export function injectStyles() {
     style.innerHTML = css;
   }
 }
+
+/**
+ * Calculates the window innerHeight and sets the --vh style property on :root,
+ * which is then taken advantage of by the CSS.
+ * This important as `innerHeight` will take into account any UI chrome on mobile devices, fixing
+ * an issue where the login button is cut off towards the bottom of the screen.
+ * Values are in pixels multiplied by 1% to convert them to vh.
+ */
+export function setWindowHeightStyle() {
+  const vh = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty('--vh', `${vh}px`);
+}

--- a/src/lock.js
+++ b/src/lock.js
@@ -1,10 +1,15 @@
-import Core, { injectStyles, css } from './core';
+import Core, { injectStyles, setWindowHeightStyle } from './core';
 import classic from './engine/classic';
 
 export default class Auth0Lock extends Core {
   constructor(clientID, domain, options) {
     super(clientID, domain, options, classic);
     injectStyles();
+    setWindowHeightStyle();
+
+    window.addEventListener('resize', () => {
+      setWindowHeightStyle();
+    });
   }
 }
 


### PR DESCRIPTION
### Changes

This PR resolves an issue on mobile where the login button was being cut off towards the bottom of the screen. This PR implements the [technique on CSS Tricks](https://css-tricks.com/the-trick-to-viewport-units-on-mobile/) to dynamically calculate the screen height and apply that to a custom variable on `:root` where it can be picked up by the CSS. It uses `100vh` as a fallback for those browsers that do not support custom variables.

See screenshots in comments.

### References

Fixes #1706 
Partial fix for #1783 

### Testing

This has been tested manually on:

* Samsung Galaxy S6 (Chrome, Firefox)
* Samsung Galaxy S9 (Chrome, Firefox)
* Samsung Galaxy Note 8 (Chrome)
* Pixel 1 (Chrome)
* OnePlus 6T
* Chrome Desktop
* Firefox Desktop
* IE11

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [ ] All relevant assets have been compiled
* [ ] All active GitHub checks have passed
