### PR TITLE
z-index needs to be less than the close button to avoid hiding it

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -175,7 +175,7 @@ loadingSize = 30px
     flex-basis: auto
     position: absolute
     width: 100%
-    z-index: 100
+    z-index: 99
 
   .auth0-lock-content-wrapper
     flex-grow: 1


### PR DESCRIPTION
### Changes

The header is further down in the DOM than the close button and they have matching z-index values so the header is overlaying the close button

https://github.com/auth0/lock/blob/master/css/index.styl#L178
https://github.com/auth0/lock/blob/master/css/index.styl#L204

close button z-index should be > header z-index

### References

fixes #1863 

### Testing

![image](https://user-images.githubusercontent.com/1299658/82659357-79870600-9c20-11ea-8053-ec62d696ebbc.png)

Also tested in IE11

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
