### PR TITLE
Fix send sms error event

### DIFF
--- a/src/__tests__/connection/passwordless/__snapshots__/passwordless.actions.test.js.snap
+++ b/src/__tests__/connection/passwordless/__snapshots__/passwordless.actions.test.js.snap
@@ -256,6 +256,13 @@ Array [
 ]
 `;
 
+exports[`passwordless actions sendSMS() normalizes the error message emits the "authorization_error" event 1`] = `
+Array [
+  "model",
+  [Error: foobar],
+]
+`;
+
 exports[`passwordless actions sendSMS() normalizes the error message with a generic error 1`] = `
 Array [
   "getEntity",

--- a/src/__tests__/connection/passwordless/passwordless.actions.test.js
+++ b/src/__tests__/connection/passwordless/passwordless.actions.test.js
@@ -186,6 +186,17 @@ describe('passwordless actions', () => {
         const { read, swap } = require('store/index');
         expectMockToMatch(swap, 1);
       });
+      it('emits the "authorization_error" event', () => {
+        actions.sendSMS('id');
+        require('core/actions').validateAndSubmit.mock.calls[0][2]('model');
+        const error = new Error('foobar');
+        error.error = 'some_error_code';
+        require('core/web_api').startPasswordless.mock.calls[0][2](error);
+
+        jest.runAllTimers();
+
+        expectMockToMatch(require('core/index').emitAuthorizationErrorEvent, 1);
+      });
     });
   });
   describe('login()', () => {

--- a/src/connection/passwordless/actions.js
+++ b/src/connection/passwordless/actions.js
@@ -115,6 +115,7 @@ function sendSMSSuccess(id) {
 function sendSMSError(id, error) {
   const m = read(getEntity, 'lock', id);
   const errorMessage = getErrorMessage(m, error);
+  l.emitAuthorizationErrorEvent(m, error);
   return swap(updateEntity, 'lock', id, l.setSubmitting, false, errorMessage);
 }
 


### PR DESCRIPTION
### Changes

In the. passwordless sms authentication when there is an error in the sendSms method there is currently no event emitted which the client can listen on and react upon (for example - In our case we would like to report this to our analytics and get a better understanding of users drop in our login funnel).
The fix is in the connection/passwordless/actions.js class to emit AuthorizationErrorEvent.

### Testing

Passwordless.actions test is updated to check that AuthorizationError event is emitted.

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
