### PR TITLE
Allows i18n en lang override

### DIFF
--- a/src/__tests__/i18n.test.js
+++ b/src/__tests__/i18n.test.js
@@ -1,0 +1,52 @@
+import Immutable from 'immutable';
+import flatten from 'flat';
+
+import enDictionary from '../i18n/en';
+import esDictionary from '../i18n/es';
+
+import * as sync from '../sync';
+import * as l from '../core/index';
+
+describe('i18n', () => {
+  let syncSpy;
+  let langSpy;
+
+  beforeEach(() => {
+    syncSpy = jest.spyOn(sync, 'default');
+
+    langSpy = jest.spyOn(l.ui, 'language').mockImplementation(() => {
+      return 'en';
+    });
+  });
+
+  afterEach(() => {
+    syncSpy.mockRestore();
+    langSpy.mockRestore();
+  });
+
+  describe('load i18n configuration', () => {
+    it('should have a defaultDictionary', () => {
+      const i18n = require('../i18n');
+
+      // We need to initialize the state
+      var m = Immutable.fromJS({});
+
+      // Initialize i18n.
+      const initialized = i18n.initI18n(m);
+
+      let language = flatten(initialized.getIn(['i18n', 'strings']).toJS());
+      const en = flatten(enDictionary);
+
+      expect(language).toEqual(en);
+    });
+  });
+
+  describe('when en language is selected', () => {
+    it('should allow check for external en dictionaries', () => {
+      const i18n = require('../i18n');
+
+      i18n.initI18n(Immutable.fromJS({}));
+      expect(syncSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -83,8 +83,6 @@ function registerLanguageDictionary(language, dictionary) {
   languageDictionaries[language] = Immutable.fromJS(dictionary);
 }
 
-registerLanguageDictionary('en', enDictionary);
-
 preload({
   method: 'registerLanguageDictionary',
   cb: registerLanguageDictionary

--- a/test/captcha.test.js
+++ b/test/captcha.test.js
@@ -39,8 +39,11 @@ describe('captcha', function() {
         this.lock.hide();
       });
 
-      it('should show the captcha input', function() {
-        expect(h.qInput(this.lock, 'captcha', false)).to.be.ok();
+      it('should show the captcha input', function(done) {
+        setTimeout(() => {
+          expect(h.qInput(this.lock, 'captcha', false)).to.be.ok();
+          done();
+        }, 500);
       });
 
       it('should require another challenge when clicking the refresh button', function(done) {


### PR DESCRIPTION
### Changes

This change allows for ‘en’ overrides.  Adds testing support to verify that the defaultDictionary is loaded, and is allowed to be overridden.

### References

ESD-6306

### Testing

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

Had to reorganize the captcha tests because of some race conditions that were happening intermittently 