### PR TITLE
Add !hostedLoginPage condition to redirect check

### DIFF
--- a/src/__tests__/core/__snapshots__/web_api.test.js.snap
+++ b/src/__tests__/core/__snapshots__/web_api.test.js.snap
@@ -1,0 +1,900 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Auth0WebApi setupClient sets the correct options when is on the hosted login page 1`] = `
+Auth0WebAPI {
+  "clients": Object {
+    "lock-id": Auth0APIClient {
+      "_enableIdPInitiatedLogin": false,
+      "authOpt": Object {
+        "nonce": undefined,
+        "popup": false,
+        "popupOptions": undefined,
+        "scope": undefined,
+        "state": undefined,
+      },
+      "client": WebAuth {
+        "_universalLogin": HostedPages {
+          "baseOptions": Object {
+            "_sendTelemetry": true,
+            "_telemetryInfo": Object {
+              "env": Object {
+                "auth0.js": "9.13.2",
+              },
+              "name": "lock.js",
+              "version": "11.24.1",
+            },
+            "_timesToRetryFailedRequests": 0,
+            "audience": undefined,
+            "clientID": "client-id",
+            "domain": "test.com",
+            "jwksURI": null,
+            "leeway": 60,
+            "nonce": undefined,
+            "overrides": null,
+            "plugins": PluginHandler {
+              "plugins": Array [
+                CordovaPlugin {
+                  "extensibilityPoints": Array [
+                    "popup.authorize",
+                    "popup.getPopupHandler",
+                  ],
+                  "version": "9.13.2",
+                  "webAuth": [Circular],
+                },
+              ],
+            },
+            "popupOrigin": undefined,
+            "redirectUri": undefined,
+            "responseMode": undefined,
+            "responseType": undefined,
+            "rootUrl": "https://test.com",
+            "scope": undefined,
+            "state": undefined,
+            "tenant": "test",
+            "token_issuer": "https://test.com/",
+            "universalLoginPage": true,
+          },
+          "client": [Circular],
+          "request": RequestBuilder {
+            "_sendTelemetry": true,
+            "_telemetryInfo": Object {
+              "env": Object {
+                "auth0.js": "9.13.2",
+              },
+              "name": "lock.js",
+              "version": "11.24.1",
+            },
+            "_timesToRetryFailedRequests": 0,
+            "_universalLoginPage": true,
+            "headers": Object {},
+          },
+          "warn": Warn {
+            "disableWarnings": false,
+          },
+        },
+        "baseOptions": Object {
+          "_sendTelemetry": true,
+          "_telemetryInfo": Object {
+            "env": Object {
+              "auth0.js": "9.13.2",
+            },
+            "name": "lock.js",
+            "version": "11.24.1",
+          },
+          "_timesToRetryFailedRequests": 0,
+          "audience": undefined,
+          "clientID": "client-id",
+          "domain": "test.com",
+          "jwksURI": null,
+          "leeway": 60,
+          "nonce": undefined,
+          "overrides": null,
+          "plugins": PluginHandler {
+            "plugins": Array [
+              CordovaPlugin {
+                "extensibilityPoints": Array [
+                  "popup.authorize",
+                  "popup.getPopupHandler",
+                ],
+                "version": "9.13.2",
+                "webAuth": [Circular],
+              },
+            ],
+          },
+          "popupOrigin": undefined,
+          "redirectUri": undefined,
+          "responseMode": undefined,
+          "responseType": undefined,
+          "rootUrl": "https://test.com",
+          "scope": undefined,
+          "state": undefined,
+          "tenant": "test",
+          "token_issuer": "https://test.com/",
+          "universalLoginPage": true,
+        },
+        "client": Authentication {
+          "baseOptions": Object {
+            "_sendTelemetry": true,
+            "_telemetryInfo": Object {
+              "env": Object {
+                "auth0.js": "9.13.2",
+              },
+              "name": "lock.js",
+              "version": "11.24.1",
+            },
+            "_timesToRetryFailedRequests": 0,
+            "audience": undefined,
+            "clientID": "client-id",
+            "domain": "test.com",
+            "jwksURI": null,
+            "leeway": 60,
+            "nonce": undefined,
+            "overrides": null,
+            "plugins": PluginHandler {
+              "plugins": Array [
+                CordovaPlugin {
+                  "extensibilityPoints": Array [
+                    "popup.authorize",
+                    "popup.getPopupHandler",
+                  ],
+                  "version": "9.13.2",
+                  "webAuth": [Circular],
+                },
+              ],
+            },
+            "popupOrigin": undefined,
+            "redirectUri": undefined,
+            "responseMode": undefined,
+            "responseType": undefined,
+            "rootUrl": "https://test.com",
+            "scope": undefined,
+            "state": undefined,
+            "tenant": "test",
+            "token_issuer": "https://test.com/",
+            "universalLoginPage": true,
+          },
+          "dbConnection": DBConnection {
+            "baseOptions": Object {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "audience": undefined,
+              "clientID": "client-id",
+              "domain": "test.com",
+              "jwksURI": null,
+              "leeway": 60,
+              "nonce": undefined,
+              "overrides": null,
+              "plugins": PluginHandler {
+                "plugins": Array [
+                  CordovaPlugin {
+                    "extensibilityPoints": Array [
+                      "popup.authorize",
+                      "popup.getPopupHandler",
+                    ],
+                    "version": "9.13.2",
+                    "webAuth": [Circular],
+                  },
+                ],
+              },
+              "popupOrigin": undefined,
+              "redirectUri": undefined,
+              "responseMode": undefined,
+              "responseType": undefined,
+              "rootUrl": "https://test.com",
+              "scope": undefined,
+              "state": undefined,
+              "tenant": "test",
+              "token_issuer": "https://test.com/",
+              "universalLoginPage": true,
+            },
+            "request": RequestBuilder {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "_universalLoginPage": undefined,
+              "headers": Object {},
+            },
+          },
+          "passwordless": PasswordlessAuthentication {
+            "baseOptions": Object {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "audience": undefined,
+              "clientID": "client-id",
+              "domain": "test.com",
+              "jwksURI": null,
+              "leeway": 60,
+              "nonce": undefined,
+              "overrides": null,
+              "plugins": PluginHandler {
+                "plugins": Array [
+                  CordovaPlugin {
+                    "extensibilityPoints": Array [
+                      "popup.authorize",
+                      "popup.getPopupHandler",
+                    ],
+                    "version": "9.13.2",
+                    "webAuth": [Circular],
+                  },
+                ],
+              },
+              "popupOrigin": undefined,
+              "redirectUri": undefined,
+              "responseMode": undefined,
+              "responseType": undefined,
+              "rootUrl": "https://test.com",
+              "scope": undefined,
+              "state": undefined,
+              "tenant": "test",
+              "token_issuer": "https://test.com/",
+              "universalLoginPage": true,
+            },
+            "request": RequestBuilder {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "_universalLoginPage": undefined,
+              "headers": Object {},
+            },
+          },
+          "request": RequestBuilder {
+            "_sendTelemetry": true,
+            "_telemetryInfo": Object {
+              "env": Object {
+                "auth0.js": "9.13.2",
+              },
+              "name": "lock.js",
+              "version": "11.24.1",
+            },
+            "_timesToRetryFailedRequests": 0,
+            "_universalLoginPage": undefined,
+            "headers": Object {},
+          },
+          "ssodataStorage": SSODataStorage {
+            "storage": Storage {
+              "handler": StorageHandler {
+                "storage": CookieStorage {},
+                "warn": Warn {
+                  "disableWarnings": undefined,
+                },
+              },
+            },
+          },
+          "warn": Warn {
+            "disableWarnings": false,
+          },
+        },
+        "crossOriginAuthentication": CrossOriginAuthentication {
+          "baseOptions": Object {
+            "_sendTelemetry": true,
+            "_telemetryInfo": Object {
+              "env": Object {
+                "auth0.js": "9.13.2",
+              },
+              "name": "lock.js",
+              "version": "11.24.1",
+            },
+            "_timesToRetryFailedRequests": 0,
+            "audience": undefined,
+            "clientID": "client-id",
+            "domain": "test.com",
+            "jwksURI": null,
+            "leeway": 60,
+            "nonce": undefined,
+            "overrides": null,
+            "plugins": PluginHandler {
+              "plugins": Array [
+                CordovaPlugin {
+                  "extensibilityPoints": Array [
+                    "popup.authorize",
+                    "popup.getPopupHandler",
+                  ],
+                  "version": "9.13.2",
+                  "webAuth": [Circular],
+                },
+              ],
+            },
+            "popupOrigin": undefined,
+            "redirectUri": undefined,
+            "responseMode": undefined,
+            "responseType": undefined,
+            "rootUrl": "https://test.com",
+            "scope": undefined,
+            "state": undefined,
+            "tenant": "test",
+            "token_issuer": "https://test.com/",
+            "universalLoginPage": true,
+          },
+          "request": RequestBuilder {
+            "_sendTelemetry": true,
+            "_telemetryInfo": Object {
+              "env": Object {
+                "auth0.js": "9.13.2",
+              },
+              "name": "lock.js",
+              "version": "11.24.1",
+            },
+            "_timesToRetryFailedRequests": 0,
+            "_universalLoginPage": undefined,
+            "headers": Object {},
+          },
+          "storage": Storage {
+            "handler": StorageHandler {
+              "storage": CookieStorage {},
+              "warn": Warn {
+                "disableWarnings": undefined,
+              },
+            },
+          },
+          "webAuth": [Circular],
+          "webMessageHandler": WebMessageHandler {
+            "warn": Warn {
+              "disableWarnings": undefined,
+            },
+            "webAuth": [Circular],
+          },
+        },
+        "popup": Popup {
+          "baseOptions": Object {
+            "_sendTelemetry": true,
+            "_telemetryInfo": Object {
+              "env": Object {
+                "auth0.js": "9.13.2",
+              },
+              "name": "lock.js",
+              "version": "11.24.1",
+            },
+            "_timesToRetryFailedRequests": 0,
+            "audience": undefined,
+            "clientID": "client-id",
+            "domain": "test.com",
+            "jwksURI": null,
+            "leeway": 60,
+            "nonce": undefined,
+            "overrides": null,
+            "plugins": PluginHandler {
+              "plugins": Array [
+                CordovaPlugin {
+                  "extensibilityPoints": Array [
+                    "popup.authorize",
+                    "popup.getPopupHandler",
+                  ],
+                  "version": "9.13.2",
+                  "webAuth": [Circular],
+                },
+              ],
+            },
+            "popupOrigin": undefined,
+            "redirectUri": undefined,
+            "responseMode": undefined,
+            "responseType": undefined,
+            "rootUrl": "https://test.com",
+            "scope": undefined,
+            "state": undefined,
+            "tenant": "test",
+            "token_issuer": "https://test.com/",
+            "universalLoginPage": true,
+          },
+          "client": Authentication {
+            "baseOptions": Object {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "audience": undefined,
+              "clientID": "client-id",
+              "domain": "test.com",
+              "jwksURI": null,
+              "leeway": 60,
+              "nonce": undefined,
+              "overrides": null,
+              "plugins": PluginHandler {
+                "plugins": Array [
+                  CordovaPlugin {
+                    "extensibilityPoints": Array [
+                      "popup.authorize",
+                      "popup.getPopupHandler",
+                    ],
+                    "version": "9.13.2",
+                    "webAuth": [Circular],
+                  },
+                ],
+              },
+              "popupOrigin": undefined,
+              "redirectUri": undefined,
+              "responseMode": undefined,
+              "responseType": undefined,
+              "rootUrl": "https://test.com",
+              "scope": undefined,
+              "state": undefined,
+              "tenant": "test",
+              "token_issuer": "https://test.com/",
+              "universalLoginPage": true,
+            },
+            "dbConnection": DBConnection {
+              "baseOptions": Object {
+                "_sendTelemetry": true,
+                "_telemetryInfo": Object {
+                  "env": Object {
+                    "auth0.js": "9.13.2",
+                  },
+                  "name": "lock.js",
+                  "version": "11.24.1",
+                },
+                "_timesToRetryFailedRequests": 0,
+                "audience": undefined,
+                "clientID": "client-id",
+                "domain": "test.com",
+                "jwksURI": null,
+                "leeway": 60,
+                "nonce": undefined,
+                "overrides": null,
+                "plugins": PluginHandler {
+                  "plugins": Array [
+                    CordovaPlugin {
+                      "extensibilityPoints": Array [
+                        "popup.authorize",
+                        "popup.getPopupHandler",
+                      ],
+                      "version": "9.13.2",
+                      "webAuth": [Circular],
+                    },
+                  ],
+                },
+                "popupOrigin": undefined,
+                "redirectUri": undefined,
+                "responseMode": undefined,
+                "responseType": undefined,
+                "rootUrl": "https://test.com",
+                "scope": undefined,
+                "state": undefined,
+                "tenant": "test",
+                "token_issuer": "https://test.com/",
+                "universalLoginPage": true,
+              },
+              "request": RequestBuilder {
+                "_sendTelemetry": true,
+                "_telemetryInfo": Object {
+                  "env": Object {
+                    "auth0.js": "9.13.2",
+                  },
+                  "name": "lock.js",
+                  "version": "11.24.1",
+                },
+                "_timesToRetryFailedRequests": 0,
+                "_universalLoginPage": undefined,
+                "headers": Object {},
+              },
+            },
+            "passwordless": PasswordlessAuthentication {
+              "baseOptions": Object {
+                "_sendTelemetry": true,
+                "_telemetryInfo": Object {
+                  "env": Object {
+                    "auth0.js": "9.13.2",
+                  },
+                  "name": "lock.js",
+                  "version": "11.24.1",
+                },
+                "_timesToRetryFailedRequests": 0,
+                "audience": undefined,
+                "clientID": "client-id",
+                "domain": "test.com",
+                "jwksURI": null,
+                "leeway": 60,
+                "nonce": undefined,
+                "overrides": null,
+                "plugins": PluginHandler {
+                  "plugins": Array [
+                    CordovaPlugin {
+                      "extensibilityPoints": Array [
+                        "popup.authorize",
+                        "popup.getPopupHandler",
+                      ],
+                      "version": "9.13.2",
+                      "webAuth": [Circular],
+                    },
+                  ],
+                },
+                "popupOrigin": undefined,
+                "redirectUri": undefined,
+                "responseMode": undefined,
+                "responseType": undefined,
+                "rootUrl": "https://test.com",
+                "scope": undefined,
+                "state": undefined,
+                "tenant": "test",
+                "token_issuer": "https://test.com/",
+                "universalLoginPage": true,
+              },
+              "request": RequestBuilder {
+                "_sendTelemetry": true,
+                "_telemetryInfo": Object {
+                  "env": Object {
+                    "auth0.js": "9.13.2",
+                  },
+                  "name": "lock.js",
+                  "version": "11.24.1",
+                },
+                "_timesToRetryFailedRequests": 0,
+                "_universalLoginPage": undefined,
+                "headers": Object {},
+              },
+            },
+            "request": RequestBuilder {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "_universalLoginPage": undefined,
+              "headers": Object {},
+            },
+            "ssodataStorage": SSODataStorage {
+              "storage": Storage {
+                "handler": StorageHandler {
+                  "storage": CookieStorage {},
+                  "warn": Warn {
+                    "disableWarnings": undefined,
+                  },
+                },
+              },
+            },
+            "warn": Warn {
+              "disableWarnings": false,
+            },
+          },
+          "crossOriginAuthentication": CrossOriginAuthentication {
+            "baseOptions": Object {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "audience": undefined,
+              "clientID": "client-id",
+              "domain": "test.com",
+              "jwksURI": null,
+              "leeway": 60,
+              "nonce": undefined,
+              "overrides": null,
+              "plugins": PluginHandler {
+                "plugins": Array [
+                  CordovaPlugin {
+                    "extensibilityPoints": Array [
+                      "popup.authorize",
+                      "popup.getPopupHandler",
+                    ],
+                    "version": "9.13.2",
+                    "webAuth": [Circular],
+                  },
+                ],
+              },
+              "popupOrigin": undefined,
+              "redirectUri": undefined,
+              "responseMode": undefined,
+              "responseType": undefined,
+              "rootUrl": "https://test.com",
+              "scope": undefined,
+              "state": undefined,
+              "tenant": "test",
+              "token_issuer": "https://test.com/",
+              "universalLoginPage": true,
+            },
+            "request": RequestBuilder {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "_universalLoginPage": undefined,
+              "headers": Object {},
+            },
+            "storage": Storage {
+              "handler": StorageHandler {
+                "storage": CookieStorage {},
+                "warn": Warn {
+                  "disableWarnings": undefined,
+                },
+              },
+            },
+            "webAuth": [Circular],
+            "webMessageHandler": WebMessageHandler {
+              "warn": Warn {
+                "disableWarnings": undefined,
+              },
+              "webAuth": [Circular],
+            },
+          },
+          "transactionManager": TransactionManager {
+            "keyLength": 32,
+            "namespace": "com.auth0.auth.",
+            "options": Object {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "audience": undefined,
+              "clientID": "client-id",
+              "domain": "test.com",
+              "jwksURI": null,
+              "leeway": 60,
+              "nonce": undefined,
+              "overrides": null,
+              "plugins": PluginHandler {
+                "plugins": Array [
+                  CordovaPlugin {
+                    "extensibilityPoints": Array [
+                      "popup.authorize",
+                      "popup.getPopupHandler",
+                    ],
+                    "version": "9.13.2",
+                    "webAuth": [Circular],
+                  },
+                ],
+              },
+              "popupOrigin": undefined,
+              "redirectUri": undefined,
+              "responseMode": undefined,
+              "responseType": undefined,
+              "rootUrl": "https://test.com",
+              "scope": undefined,
+              "state": undefined,
+              "tenant": "test",
+              "token_issuer": "https://test.com/",
+              "universalLoginPage": true,
+            },
+            "storage": Storage {
+              "handler": StorageHandler {
+                "storage": CookieStorage {},
+                "warn": Warn {
+                  "disableWarnings": undefined,
+                },
+              },
+            },
+          },
+          "warn": Warn {
+            "disableWarnings": false,
+          },
+          "webAuth": [Circular],
+        },
+        "redirect": Redirect {
+          "baseOptions": Object {
+            "_sendTelemetry": true,
+            "_telemetryInfo": Object {
+              "env": Object {
+                "auth0.js": "9.13.2",
+              },
+              "name": "lock.js",
+              "version": "11.24.1",
+            },
+            "_timesToRetryFailedRequests": 0,
+            "audience": undefined,
+            "clientID": "client-id",
+            "domain": "test.com",
+            "jwksURI": null,
+            "leeway": 60,
+            "nonce": undefined,
+            "overrides": null,
+            "plugins": PluginHandler {
+              "plugins": Array [
+                CordovaPlugin {
+                  "extensibilityPoints": Array [
+                    "popup.authorize",
+                    "popup.getPopupHandler",
+                  ],
+                  "version": "9.13.2",
+                  "webAuth": [Circular],
+                },
+              ],
+            },
+            "popupOrigin": undefined,
+            "redirectUri": undefined,
+            "responseMode": undefined,
+            "responseType": undefined,
+            "rootUrl": "https://test.com",
+            "scope": undefined,
+            "state": undefined,
+            "tenant": "test",
+            "token_issuer": "https://test.com/",
+            "universalLoginPage": true,
+          },
+          "crossOriginAuthentication": CrossOriginAuthentication {
+            "baseOptions": Object {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "audience": undefined,
+              "clientID": "client-id",
+              "domain": "test.com",
+              "jwksURI": null,
+              "leeway": 60,
+              "nonce": undefined,
+              "overrides": null,
+              "plugins": PluginHandler {
+                "plugins": Array [
+                  CordovaPlugin {
+                    "extensibilityPoints": Array [
+                      "popup.authorize",
+                      "popup.getPopupHandler",
+                    ],
+                    "version": "9.13.2",
+                    "webAuth": [Circular],
+                  },
+                ],
+              },
+              "popupOrigin": undefined,
+              "redirectUri": undefined,
+              "responseMode": undefined,
+              "responseType": undefined,
+              "rootUrl": "https://test.com",
+              "scope": undefined,
+              "state": undefined,
+              "tenant": "test",
+              "token_issuer": "https://test.com/",
+              "universalLoginPage": true,
+            },
+            "request": RequestBuilder {
+              "_sendTelemetry": true,
+              "_telemetryInfo": Object {
+                "env": Object {
+                  "auth0.js": "9.13.2",
+                },
+                "name": "lock.js",
+                "version": "11.24.1",
+              },
+              "_timesToRetryFailedRequests": 0,
+              "_universalLoginPage": undefined,
+              "headers": Object {},
+            },
+            "storage": Storage {
+              "handler": StorageHandler {
+                "storage": CookieStorage {},
+                "warn": Warn {
+                  "disableWarnings": undefined,
+                },
+              },
+            },
+            "webAuth": [Circular],
+            "webMessageHandler": WebMessageHandler {
+              "warn": Warn {
+                "disableWarnings": undefined,
+              },
+              "webAuth": [Circular],
+            },
+          },
+          "warn": Warn {
+            "disableWarnings": false,
+          },
+          "webAuth": [Circular],
+        },
+        "ssodataStorage": SSODataStorage {
+          "storage": Storage {
+            "handler": StorageHandler {
+              "storage": CookieStorage {},
+              "warn": Warn {
+                "disableWarnings": undefined,
+              },
+            },
+          },
+        },
+        "transactionManager": TransactionManager {
+          "keyLength": 32,
+          "namespace": "com.auth0.auth.",
+          "options": Object {
+            "_sendTelemetry": true,
+            "_telemetryInfo": Object {
+              "env": Object {
+                "auth0.js": "9.13.2",
+              },
+              "name": "lock.js",
+              "version": "11.24.1",
+            },
+            "_timesToRetryFailedRequests": 0,
+            "audience": undefined,
+            "clientID": "client-id",
+            "domain": "test.com",
+            "jwksURI": null,
+            "leeway": 60,
+            "nonce": undefined,
+            "overrides": null,
+            "plugins": PluginHandler {
+              "plugins": Array [
+                CordovaPlugin {
+                  "extensibilityPoints": Array [
+                    "popup.authorize",
+                    "popup.getPopupHandler",
+                  ],
+                  "version": "9.13.2",
+                  "webAuth": [Circular],
+                },
+              ],
+            },
+            "popupOrigin": undefined,
+            "redirectUri": undefined,
+            "responseMode": undefined,
+            "responseType": undefined,
+            "rootUrl": "https://test.com",
+            "scope": undefined,
+            "state": undefined,
+            "tenant": "test",
+            "token_issuer": "https://test.com/",
+            "universalLoginPage": true,
+          },
+          "storage": Storage {
+            "handler": StorageHandler {
+              "storage": CookieStorage {},
+              "warn": Warn {
+                "disableWarnings": undefined,
+              },
+            },
+          },
+        },
+        "webMessageHandler": WebMessageHandler {
+          "warn": Warn {
+            "disableWarnings": undefined,
+          },
+          "webAuth": [Circular],
+        },
+      },
+      "domain": "test.com",
+      "isUniversalLogin": false,
+      "lockID": "lock-id",
+    },
+  },
+}
+`;

--- a/src/__tests__/core/web_api.test.js
+++ b/src/__tests__/core/web_api.test.js
@@ -9,11 +9,11 @@ describe('Auth0WebApi', () => {
   const client = () => Auth0WebApi.clients[LOCK_ID];
 
   beforeEach(() => {
-    originalWindow = window;
+    originalWindow = global.window;
   });
 
   afterEach(() => {
-    window = originalWindow;
+    global.window = originalWindow;
   });
 
   describe('setupClient', () => {

--- a/src/__tests__/core/web_api.test.js
+++ b/src/__tests__/core/web_api.test.js
@@ -1,0 +1,61 @@
+import Auth0WebApi from '../../core/web_api';
+
+describe('Auth0WebApi', () => {
+  let originalWindow;
+
+  const LOCK_ID = 'lock-id';
+  const CLIENT_ID = 'client-id';
+  const DEFAULT_DOMAIN = 'test.com';
+  const client = () => Auth0WebApi.clients[LOCK_ID];
+
+  beforeEach(() => {
+    originalWindow = window;
+  });
+
+  afterEach(() => {
+    window = originalWindow;
+  });
+
+  describe('setupClient', () => {
+    it('sets the correct options when is on the hosted login page', () => {
+      Auth0WebApi.setupClient(LOCK_ID, CLIENT_ID, DEFAULT_DOMAIN, { redirect: true });
+      expect(Auth0WebApi).toMatchSnapshot();
+    });
+
+    it('sets redirect: true when on the same origin as the specified domain', () => {
+      delete global.window.location;
+      window.location = { ...originalWindow.location, host: DEFAULT_DOMAIN, search: '' };
+
+      Auth0WebApi.setupClient(LOCK_ID, CLIENT_ID, DEFAULT_DOMAIN, {});
+      expect(client().authOpt.popup).toBe(false);
+    });
+
+    it('sets redirect: false when on a different origin as the specified domain', () => {
+      delete global.window.location;
+      window.location = { ...originalWindow.location, host: 'test-other.com', search: '' };
+
+      Auth0WebApi.setupClient(LOCK_ID, CLIENT_ID, DEFAULT_DOMAIN, {});
+      expect(client().authOpt.popup).toBe(true);
+    });
+
+    it('forces popup and sso mode for cordova, only when not running in the hosted environment', () => {
+      delete global.window.location;
+      window.location = { ...originalWindow.location, host: DEFAULT_DOMAIN, search: '' };
+      window.cordova = true;
+
+      Auth0WebApi.setupClient(LOCK_ID, CLIENT_ID, DEFAULT_DOMAIN, {});
+      expect(client().authOpt.popup).toBe(false);
+      expect(client().authOpt.sso).toBeUndefined();
+    });
+
+    it('forces popup and sso mode for electron, only when not running in the hosted environment', () => {
+      delete global.window.location;
+      window.location = { ...originalWindow.location, host: DEFAULT_DOMAIN, search: '' };
+      window.electron = true;
+
+      Auth0WebApi.setupClient(LOCK_ID, CLIENT_ID, DEFAULT_DOMAIN, {});
+      expect(client().authOpt.popup).toBe(false);
+      expect(client().authOpt.sso).toBeUndefined();
+    });
+  });
+});

--- a/src/core/web_api.js
+++ b/src/core/web_api.js
@@ -12,7 +12,7 @@ class Auth0WebAPI {
 
     // for cordova and electron we should force popup without SSO so it uses
     // /ro or /oauth/token for DB connections
-    if (window && (!!window.cordova || !!window.electron)) {
+    if (!hostedLoginPage && window && (!!window.cordova || !!window.electron)) {
       opts.redirect = false;
       opts.sso = false;
     }


### PR DESCRIPTION
### Changes

This PR forces popup mode + sso mode for Electron and Cordova apps only when not on the hosted login page. This means that Electron apps where the login page is opened inside the app would not try and do a cross-origin authentication request when using the hosted ULP.

### References

Raised by internal ESD.

### Testing

Tested and verified through manual testing with a customer using an Electron app.

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
