### PR TITLE
Remove top padding from wrapper element

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -185,7 +185,7 @@ loadingSize = 30px
     overflow-x: auto
 
   .auth0-lock-content-body-wrapper
-    padding-top 10px
+    // padding-top 10px
 
   .auth0-lock-close-button, .auth0-lock-back-button
     -webkit-box-sizing content-box !important


### PR DESCRIPTION
### Changes

This PR removes some slight top padding from the top of the form wrapper, which
has an effect on any error message panels that are being shown.

The removal of the padding doesn't affect the UI too badly so I've decided to
just remove it.

**Without error**

![image](https://user-images.githubusercontent.com/766403/97023124-f65e3900-154c-11eb-956a-69f81c1625db.png)

**With error**

![image](https://user-images.githubusercontent.com/766403/97023085-e7778680-154c-11eb-815e-11dc38f4e045.png)

### References

Fixes #1933

### Testing

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] All code quality tools/guidelines have been run/followed
* [X] All relevant assets have been compiled
* [X] All active GitHub checks have passed
