### PR TITLE
Release 11.24.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [v11.24.4](https://github.com/auth0/lock/tree/v11.24.4) (2020-07-02)
+[Full Changelog](https://github.com/auth0/lock/compare/v11.24.3...v11.24.4)
+
+
+**Changed**
+- [SDK-1756] Remove HTML5 novalidate attribute from Lock form [\#1890](https://github.com/auth0/lock/pull/1890) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- Bump auth0-js to 9.13.3 [\#1889](https://github.com/auth0/lock/pull/1889) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
+
 ## [v11.24.3](https://github.com/auth0/lock/tree/v11.24.3) (2020-06-19)
 [Full Changelog](https://github.com/auth0/lock/compare/v11.24.2...v11.24.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 
 **Changed**
-- [SDK-1756] Remove HTML5 novalidate attribute from Lock form [\#1890](https://github.com/auth0/lock/pull/1890) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- [SDK-1756] Add HTML5 novalidate attribute to Lock form to remove native browser validation [\#1890](https://github.com/auth0/lock/pull/1890) ([stevehobbsdev](https://github.com/stevehobbsdev))
 - Bump auth0-js to 9.13.3 [\#1889](https://github.com/auth0/lock/pull/1889) ([stevehobbsdev](https://github.com/stevehobbsdev))
 
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ From CDN
 
 ```html
 <!-- Latest patch release (recommended for production) -->
-<script src="https://cdn.auth0.com/js/lock/11.24.3/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/11.24.4/lock.min.js"></script>
 ```
 
 From [npm](https://npmjs.org)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.24.3",
+  "version": "11.24.4",
   "main": "build/lock.js",
   "ignore": [
     "lib-cov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.24.3",
+  "version": "11.24.4",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION
**Changed**
- [SDK-1756] Add HTML5 novalidate attribute to Lock form to remove native browser validation [\#1890](https://github.com/auth0/lock/pull/1890) ([stevehobbsdev](https://github.com/stevehobbsdev))
- Bump auth0-js to 9.13.3 [\#1889](https://github.com/auth0/lock/pull/1889) ([stevehobbsdev](https://github.com/stevehobbsdev))

[SDK-1756]: https://auth0team.atlassian.net/browse/SDK-1756