### PR TITLE
[CAUTH-500] Reload recaptcha after wrong username or password

### DIFF
--- a/src/__tests__/field/captcha.test.jsx
+++ b/src/__tests__/field/captcha.test.jsx
@@ -3,14 +3,14 @@ import { mount } from 'enzyme';
 import I from 'immutable';
 
 import CaptchaPane from '../../field/captcha/captcha_pane';
-import RecaptchaV2 from '../../field/captcha/recaptchav2';
+import { ReCAPTCHA } from '../../field/captcha/recaptchav2';
 import CaptchaInput from '../../ui/input/captcha_input';
 
-const createLockMock = ({ provider = 'none', siteKey = '' } = {}) =>
+const createLockMock = ({ provider = 'auth0', required = true, siteKey = '' } = {}) =>
   I.fromJS({
     id: '__lock-id__',
     core: {
-      captcha: { provider, siteKey }
+      captcha: { provider, siteKey, required: required }
     }
   });
 
@@ -48,11 +48,11 @@ describe('CaptchaPane', () => {
     });
 
     it('should render reCaptcha if provider is recaptchav2', () => {
-      expect(wrapper.find(RecaptchaV2)).toHaveLength(1);
+      expect(wrapper.find(ReCAPTCHA)).toHaveLength(1);
     });
 
     it('should pass the sitekey', () => {
-      expect(wrapper.find(RecaptchaV2).props().siteKey).toBe('mySiteKey');
+      expect(wrapper.find(ReCAPTCHA).props().sitekey).toBe('mySiteKey');
     });
   });
 });

--- a/src/__tests__/field/captcha/__snapshots__/recaptchav2.test.jsx.snap
+++ b/src/__tests__/field/captcha/__snapshots__/recaptchav2.test.jsx.snap
@@ -3,14 +3,14 @@
 exports[`RecaptchaV2 should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <Unknown
+  Symbol(enzyme.__unrendered__): <ReCAPTCHA
     lock={
       Immutable.Map {
         "id": "__lock-id__",
         "core": Immutable.Map {
           "captcha": Immutable.Map {
             "provider": "recaptchav2",
-            "siteKey": "mySiteKey",
+            "sitekey": "mySiteKey",
           },
           "transient": Immutable.Map {
             "ui": Immutable.Map {
@@ -20,7 +20,10 @@ ShallowWrapper {
         },
       }
     }
-    siteKey="mySiteKey"
+    onChange={[Function]}
+    onErrored={[Function]}
+    onExpired={[Function]}
+    sitekey="mySiteKey"
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],

--- a/src/__tests__/field/captcha/recaptchav2.test.jsx
+++ b/src/__tests__/field/captcha/recaptchav2.test.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import I from 'immutable';
 
-import RecaptchaV2, { render } from '../../../field/captcha/recaptchav2';
+import { ReCAPTCHA } from '../../../field/captcha/recaptchav2';
 
-const createLockMock = ({ provider = 'none', siteKey = '' } = {}) =>
+const createLockMock = ({ provider = 'none', sitekey = '' } = {}) =>
   I.fromJS({
     id: '__lock-id__',
     core: {
-      captcha: { provider, siteKey },
+      captcha: { provider, sitekey },
       transient: {
         ui: {
           language: 'en-US'
@@ -19,8 +19,9 @@ const createLockMock = ({ provider = 'none', siteKey = '' } = {}) =>
 
 describe('RecaptchaV2', () => {
   it('should match the snapshot', () => {
-    const mockLock = createLockMock({ provider: 'recaptchav2', siteKey: 'mySiteKey' });
-    const wrapper = shallow(<RecaptchaV2 lock={mockLock} siteKey={'mySiteKey'} />);
+    const mockLock = createLockMock({ provider: 'recaptchav2', sitekey: 'mySiteKey' });
+    const wrapper = shallow(<ReCAPTCHA lock={mockLock} sitekey={'mySiteKey'} />);
+
     expect(wrapper).toMatchSnapshot();
   });
 
@@ -32,10 +33,10 @@ describe('RecaptchaV2', () => {
       document.getElementById('renderTest').remove();
     });
     it('injects the script', () => {
-      const mockLock = createLockMock({ provider: 'recaptchav2', siteKey: 'mySiteKey' });
-      render(mockLock, document.getElementById('renderTest'), {});
-      expect(document.body.innerHTML).toBe(
-        '<div id="renderTest"></div><script src="https://www.google.com/recaptcha/api.js?hl=en-US"></script>'
+      ReCAPTCHA.loadScript({ hl: 'en-US' }, document.body);
+      expect(document.body.innerHTML).toContain('<div id="renderTest">');
+      expect(document.body.innerHTML).toContain(
+        '<script src="https://www.google.com/recaptcha/api.js?hl=en-US'
       );
     });
   });

--- a/src/field/captcha.js
+++ b/src/field/captcha.js
@@ -1,4 +1,6 @@
-import { setField, setFieldShowInvalid } from './index';
+import { setField, setFieldShowInvalid, getFieldValue } from './index';
+
+const onResetCallbacks = [];
 
 export function validate(captcha) {
   return !!captcha;
@@ -14,4 +16,8 @@ export function set(m, captcha, wasInvalid) {
 
 export function reset(m, wasInvalid) {
   return set(m, '', wasInvalid);
+}
+
+export function getValue(m) {
+  return getFieldValue(m, 'captcha');
 }

--- a/src/field/captcha/captcha_pane.jsx
+++ b/src/field/captcha/captcha_pane.jsx
@@ -7,7 +7,7 @@ import * as l from '../../core/index';
 import { swap, updateEntity } from '../../store/index';
 import * as captchaField from '../captcha';
 import { getFieldValue, isFieldVisiblyInvalid } from '../index';
-import RecaptchaV2 from './recaptchav2';
+import { ReCAPTCHA } from './recaptchav2';
 
 export default class CaptchaPane extends React.Component {
   render() {
@@ -15,14 +15,30 @@ export default class CaptchaPane extends React.Component {
 
     const lockId = l.id(lock);
 
-    function handleChange(e) {
-      swap(updateEntity, 'lock', lockId, captchaField.set, e.target.value);
-    }
-
     const captcha = l.captcha(lock);
 
     if (captcha.get('provider') === 'recaptcha_v2') {
-      return <RecaptchaV2 lock={lock} siteKey={captcha.get('siteKey')} />;
+      function handleChange(value) {
+        swap(updateEntity, 'lock', lockId, captchaField.set, value);
+      }
+
+      function reset() {
+        handleChange();
+      }
+
+      return (
+        <ReCAPTCHA
+          sitekey={captcha.get('siteKey')}
+          onChange={handleChange}
+          onExpired={reset}
+          hl={l.ui.language(lock)}
+          value={captchaField.getValue(lock)}
+        />
+      );
+    }
+
+    function handleChange(e) {
+      swap(updateEntity, 'lock', lockId, captchaField.set, e.target.value);
     }
 
     const placeholder =

--- a/src/utils/createRef.js
+++ b/src/utils/createRef.js
@@ -1,0 +1,11 @@
+/**
+ * This is similar to React.createRef(),
+ * the current version of this library doesn't support it.
+ * @returns {function} the ref func
+ */
+export function createRef() {
+  const f = function(element) {
+    f.current = element;
+  };
+  return f;
+}


### PR DESCRIPTION
### Changes

I've refactored our ReCaptcha component in a more react-ish class. I've tested this in deep and now it seems to work as we expect.

This should be released as a **patch** because we are not changing any existing API nor adding a new ones.

I am also attaching in this PR a couple of images showing the wrong behavior.

## Wrong behavior

![Screen-Recording-2020-06-24-16-28-41](https://user-images.githubusercontent.com/178512/85618936-e8001f00-b637-11ea-9e15-9a66042176b0.gif)

**As you can see after getting the error the recaptcha can't be re-checked, and the form can't be submitted.**

## Fixed behavior 
![Screen-Recording-2020-06-24-16-04-55](https://user-images.githubusercontent.com/178512/85616870-b76ab600-b634-11ea-9be7-40bbcf9b4795.gif)



### References

https://auth0team.atlassian.net/browse/CAUTH-500

### Testing

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
