### PR TITLE
[SDK-1300] Added missing translation keys for 6 EU languages

### DIFF
--- a/src/i18n/da.js
+++ b/src/i18n/da.js
@@ -47,7 +47,9 @@ export default {
       password_no_user_info_error: 'Adgangskoden indeholder information om din bruger.',
       password_strength_error: 'Adgangskoden er for svag.',
       user_exists: 'Denne bruger eksisterer allerede.',
-      username_exists: 'Dette brugernavn eksisterer allerede.'
+      username_exists: 'Dette brugernavn eksisterer allerede.',
+      social_signup_needs_terms_acception:
+        'Du accepterer servicevilkårene nedenfor for at fortsætte.'
     }
   },
   success: {
@@ -128,5 +130,7 @@ export default {
   mfaSubmitLabel: 'Log på',
   mfaCodeErrorHint: 'Brug %d tal',
   showPassword: 'Vis adgangskode',
-  signUpTerms: 'Ved at tilmelde dig accepterer du vores servicevilkår og privatlivspolitik.'
+  signUpTerms: 'Ved at tilmelde dig accepterer du vores servicevilkår og privatlivspolitik.',
+  captchaCodeInputPlaceholder: 'Indtast koden vist ovenfor',
+  captchaMathInputPlaceholder: 'Løs formlen vist ovenfor'
 };

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -1,3 +1,6 @@
+// Some of this file has been automatically translated.
+// Feel free to submit a PR if you find a more accurate translation.
+
 export default {
   error: {
     forgotPassword: {
@@ -48,7 +51,8 @@ export default {
       password_no_user_info_error: 'Das Passwort basiert auf Benutzerinformationen.',
       password_strength_error: 'Das Passwort ist zu schwach.',
       user_exists: 'Der Nutzer existiert bereits.',
-      username_exists: 'Der Nutzername wird bereits verwendet.'
+      username_exists: 'Der Nutzername wird bereits verwendet.',
+      social_signup_needs_terms_acception: 'Akzeptieren Sie bitte unsere Nutzungsbedingungen.'
     }
   },
   success: {
@@ -133,5 +137,7 @@ export default {
   mfaSubmitLabel: 'Anmelden',
   mfaCodeErrorHint: 'Verwenden %d Zahlen',
   signUpTerms:
-    'Mit der Anmeldung stimmen Sie unseren Nutzungsbedingungen und Datenschutzbestimmungen zu.'
+    'Mit der Anmeldung stimmen Sie unseren Nutzungsbedingungen und Datenschutzbestimmungen zu.',
+  captchaCodeInputPlaceholder: 'Geben Sie den oben gezeigten Code ein',
+  captchaMathInputPlaceholder: 'Löse die oben gezeigte Formel'
 };

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -52,7 +52,8 @@ export default {
       password_strength_error: 'Das Passwort ist zu schwach.',
       user_exists: 'Der Nutzer existiert bereits.',
       username_exists: 'Der Nutzername wird bereits verwendet.',
-      social_signup_needs_terms_acception: 'Akzeptieren Sie bitte unsere Nutzungsbedingungen.'
+      social_signup_needs_terms_acception:
+        'Bitte stimmen Sie den untenstehenden Nutzungsbedingungen zu, um fortzufahren.'
     }
   },
   success: {
@@ -138,6 +139,6 @@ export default {
   mfaCodeErrorHint: 'Verwenden %d Zahlen',
   signUpTerms:
     'Mit der Anmeldung stimmen Sie unseren Nutzungsbedingungen und Datenschutzbestimmungen zu.',
-  captchaCodeInputPlaceholder: 'Geben Sie den oben gezeigten Code ein',
-  captchaMathInputPlaceholder: 'Löse die oben gezeigte Formel'
+  captchaCodeInputPlaceholder: 'Geben Sie den oben angezeigten Code ein.',
+  captchaMathInputPlaceholder: 'Lösen Sie die oben gezeigte Formel.'
 };

--- a/src/i18n/it.js
+++ b/src/i18n/it.js
@@ -47,7 +47,9 @@ export default {
       password_no_user_info_error: "La password si basa sulle informazioni dell'utente.",
       password_strength_error: 'La password è troppo debole.',
       user_exists: "L'utente esiste già.",
-      username_exists: 'Il nome utente esiste già.'
+      username_exists: 'Il nome utente esiste già.',
+      social_signup_needs_terms_acception:
+        'Si prega di accettare i Termini di servizio di seguito per continuare.'
     }
   },
   success: {
@@ -127,5 +129,7 @@ export default {
   mfaSubmitLabel: 'Accedere',
   mfaCodeErrorHint: 'Usare %d numeri',
   showPassword: 'Mostra password',
-  signUpTerms: "Iscrivendoti, accetti i nostri termini di servizio e l'informativa sulla privacy."
+  signUpTerms: "Iscrivendoti, accetti i nostri termini di servizio e l'informativa sulla privacy.",
+  captchaCodeInputPlaceholder: 'Inserisci il codice mostrato sopra',
+  captchaMathInputPlaceholder: 'Risolvi la formula mostrata sopra'
 };

--- a/src/i18n/nb.js
+++ b/src/i18n/nb.js
@@ -46,7 +46,8 @@ export default {
       password_no_user_info_error: 'Passordet er basert på kjent bruksdata.',
       password_strength_error: 'Passordet er for svakt.',
       user_exists: 'Brukeren finnes fra før.',
-      username_exists: 'Brukernavnet finnes fra før.'
+      username_exists: 'Brukernavnet finnes fra før.',
+      social_signup_needs_terms_acception: 'Vennligst godta vilkårene nedenfor for å fortsette.'
     }
   },
   success: {
@@ -127,5 +128,7 @@ export default {
   forgotPasswordTitle: 'Tilbakestille passordet ditt',
   signUpTitle: 'Logg inn',
   showPassword: 'Vis passord',
-  signUpTerms: 'Ved å registrere deg, godtar du våre vilkår for bruk og personvern.'
+  signUpTerms: 'Ved å registrere deg, godtar du våre vilkår for bruk og personvern.',
+  captchaCodeInputPlaceholder: 'Tast inn koden vist over',
+  captchaMathInputPlaceholder: 'Løs formelen vist ovenfor'
 };

--- a/src/i18n/nl.js
+++ b/src/i18n/nl.js
@@ -49,7 +49,9 @@ export default {
       password_no_user_info_error: 'Wachtwoord is gebaseerd op gebruikers informatie.',
       password_strength_error: 'Wachtwoord is niet sterk genoeg.',
       user_exists: 'Gebruiker bestaat al.',
-      username_exists: 'Gebruikersnaam bestaat al.'
+      username_exists: 'Gebruikersnaam bestaat al.',
+      social_signup_needs_terms_acception:
+        'Ga akkoord met de onderstaande Servicevoorwaarden om door te gaan.'
     }
   },
   success: {
@@ -132,5 +134,7 @@ export default {
   mfaCodeErrorHint: 'Gebruik %d nummers',
   showPassword: 'Laat wachtwoord zien',
   signUpTerms:
-    'Door u aan te melden gaat u akkoord met onze servicevoorwaarden en ons privacybeleid.'
+    'Door u aan te melden gaat u akkoord met onze servicevoorwaarden en ons privacybeleid.',
+  captchaCodeInputPlaceholder: 'Voer de hierboven getoonde code in',
+  captchaMathInputPlaceholder: 'Los de bovenstaande formule op'
 };

--- a/src/i18n/nn.js
+++ b/src/i18n/nn.js
@@ -50,7 +50,8 @@ export default {
       password_no_user_info_error: 'Passordet er basert på kjende bruksdata.',
       password_strength_error: 'Passordet er for svakt.',
       user_exists: 'Denne brukaren eksisterer allereie.',
-      username_exists: 'Dette brukernamnet eksisterer allereie.'
+      username_exists: 'Dette brukernamnet eksisterer allereie.',
+      social_signup_needs_terms_acception: 'Vennligst godta vilkårene nedenfor for å fortsette.'
     }
   },
   success: {
@@ -132,5 +133,7 @@ export default {
   mfaLoginInstructions: 'Ver venleg og tast inn verifiseringskoden som er generert på din mobil',
   mfaSubmitLabel: 'Logg inn',
   mfaCodeErrorHint: 'Bruk %d tall',
-  signUpTerms: 'Ved å registrere deg, godtar du våre vilkår for bruk og personvern.'
+  signUpTerms: 'Ved å registrere deg, godtar du våre vilkår for bruk og personvern.',
+  captchaCodeInputPlaceholder: 'Tast inn koden vist over',
+  captchaMathInputPlaceholder: 'Løs formelen vist ovenfor'
 };

--- a/src/i18n/no.js
+++ b/src/i18n/no.js
@@ -50,7 +50,8 @@ export default {
       password_no_user_info_error: 'Passordet er basert på kjente bruksdata.',
       password_strength_error: 'Passordet er for svakt.',
       user_exists: 'Denne brukeren eksisterer allerede.',
-      username_exists: 'Dette brukernavnet eksisterer allerede.'
+      username_exists: 'Dette brukernavnet eksisterer allerede.',
+      social_signup_needs_terms_acception: 'Vennligst godta vilkårene nedenfor for å fortsette.'
     }
   },
   success: {
@@ -132,5 +133,7 @@ export default {
   mfaLoginInstructions: 'Vennligst tast inn verifiseringskoden som er generert på din mobilenhet',
   mfaSubmitLabel: 'Logg inn',
   mfaCodeErrorHint: 'Bruk %d tall',
-  signUpTerms: 'Ved å registrere deg, godtar du våre vilkår for bruk og personvern.'
+  signUpTerms: 'Ved å registrere deg, godtar du våre vilkår for bruk og personvern.',
+  captchaCodeInputPlaceholder: 'Tast inn koden vist over',
+  captchaMathInputPlaceholder: 'Løs formelen vist ovenfor'
 };

--- a/src/i18n/sv.js
+++ b/src/i18n/sv.js
@@ -46,7 +46,8 @@ export default {
       password_no_user_info_error: 'Lösenordet baseras på personuppgifter.',
       password_strength_error: 'Lösenordet är för svagt.',
       user_exists: 'Användaren finns redan.',
-      username_exists: 'Användarnamnet finns redan.'
+      username_exists: 'Användarnamnet finns redan.',
+      social_signup_needs_terms_acception: 'Godkänn användarvillkoren nedan för att fortsätta.'
     }
   },
   success: {
@@ -126,5 +127,7 @@ export default {
   mfaSubmitLabel: 'Logga in',
   mfaCodeErrorHint: 'Använd %d',
   showPassword: 'Visa lösenord',
-  signUpTerms: 'Genom att anmäla dig godkänner du våra användarvillkor och integritetspolicy.'
+  signUpTerms: 'Genom att anmäla dig godkänner du våra användarvillkor och integritetspolicy.',
+  captchaCodeInputPlaceholder: 'Ange koden som visas ovan',
+  captchaMathInputPlaceholder: 'Lös formeln som visas ovan'
 };


### PR DESCRIPTION
### Changes

This PR adds missing translations for:

* Dutch
* Italian
* Norweigen
* German
* Swedish
* Danish

All of these except for one German translation has been provided by Google Translate.

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
