### PR TITLE
[SDK-1361] Fix missing padding on social buttons

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -596,6 +596,8 @@ loadingSize = 30px
         display block
         overflow hidden
         width 100%
+        padding-left 50px
+        padding-right 15px
         line-height 40px
         text-align left
         text-overflow ellipsis
@@ -605,8 +607,6 @@ loadingSize = 30px
         white-space nowrap
         transition background 0.3s
         -webkit-transition background 0.3s
-        text-align center
-        padding-right 20px    // just enough to balance out the social button (width: 40px)
 
         // Thicken up the font on HDPI devices
         @media (-webkit-min-device-pixel-ratio: 2),


### PR DESCRIPTION
### Changes

This PR:

* Removes `text-center` on the social button text
* Adds left/right padding

This was missing from the previous update to these buttons.

*Preview*

![image](https://user-images.githubusercontent.com/766403/74722359-b104a180-5230-11ea-9e84-25d64dce6dcb.png)


### Testing

Tested manually in the browser.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
