### PR TITLE
Show the "Can't be blank" message under the password input

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -1210,6 +1210,7 @@ loadingSize = 30px
 .auth0-lock-password-strength
   width 100%
   bottom 41px
+  left 0
   // width calc(100% - 28px)
   display block
   text-align left

--- a/src/__tests__/ui/input/__snapshots__/input_wrap.test.jsx.snap
+++ b/src/__tests__/ui/input/__snapshots__/input_wrap.test.jsx.snap
@@ -6,9 +6,10 @@ exports[`InputWrap renders correctly with the \`after\` prop 1`] = `
 >
   <div
     className="auth0-lock-input-wrap"
-  />
-  <span>
-    after
-  </span>
+  >
+    <span>
+      after
+    </span>
+  </div>
 </div>
 `;

--- a/src/__tests__/ui/input/password_input.test.jsx
+++ b/src/__tests__/ui/input/password_input.test.jsx
@@ -3,6 +3,7 @@ import { mount, shallow } from 'enzyme';
 
 import { mockComponent } from 'testUtils';
 import { extractPropsFromWrapper } from '../../testUtils';
+import InputWrap from '../../../ui/input/input_wrap';
 
 jest.mock('ui/input/input_wrap', () => mockComponent('input_wrap'));
 jest.mock('ui/input/password/password_strength', () => mockComponent('password_strength'));
@@ -50,5 +51,10 @@ describe('PasswordInput', () => {
     const Input = getComponent();
     const wrapper = mount(<Input {...defaultProps} />);
     expect(wrapper.find('input').props().autoComplete).toBe('off');
+  });
+  test('shows invalid Hint', () => {
+    const Input = getComponent();
+    const wrapper = mount(<Input {...defaultProps} />);
+    expect(wrapper.find(InputWrap).props().invalidHint).toBe('invalidHint');
   });
 });

--- a/src/ui/input/input_wrap.jsx
+++ b/src/ui/input/input_wrap.jsx
@@ -40,8 +40,8 @@ export default class InputWrap extends React.Component {
         <div className={wrapClassName}>
           {iconElement}
           {this.props.children}
+          {after}
         </div>
-        {after}
         {errorTooltip}
       </div>
     );

--- a/src/ui/input/password_input.jsx
+++ b/src/ui/input/password_input.jsx
@@ -61,7 +61,7 @@ export default class PasswordInput extends React.Component {
       <InputWrap
         after={passwordStrength}
         focused={focused}
-        invalidHint={policy ? undefined : invalidHint}
+        invalidHint={invalidHint}
         isValid={isValid}
         name="password"
         icon={icon}


### PR DESCRIPTION
### Changes

Show the "Can't be blank" message under the password field when you try and submit a blank password.

#### Before

<img width="325" alt="before" src="https://user-images.githubusercontent.com/1299658/84139521-f222fa80-aa47-11ea-853a-2d58968e7bda.png">

#### After

<img width="337" alt="after" src="https://user-images.githubusercontent.com/1299658/84139528-f64f1800-aa47-11ea-81ce-5218dacd3fc3.png">

### References

fixes #1721 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of the platform/language

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] All code quality tools/guidelines have been run/followed
* [ ] All relevant assets have been compiled
* [ ] All active GitHub checks have passed
