### PR TITLE
Fix header height calculation for large titles

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -186,6 +186,7 @@ loadingSize = 30px
 
   .auth0-lock-content-body-wrapper
     padding-top 10px
+    margin-top: var(--header-height, 100px)
 
   .auth0-lock-close-button, .auth0-lock-back-button
     -webkit-box-sizing content-box !important

--- a/src/__tests__/testUtils.js
+++ b/src/__tests__/testUtils.js
@@ -1,8 +1,8 @@
 import React from 'react'; // eslint-disable-line
 import renderer from 'react-test-renderer';
 
-export const expectComponent = children => {
-  const component = renderer.create(children);
+export const expectComponent = (children, opts) => {
+  const component = renderer.create(children, opts);
   return expect(component);
 };
 
@@ -40,26 +40,18 @@ export const extractPropsFromWrapper = (wrapper, index = 0) =>
 export const setURL = (url, options = {}) => {
   const parser = document.createElement('a');
   parser.href = url;
-  [
-    'href',
-    'protocol',
-    'host',
-    'hostname',
-    'origin',
-    'port',
-    'pathname',
-    'search',
-    'hash'
-  ].forEach(prop => {
-    let value = parser[prop];
-    if (prop === 'origin' && options.noOrigin) {
-      value = null;
+  ['href', 'protocol', 'host', 'hostname', 'origin', 'port', 'pathname', 'search', 'hash'].forEach(
+    prop => {
+      let value = parser[prop];
+      if (prop === 'origin' && options.noOrigin) {
+        value = null;
+      }
+      Object.defineProperty(window.location, prop, {
+        value,
+        writable: true
+      });
     }
-    Object.defineProperty(window.location, prop, {
-      value,
-      writable: true
-    });
-  });
+  );
 };
 
 export const expectMockToMatch = ({ mock }, numberOfCalls) => {

--- a/src/__tests__/ui/box/__snapshots__/chrome.test.jsx.snap
+++ b/src/__tests__/ui/box/__snapshots__/chrome.test.jsx.snap
@@ -21,11 +21,6 @@ exports[`Chrome can dislay all global messages together 1`] = `
       />
       <div
         className="auth0-lock-content-body-wrapper"
-        style={
-          Object {
-            "marginTop": 200,
-          }
-        }
       >
         <div>
           <div>
@@ -175,11 +170,6 @@ exports[`Chrome renders correctly when there is a global information message 1`]
       />
       <div
         className="auth0-lock-content-body-wrapper"
-        style={
-          Object {
-            "marginTop": 200,
-          }
-        }
       >
         <div>
           <div>
@@ -301,11 +291,6 @@ exports[`Chrome renders correctly when there is a global message 1`] = `
       />
       <div
         className="auth0-lock-content-body-wrapper"
-        style={
-          Object {
-            "marginTop": 200,
-          }
-        }
       >
         <div>
           <div>
@@ -427,11 +412,6 @@ exports[`Chrome renders correctly when there is a global success message 1`] = `
       />
       <div
         className="auth0-lock-content-body-wrapper"
-        style={
-          Object {
-            "marginTop": 200,
-          }
-        }
       >
         <div>
           <div>
@@ -553,11 +533,6 @@ exports[`Chrome renders correctly with basic props 1`] = `
       />
       <div
         className="auth0-lock-content-body-wrapper"
-        style={
-          Object {
-            "marginTop": 200,
-          }
-        }
       >
         <div>
           <div />

--- a/src/__tests__/ui/box/__snapshots__/header.test.jsx.snap
+++ b/src/__tests__/ui/box/__snapshots__/header.test.jsx.snap
@@ -37,6 +37,43 @@ exports[`Header renders correctly with basic props 1`] = `
 </div>
 `;
 
+exports[`Header sets the header size property on the document element 1`] = `
+<div
+  className="auth0-lock-header"
+>
+  <div
+    className="auth0-lock-header-bg auth0-lock-blur-support"
+  >
+    <div
+      className="auth0-lock-header-bg-blur auth0-lock-no-grayscale"
+      style={
+        Object {
+          "backgroundImage": "url('some-image.png')",
+        }
+      }
+    />
+    <div
+      className="auth0-lock-header-bg-solid"
+      style={
+        Object {
+          "backgroundColor": "red",
+        }
+      }
+    />
+  </div>
+  <div
+    className="auth0-lock-header-welcome"
+  >
+    <div
+      className="auth0-lock-firstname"
+      title="Header"
+    >
+      Header
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Header shows the back button when there is a handler 1`] = `
 <div
   className="auth0-lock-header"

--- a/src/__tests__/ui/box/__snapshots__/header.test.jsx.snap
+++ b/src/__tests__/ui/box/__snapshots__/header.test.jsx.snap
@@ -1,0 +1,131 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Header renders correctly with basic props 1`] = `
+<div
+  className="auth0-lock-header"
+>
+  <div
+    className="auth0-lock-header-bg auth0-lock-blur-support"
+  >
+    <div
+      className="auth0-lock-header-bg-blur auth0-lock-no-grayscale"
+      style={
+        Object {
+          "backgroundImage": "url('some-image.png')",
+        }
+      }
+    />
+    <div
+      className="auth0-lock-header-bg-solid"
+      style={
+        Object {
+          "backgroundColor": "red",
+        }
+      }
+    />
+  </div>
+  <div
+    className="auth0-lock-header-welcome"
+  >
+    <div
+      className="auth0-lock-firstname"
+      title="Header"
+    >
+      Header
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Header shows the back button when there is a handler 1`] = `
+<div
+  className="auth0-lock-header"
+>
+  <span
+    aria-label="back"
+    className="auth0-lock-back-button"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" enable-background=\\"new 0 0 24 24\\" version=\\"1.0\\" viewBox=\\"0 0 24 24\\" xml:space=\\"preserve\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\"> <polyline fill=\\"none\\" points=\\"12.5,21 3.5,12 12.5,3 \\" stroke=\\"#000000\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\"></polyline> <line fill=\\"none\\" stroke=\\"#000000\\" stroke-miterlimit=\\"10\\" stroke-width=\\"2\\" x1=\\"22\\" x2=\\"3.5\\" y1=\\"12\\" y2=\\"12\\"></line> </svg>",
+      }
+    }
+    id="undefined-back-button"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    tabIndex={0}
+  />
+  <div
+    className="auth0-lock-header-bg auth0-lock-blur-support"
+  >
+    <div
+      className="auth0-lock-header-bg-blur auth0-lock-no-grayscale"
+      style={
+        Object {
+          "backgroundImage": "url('some-image.png')",
+        }
+      }
+    />
+    <div
+      className="auth0-lock-header-bg-solid"
+      style={
+        Object {
+          "backgroundColor": "red",
+        }
+      }
+    />
+  </div>
+  <div
+    className="auth0-lock-header-welcome"
+  >
+    <div
+      className="auth0-lock-firstname"
+      title="Header"
+    >
+      Header
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Header shows the logoUrl when there is no name 1`] = `
+<div
+  className="auth0-lock-header"
+>
+  <div
+    className="auth0-lock-header-bg auth0-lock-blur-support"
+  >
+    <div
+      className="auth0-lock-header-bg-blur"
+      style={
+        Object {
+          "backgroundImage": "url('some-image.png')",
+        }
+      }
+    />
+    <div
+      className="auth0-lock-header-bg-solid"
+      style={
+        Object {
+          "backgroundColor": "red",
+        }
+      }
+    />
+  </div>
+  <div
+    className="auth0-lock-header-welcome"
+  >
+    <img
+      alt=""
+      className="auth0-lock-header-logo"
+      src="some-logo.png"
+    />
+    <div
+      className="auth0-lock-name"
+      title="This is the header"
+    >
+      This is the header
+    </div>
+  </div>
+</div>
+`;

--- a/src/__tests__/ui/box/chrome.test.jsx
+++ b/src/__tests__/ui/box/chrome.test.jsx
@@ -26,7 +26,6 @@ describe('Chrome', () => {
 
   beforeEach(() => {
     Chrome = getComponent();
-    Chrome.prototype.getHeaderSize = jest.fn(() => 200);
   });
 
   it('renders correctly with basic props', () => {

--- a/src/__tests__/ui/box/header.test.jsx
+++ b/src/__tests__/ui/box/header.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { expectComponent } from 'testUtils';
+
+const getComponent = () => require('ui/box/header').default;
+
+describe('Header', () => {
+  let Header;
+
+  beforeEach(() => {
+    Header = getComponent();
+  });
+
+  it('renders correctly with basic props', () => {
+    const props = {
+      title: 'This is the header',
+      name: 'Header',
+      logoUrl: 'some-logo.png',
+      backgroundUrl: 'some-image.png',
+      backgroundColor: 'red'
+    };
+
+    expectComponent(<Header {...props} />).toMatchSnapshot();
+  });
+
+  it('shows the back button when there is a handler', () => {
+    const props = {
+      title: 'This is the header',
+      name: 'Header',
+      logoUrl: 'some-logo.png',
+      backgroundUrl: 'some-image.png',
+      backgroundColor: 'red',
+      backHandler: () => jest.fn()
+    };
+
+    expectComponent(<Header {...props} />).toMatchSnapshot();
+  });
+
+  it('shows the logoUrl when there is no name', () => {
+    const props = {
+      title: 'This is the header',
+      backgroundUrl: 'some-image.png',
+      logoUrl: 'some-logo.png',
+      backgroundColor: 'red'
+    };
+
+    expectComponent(<Header {...props} />).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/ui/box/header.test.jsx
+++ b/src/__tests__/ui/box/header.test.jsx
@@ -45,4 +45,22 @@ describe('Header', () => {
 
     expectComponent(<Header {...props} />).toMatchSnapshot();
   });
+
+  it('sets the header size property on the document element', () => {
+    const spy = jest.spyOn(document.documentElement.style, 'setProperty');
+
+    const props = {
+      title: 'This is the header',
+      name: 'Header',
+      logoUrl: 'some-logo.png',
+      backgroundUrl: 'some-image.png',
+      backgroundColor: 'red'
+    };
+
+    expectComponent(<Header {...props} />, {
+      createNodeMock: () => ({ clientHeight: 100 })
+    }).toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalledWith('--header-height', '100px');
+  });
 });

--- a/src/ui/box/chrome.jsx
+++ b/src/ui/box/chrome.jsx
@@ -84,7 +84,7 @@ const AUXILIARY_ANIMATION_DURATION = 350;
 export default class Chrome extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { moving: false, reverse: false, headerHeight: 0 };
+    this.state = { moving: false, reverse: false };
   }
 
   componentWillReceiveProps(nextProps) {
@@ -145,10 +145,6 @@ export default class Chrome extends React.Component {
     }
   }
 
-  componentDidMount() {
-    this.setState({ headerHeight: this.getHeaderSize() });
-  }
-
   onWillSlide() {
     this.setState({ moving: true });
     this.sliding = true;
@@ -187,19 +183,6 @@ export default class Chrome extends React.Component {
     if (error) {
       error.focus();
     }
-  }
-
-  // Record the header element so that we can retrieve its size when the
-  // component renders
-  setHeaderElement(element) {
-    this.header = element;
-  }
-
-  // Get the size (rather than the element itself), as returning
-  // the element makes this difficult to test (we can't reasonably enforce the size
-  // as it's not rendered to a screen).
-  getHeaderSize() {
-    return this.header ? this.header.getDOMNode().clientHeight : 0;
   }
 
   render() {
@@ -286,13 +269,9 @@ export default class Chrome extends React.Component {
               backgroundUrl={backgroundUrl}
               backgroundColor={primaryColor}
               logoUrl={logo}
-              ref={::this.setHeaderElement}
             />
 
-            <div
-              className="auth0-lock-content-body-wrapper"
-              style={{ marginTop: this.state.headerHeight }}
-            >
+            <div className="auth0-lock-content-body-wrapper">
               <TransitionGroup>
                 <CSSTransition classNames="global-message" timeout={MESSAGE_ANIMATION_DURATION}>
                   <div>

--- a/src/ui/box/header.jsx
+++ b/src/ui/box/header.jsx
@@ -6,6 +6,15 @@ import { BackButton } from './button';
 // TODO: simplify this mess :)
 
 export default class Header extends React.Component {
+  setHeaderHeightStyle(headerElement) {
+    console.log(headerElement);
+
+    if (headerElement) {
+      const height = headerElement.clientHeight || 0;
+      document.documentElement.style.setProperty('--header-height', `${height}px`);
+    }
+  }
+
   getDOMNode() {
     return ReactDOM.findDOMNode(this);
   }
@@ -14,7 +23,7 @@ export default class Header extends React.Component {
     const { backHandler, backgroundColor, backgroundUrl, logoUrl, name, title } = this.props;
 
     return (
-      <div className="auth0-lock-header">
+      <div className="auth0-lock-header" ref={::this.setHeaderHeightStyle}>
         {backHandler && <BackButton onClick={backHandler} />}
         <Background imageUrl={backgroundUrl} backgroundColor={backgroundColor} grayScale={!!name} />
         <Welcome title={title} name={name} imageUrl={name ? undefined : logoUrl} />

--- a/src/ui/box/header.jsx
+++ b/src/ui/box/header.jsx
@@ -7,8 +7,6 @@ import { BackButton } from './button';
 
 export default class Header extends React.Component {
   setHeaderHeightStyle(headerElement) {
-    console.log(headerElement);
-
     if (headerElement) {
       const height = headerElement.clientHeight || 0;
       document.documentElement.style.setProperty('--header-height', `${height}px`);


### PR DESCRIPTION
### Changes

This PR changes the way the header height is calculated. Previously it used to get the height once on component mount, but this proved to be problematic when the title was updated after the component was rendered and a large title caused the header height to change.

Now, the height is calculated when the `Header` component is rendered, and the height is set as a CSS variable on the document root. This should also be more performant as the old state change would cause the component to re-render.

The downside is that this is difficult to test. However, basic smoke tests for `Header` were missing, which have now been added.

**Preview**

![image](https://user-images.githubusercontent.com/766403/81092154-1b57e480-8ef8-11ea-99d8-4e3eefaadebc.png)

### References

Raised internally through an ESD ticket.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
