### PR TITLE
[CAUTH-373] do not autologin the user if captcha is required

### DIFF
--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -112,6 +112,12 @@ function signUpSuccess(id, result, popupHandler) {
   l.emitEvent(lock, 'signup success', result);
 
   if (shouldAutoLogin(lock)) {
+    const isCaptchaRequired = l.captcha(lock) && l.captcha(lock).get('required');
+
+    if (isCaptchaRequired) {
+      return successCaptchaRequired(id);
+    }
+
     swap(updateEntity, 'lock', id, m => m.set('signedUp', true));
 
     // TODO: check options, redirect is missing
@@ -172,6 +178,20 @@ function autoLogInError(id, error) {
     } else {
       return l.setSubmitting(m, false, errorMessage);
     }
+  });
+}
+
+function successCaptchaRequired(id) {
+  swap(updateEntity, 'lock', id, m => {
+    if (!hasScreen(m, 'login')) {
+      return l.setSubmitting(m, false);
+    }
+    // _ prevents cleaning the fields
+    m = l.setSubmitting(setScreen(m, 'login', ['_']), false);
+
+    const message = i18n.str(m, ['error', 'signUp', 'captcha_required']);
+
+    return l.setGlobalSuccess(m, message);
   });
 }
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -552,12 +552,6 @@ export function loginErrorMessage(m, error, type) {
     code = 'password_change_required';
   }
 
-  if (code === 'invalid_captcha') {
-    return captcha(m).get('type') === 'code'
-      ? i18n.html(m, 'captchaCodeInputPlaceholder')
-      : i18n.html(m, 'captchaMathInputPlaceholder');
-  }
-
   return (
     i18n.html(m, ['error', 'login', code]) || i18n.html(m, ['error', 'login', 'lock.fallback'])
   );

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -10,6 +10,7 @@ export default {
     login: {
       blocked_user: 'The user is blocked.',
       invalid_user_password: 'Wrong credentials.',
+      invalid_captcha: 'The text you entered was incorrect. <br /> Please try again.',
       'lock.fallback': "We're sorry, something went wrong when attempting to log in.",
       'lock.invalid_code': 'Wrong code.',
       'lock.invalid_email_password': 'Wrong email or password.',
@@ -38,6 +39,7 @@ export default {
     },
     signUp: {
       invalid_password: 'Password is invalid.',
+      captcha_required: 'Enter the code shown below to finish signing up.',
       'lock.fallback': "We're sorry, something went wrong when attempting to sign up.",
       password_dictionary_error: 'Password is too common.',
       password_no_user_info_error: 'Password is based on user information.',

--- a/src/i18n/es.js
+++ b/src/i18n/es.js
@@ -10,6 +10,7 @@ export default {
     login: {
       blocked_user: 'El usuario se encuentra bloqueado.',
       invalid_user_password: 'Credenciales inválidas.',
+      invalid_captcha: 'El texto ingresado es incorrecto. <br /> Por favor, vuelva a intentarlo.',
       'lock.fallback': 'Ocurrió un error al iniciar sesión.',
       'lock.invalid_code': 'Código inválido.',
       'lock.invalid_email_password': 'Correo y contraseña inválidos.',
@@ -39,6 +40,8 @@ export default {
     },
     signUp: {
       invalid_password: 'La contraseña es inválida.',
+      captcha_required:
+        'Ingrese el código que se muestra a continuación para finalizar el registro.',
       'lock.fallback': 'Ocurrió un error durante el registro.',
       password_dictionary_error: 'La constraseña es muy común.',
       password_no_user_info_error: 'La constraseña es similar a los datos del usuario.',


### PR DESCRIPTION
### Changes

Prevent the autologin of the user if captcha is required for the transaction.

![image](https://user-images.githubusercontent.com/178512/76019388-65c0e300-5f00-11ea-8802-fa43773188fc.png)


### References

https://auth0team.atlassian.net/browse/CAUTH-373

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
