### PR TITLE
Release v11.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v11.25.0](https://github.com/auth0/lock/tree/v11.25.0) (2020-07-09)
+[Full Changelog](https://github.com/auth0/lock/compare/v11.24.5...v11.25.0)
+
+
+**Added**
+- [SDK-1710] Allow Lock to use connection display name field from client configuration file [\#1896](https://github.com/auth0/lock/pull/1896) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
+
 ## [v11.24.5](https://github.com/auth0/lock/tree/v11.24.5) (2020-07-03)
 [Full Changelog](https://github.com/auth0/lock/compare/v11.24.4...v11.24.5)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ From CDN
 
 ```html
 <!-- Latest patch release (recommended for production) -->
-<script src="https://cdn.auth0.com/js/lock/11.24.5/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/11.25.0/lock.min.js"></script>
 ```
 
 From [npm](https://npmjs.org)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.24.5",
+  "version": "11.25.0",
   "main": "build/lock.js",
   "ignore": [
     "lib-cov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.24.5",
+  "version": "11.25.0",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION
**Added**
- [SDK-1710] Allow Lock to use connection display name field from client configuration file [\#1896](https://github.com/auth0/lock/pull/1896) ([stevehobbsdev](https://github.com/stevehobbsdev))

[SDK-1710]: https://auth0team.atlassian.net/browse/SDK-1710