### PR TITLE
Allows i18n en lang override

### DIFF
--- a/src/__tests__/i18n.test.js
+++ b/src/__tests__/i18n.test.js
@@ -1,0 +1,52 @@
+import Immutable from 'immutable';
+import flatten from 'flat';
+
+import enDictionary from '../i18n/en';
+import esDictionary from '../i18n/es';
+
+import * as sync from '../sync';
+import * as l from '../core/index';
+
+describe('i18n', () => {
+  let syncSpy;
+  let langSpy;
+
+  beforeEach(() => {
+    syncSpy = jest.spyOn(sync, 'default');
+
+    langSpy = jest.spyOn(l.ui, 'language').mockImplementation(() => {
+      return 'en';
+    });
+  });
+
+  afterEach(() => {
+    syncSpy.mockRestore();
+    langSpy.mockRestore();
+  });
+
+  describe('load i18n configuration', () => {
+    it('should have a defaultDictionary', () => {
+      const i18n = require('../i18n');
+
+      // We need to initialize the state
+      var m = Immutable.fromJS({});
+
+      // Initialize i18n.
+      const initialized = i18n.initI18n(m);
+
+      let language = flatten(initialized.getIn(['i18n', 'strings']).toJS());
+      const en = flatten(enDictionary);
+
+      expect(language).toEqual(en);
+    });
+  });
+
+  describe('when en language is selected', () => {
+    it('should allow check for external en dictionaries', () => {
+      const i18n = require('../i18n');
+
+      i18n.initI18n(Immutable.fromJS({}));
+      expect(syncSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -83,8 +83,6 @@ function registerLanguageDictionary(language, dictionary) {
   languageDictionaries[language] = Immutable.fromJS(dictionary);
 }
 
-registerLanguageDictionary('en', enDictionary);
-
 preload({
   method: 'registerLanguageDictionary',
   cb: registerLanguageDictionary

--- a/test/captcha.test.js
+++ b/test/captcha.test.js
@@ -22,41 +22,6 @@ describe('captcha', function() {
   before(h.stubWebApis);
   after(h.restoreWebApis);
 
-  describe('when the api returns a new challenge', function() {
-    beforeEach(function(done) {
-      this.stub = h.stubGetChallenge([requiredResponse1, requiredResponse2]);
-      this.lock = h.displayLock('', lockOpts, done);
-    });
-
-    afterEach(function() {
-      this.lock.hide();
-    });
-
-    it('should show the captcha input', function() {
-      expect(h.qInput(this.lock, 'captcha', false)).to.be.ok();
-    });
-
-    it('should require another challenge when clicking the refresh button', function(done) {
-      h.clickRefreshCaptchaButton(this.lock);
-      setTimeout(() => {
-        expect(h.q(this.lock, '.auth0-lock-captcha-image').style.backgroundImage).to.equal(
-          `url("${requiredResponse2.image}")`
-        );
-        done();
-      }, 200);
-    });
-
-    it('should submit the captcha provided by the user', function() {
-      h.logInWithEmailPasswordAndCaptcha(this.lock);
-      expect(h.wasLoginAttemptedWith({ captcha: 'captchaValue' })).to.be.ok();
-    });
-
-    it('should not submit the form if the captcha is not provided', function() {
-      h.logInWithEmailAndPassword(this.lock);
-      expect(h.wasLoginAttemptedWith({})).to.not.be.ok();
-    });
-  });
-
   describe('when the challenge api returns required: false', function() {
     beforeEach(function(done) {
       h.stubGetChallenge({
@@ -88,6 +53,44 @@ describe('captcha', function() {
       it('should call the challenge api again and show the input', function() {
         expect(h.qInput(this.lock, 'captcha', false)).to.be.ok();
       });
+    });
+  });
+
+  describe('when the api returns a new challenge', function() {
+    beforeEach(function(done) {
+      this.stub = h.stubGetChallenge([requiredResponse1, requiredResponse2]);
+      this.lock = h.displayLock('', lockOpts, done);
+    });
+
+    afterEach(function() {
+      this.lock.hide();
+    });
+
+    it('should require another challenge when clicking the refresh button', function(done) {
+      h.clickRefreshCaptchaButton(this.lock);
+      setTimeout(() => {
+        expect(h.q(this.lock, '.auth0-lock-captcha-image').style.backgroundImage).to.equal(
+          `url("${requiredResponse2.image}")`
+        );
+        done();
+      }, 200);
+    });
+
+    it('should submit the captcha provided by the user', function() {
+      h.logInWithEmailPasswordAndCaptcha(this.lock);
+      expect(h.wasLoginAttemptedWith({ captcha: 'captchaValue' })).to.be.ok();
+    });
+
+    it('should not submit the form if the captcha is not provided', function() {
+      h.logInWithEmailAndPassword(this.lock);
+      expect(h.wasLoginAttemptedWith({})).to.not.be.ok();
+    });
+
+    it('should show the captcha input', function(done) {
+      setTimeout(() => {
+        expect(h.qInput(this.lock, 'captcha', false)).to.be.ok();
+        done();
+      }, 200);
     });
   });
 });


### PR DESCRIPTION
### Changes

This change allows for ‘en’ overrides.  Adds testing support to verify that the defaultDictionary is loaded, and is allowed to be overridden.

### References

ESD-6306

### Testing

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

Had to reorganize the captcha tests because of some race conditions that were happening intermittently 