### PR TITLE
Release v11.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [v11.26.2](https://github.com/auth0/lock/tree/v11.26.2) (2020-08-12)
+[Full Changelog](https://github.com/auth0/lock/compare/v11.26.1...v11.26.2)
+
+**Fixed**
+- i18n asset recovery [\#1912](https://github.com/auth0/lock/pull/1912) ([davidpatrick](https://github.com/davidpatrick))
+- [SDK-1813] Send connection scope config to enterprise connections [\#1910](https://github.com/auth0/lock/pull/1910) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
+**Security**
+- [Security] Bump elliptic from 6.4.1 to 6.5.3 [\#1909](https://github.com/auth0/lock/pull/1909) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))
+
+
 ## [v11.26.1](https://github.com/auth0/lock/tree/v11.26.1) (2020-07-23)
 [Full Changelog](https://github.com/auth0/lock/compare/v11.26.0...v11.26.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [Full Changelog](https://github.com/auth0/lock/compare/v11.26.1...v11.26.2)
 
 **Fixed**
-- i18n asset recovery [\#1912](https://github.com/auth0/lock/pull/1912) ([davidpatrick](https://github.com/davidpatrick))
+- Fallback to default language dictionary when the language file cannot be loaded [\#1912](https://github.com/auth0/lock/pull/1912) ([davidpatrick](https://github.com/davidpatrick))
 - [SDK-1813] Send connection scope config to enterprise connections [\#1910](https://github.com/auth0/lock/pull/1910) ([stevehobbsdev](https://github.com/stevehobbsdev))
 
 **Security**

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ From CDN
 
 ```html
 <!-- Latest patch release (recommended for production) -->
-<script src="https://cdn.auth0.com/js/lock/11.26.1/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/11.26.2/lock.min.js"></script>
 ```
 
 From [npm](https://npmjs.org)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.26.1",
+  "version": "11.26.2",
   "main": "build/lock.js",
   "ignore": [
     "lib-cov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.26.1",
+  "version": "11.26.2",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION
**Fixed**
- Fallback to default language dictionary when the language file cannot be loaded [\#1912](https://github.com/auth0/lock/pull/1912) ([davidpatrick](https://github.com/davidpatrick))
- [SDK-1813] Send connection scope config to enterprise connections [\#1910](https://github.com/auth0/lock/pull/1910) ([stevehobbsdev](https://github.com/stevehobbsdev))

**Security**
- [Security] Bump elliptic from 6.4.1 to 6.5.3 [\#1909](https://github.com/auth0/lock/pull/1909) ([dependabot-preview[bot]](https://github.com/apps/dependabot-preview))

[SDK-1813]: https://auth0team.atlassian.net/browse/SDK-1813