### PR TITLE
[SDK-1809] Connection display name is used even when no IdP domains are available

### DIFF
--- a/src/__tests__/connection/enterprise/__snapshots__/quick_auth_screen.test.jsx.snap
+++ b/src/__tests__/connection/enterprise/__snapshots__/quick_auth_screen.test.jsx.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`The quick auth screen renders the connection using the connection display name when preferConnectionDisplayName is true and there are no IdP domains configured 1`] = `
+<div
+  className="auth0-lock-last-login-pane"
+>
+  <a
+    className="auth0-lock-social-button auth0-lock-social-big-button"
+    data-provider="auth0"
+    onClick={[Function]}
+    style={Object {}}
+    type="button"
+  >
+    <div
+      className="auth0-lock-social-button-icon"
+      style={Object {}}
+    />
+    <div
+      className="auth0-lock-social-button-text"
+      style={Object {}}
+    >
+      loginAtLabel,My Connection
+    </div>
+  </a>
+  <div
+    className="auth0-loading-container"
+  >
+    <div
+      className="auth0-loading"
+    />
+  </div>
+</div>
+`;
+
 exports[`The quick auth screen renders the connection using the connection domain when preferConnectionDisplayName is true, but no display name available 1`] = `
 <div
   className="auth0-lock-last-login-pane"

--- a/src/__tests__/connection/enterprise/quick_auth_screen.test.jsx
+++ b/src/__tests__/connection/enterprise/quick_auth_screen.test.jsx
@@ -85,6 +85,23 @@ describe('The quick auth screen', () => {
     expectComponent(<Component {...defaultProps} />).toMatchSnapshot();
   });
 
+  it('renders the connection using the connection display name when preferConnectionDisplayName is true and there are no IdP domains configured', () => {
+    const mockConnection = I.fromJS({
+      name: 'Test',
+      displayName: 'My Connection'
+    });
+
+    const { quickAuthConnection } = require('connection/enterprise');
+    quickAuthConnection.mockReturnValue(mockConnection);
+
+    const l = require('core/index');
+    l.ui.preferConnectionDisplayName.mockReturnValue(true);
+
+    const Component = getComponent();
+
+    expectComponent(<Component {...defaultProps} />).toMatchSnapshot();
+  });
+
   it('renders the connection using the connection name when there is no domain available', () => {
     const mockConnection = I.fromJS({
       name: 'Test'

--- a/src/connection/enterprise/quick_auth_screen.jsx
+++ b/src/connection/enterprise/quick_auth_screen.jsx
@@ -23,18 +23,14 @@ const Component = ({ i18n, model }) => {
   const connectionDomain = connection.getIn(['domains', 0]);
   const connectionDisplayName = connection.getIn(['displayName']) || null;
   const preferConnectionDisplayName = l.ui.preferConnectionDisplayName(model);
-
   const buttonTheme = theme.get(connection.get('name'));
 
   const buttonLabel =
     (buttonTheme && buttonTheme.get('displayName')) ||
-    (connectionDomain &&
-      i18n.str(
-        'loginAtLabel',
-        preferConnectionDisplayName && connectionDisplayName
-          ? connectionDisplayName
-          : connectionDomain
-      )) ||
+    (preferConnectionDisplayName &&
+      connectionDisplayName &&
+      i18n.str('loginAtLabel', connectionDisplayName)) ||
+    (connectionDomain && i18n.str('loginAtLabel', connectionDomain)) ||
     i18n.str('loginAtLabel', connectionName);
 
   const primaryColor = buttonTheme && buttonTheme.get('primaryColor');


### PR DESCRIPTION
### Changes

There is a bug in the current Lock release that causes Lock to ignore the
connection display name if there are no IdP Domains configured for the
connection, even if `preferConnectionDisplayName` is `true` - this PR fixes
that so that the connection display name is used despite there being no domains
configured.

### References

Raised through internal service desk ticket.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] All code quality tools/guidelines have been run/followed
* [X] All relevant assets have been compiled
* [X] All active GitHub checks have passed
