### PR TITLE
Fix typos

### DIFF
--- a/scripts/lang-audit.js
+++ b/scripts/lang-audit.js
@@ -7,7 +7,7 @@ const directory = path_module.join(__dirname, '..', 'src', 'i18n');
 const loader = new NodeESModuleLoader(directory);
 
 /**
- * Flattens an object recursively so that any nested objects are refered to on the root object using
+ * Flattens an object recursively so that any nested objects are referred to on the root object using
  * a key path.
  * e.g. turns:
  * {

--- a/src/engine/passwordless/social_or_email_login_screen.jsx
+++ b/src/engine/passwordless/social_or_email_login_screen.jsx
@@ -26,7 +26,7 @@ const Component = ({ i18n, model }) => {
     <EmailPane i18n={i18n} lock={model} placeholder={i18n.str('emailInputPlaceholder')} />
   ) : null;
 
-  // TODO: instructions can't be on EmailPane beacuse it breaks the CSS,
+  // TODO: instructions can't be on EmailPane because it breaks the CSS,
   // all input fields needs to share a parent so the last one doesn't have
   // a bottom margin.
   //

--- a/support/playground/index.html
+++ b/support/playground/index.html
@@ -377,7 +377,7 @@ lock.{{method}}(options, function (...) {
     </textarea>
 
     <textarea id="authentication-success-template" type="x-tmpl-mustache" style="display:none;">
-// You have successfuly authenticated
+// You have successfully authenticated
 {
   profile: {
     iss: "{{ profile.iss }}",

--- a/test/out-of-date/lock/index.js
+++ b/test/out-of-date/lock/index.js
@@ -115,7 +115,7 @@ describe('rendering a lock', function() {
         renderedLock = l.render(lock, modeName, { container: container });
       });
 
-      it('assings it as the container id', function() {
+      it('assigns it as the container id', function() {
         expect(l.ui.containerID(renderedLock)).to.be(container);
       });
 


### PR DESCRIPTION
Hey,

This tiny PR will fix : 

- 1 typo in `scripts/lang-audit.js`
- 1 typo in `src/engine/passwordless/social_or_email_login_screen.jsx`
- 1 typo in `support/playground/index.html`
- 1 typo in `test/out-of-date/lock/index.js`



Bye! :robot: