### PR TITLE
Change Sign in with Apple button background to full black

### DIFF
--- a/css/social_icons.styl
+++ b/css/social_icons.styl
@@ -28,7 +28,7 @@
   background-color: #4285f4;
 }
 .auth0-lock-social-button[data-provider^="apple"] {
-  background-color: #333;
+  background-color: #000;
 }
 .auth0-lock-social-button[data-provider^="line"] {
   background-color: #00b900;


### PR DESCRIPTION
### Changes

This is a design change for compliance with Apple's guidelines. While they don't specifically call out that the button has to be full black, there are concerns that something like this might cause an app to fail. This change is precautionary.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
