### PR TITLE
[SDK-1389] Applied appearance styles for Bootstrap in Safari

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -543,6 +543,8 @@ loadingSize = 30px
     -webkit-transition background-color .2s ease-in-out
     transition background-color .2s ease-in-out
     cursor: pointer
+    -webkit-appearance: none !important;
+    appearance: none !important;
 
     &[data-provider^=google]
       .auth0-lock-social-button-text


### PR DESCRIPTION
### Changes

This makes sure the appearance value is set correctly when Bootstrap is included on the Lock template, which sets `appearance: button`. This breaks the UI in Safari, which renders the buttons without a background color.

**Before**

<img width="403" alt="Screenshot 2020-03-03 at 10 14 15" src="https://user-images.githubusercontent.com/766403/75766106-88a09b00-5d38-11ea-8839-a83091e51503.png">

**After**

<img width="382" alt="Screenshot 2020-03-03 at 10 13 43" src="https://user-images.githubusercontent.com/766403/75766120-8cccb880-5d38-11ea-8da4-4d4c6933bbff.png">

### References

This originated from an internal service desk ticket.

### Testing

This was tested manually by including the Bootstrap CSS on the playground template.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
