### PR TITLE
[SDK-1756] Remove HTML5 novalidate attribute from Lock form

### DIFF
--- a/src/__tests__/ui/box/__snapshots__/container.test.jsx.snap
+++ b/src/__tests__/ui/box/__snapshots__/container.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`Container when suppressSubmitOverlay is true it does not display the ov
     <form
       className="auth0-lock-widget"
       method="post"
+      noValidate={true}
       onSubmit={[Function]}
     >
       <div

--- a/src/ui/box/container.jsx
+++ b/src/ui/box/container.jsx
@@ -209,7 +209,12 @@ export default class Container extends React.Component {
       <div className={className} lang={this.props.language}>
         {overlay}
         <div className="auth0-lock-center">
-          <form className="auth0-lock-widget" method="post" onSubmit={::this.handleSubmit}>
+          <form
+            className="auth0-lock-widget"
+            method="post"
+            noValidate
+            onSubmit={::this.handleSubmit}
+          >
             {avatar && <Avatar imageUrl={avatar} />}
             {closeHandler && <CloseButton onClick={::this.handleClose} />}
             <div className="auth0-lock-widget-container">


### PR DESCRIPTION
### Changes

This change removes the HTML5 `novalidate` attribute, preventing the browser
from performing its own native validation and allowing Lock to do its
validation instead.

The native validation prevented users from submitting email addresses such as
"téstiñg.üsêr@example.com", which is a valid value on the Auth0 server side.

### References

Raised through internal service desk ticket.

### Testing

Tested manually. Cannot test through integration testing as the client-side
native validation does not kick in.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] All code quality tools/guidelines have been run/followed
* [X] All relevant assets have been compiled
* [X] All active GitHub checks have passed
