### PR TITLE
Release v11.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v11.25.1](https://github.com/auth0/lock/tree/v11.25.1) (2020-07-14)
+[Full Changelog](https://github.com/auth0/lock/compare/v11.25.0...v11.25.1)
+
+
+**Fixed**
+- [SDK-1809] Connection display name is used even when no IdP domains are available [\#1898](https://github.com/auth0/lock/pull/1898) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
+
 ## [v11.25.0](https://github.com/auth0/lock/tree/v11.25.0) (2020-07-09)
 [Full Changelog](https://github.com/auth0/lock/compare/v11.24.5...v11.25.0)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ From CDN
 
 ```html
 <!-- Latest patch release (recommended for production) -->
-<script src="https://cdn.auth0.com/js/lock/11.25.0/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/11.25.1/lock.min.js"></script>
 ```
 
 From [npm](https://npmjs.org)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.25.0",
+  "version": "11.25.1",
   "main": "build/lock.js",
   "ignore": [
     "lib-cov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.25.0",
+  "version": "11.25.1",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION
**Fixed**
- [SDK-1809] Connection display name is used even when no IdP domains are available [\#1898](https://github.com/auth0/lock/pull/1898) ([stevehobbsdev](https://github.com/stevehobbsdev))


[SDK-1809]: https://auth0team.atlassian.net/browse/SDK-1809