### PR TITLE
[SDK-1556] Apply window height style to root document for Passwordless UI

### DIFF
--- a/src/passwordless.js
+++ b/src/passwordless.js
@@ -1,10 +1,15 @@
-import Core, { injectStyles, css } from './core';
+import Core, { injectStyles, setWindowHeightStyle } from './core';
 import passwordless from './engine/passwordless';
 
 export default class Auth0LockPasswordless extends Core {
   constructor(clientID, domain, options) {
     super(clientID, domain, options, passwordless);
     injectStyles();
+    setWindowHeightStyle();
+
+    window.addEventListener('resize', () => {
+      setWindowHeightStyle();
+    });
   }
 }
 


### PR DESCRIPTION
### Changes

Determines the window height using JavaScript and applies height to document root when using the Passwordless UI. This takes into account any window chrome provided by mobile devices.

This is a patch that was already applied to the primary Lock UI, but not passwordless.

**Before**
![image](https://user-images.githubusercontent.com/766403/83882056-779d6680-a739-11ea-9e50-020c9243e5df.png)

**After**
![image](https://user-images.githubusercontent.com/766403/83881942-4de43f80-a739-11ea-83d7-c94a7cea9c38.png)

### References

Fixes #1826 

### Testing

Tested manually using Browserstack + local iOS 11 Pro Simulator.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
