### PR TITLE
Release 11.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 **Fixed**
 - Remove top padding from wrapper element [\#1939](https://github.com/auth0/lock/pull/1939) ([stevehobbsdev](https://github.com/stevehobbsdev))
 - Remove javascript:void(0) from links that do not navigate [\#1938](https://github.com/auth0/lock/pull/1938) ([stevehobbsdev](https://github.com/stevehobbsdev))
-- Respect showTerms option for passworless [\#1931](https://github.com/auth0/lock/pull/1931) ([saltukalakus](https://github.com/saltukalakus))
+- Respect showTerms option for passwordless [\#1931](https://github.com/auth0/lock/pull/1931) ([saltukalakus](https://github.com/saltukalakus))
 
 
 ## [v11.27.0](https://github.com/auth0/lock/tree/v11.27.0) (2020-09-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v11.27.1](https://github.com/auth0/lock/tree/v11.27.1) (2020-10-26)
+[Full Changelog](https://github.com/auth0/lock/compare/v11.27.0...v11.27.1)
+
+
+**Fixed**
+- Remove top padding from wrapper element [\#1939](https://github.com/auth0/lock/pull/1939) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- Remove javascript:void(0) from links that do not navigate [\#1938](https://github.com/auth0/lock/pull/1938) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- Respect showTerms option for passworless [\#1931](https://github.com/auth0/lock/pull/1931) ([saltukalakus](https://github.com/saltukalakus))
+
+
 ## [v11.27.0](https://github.com/auth0/lock/tree/v11.27.0) (2020-09-18)
 [Full Changelog](https://github.com/auth0/lock/compare/v11.26.3...v11.27.0)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ From CDN
 
 ```html
 <!-- Latest patch release (recommended for production) -->
-<script src="https://cdn.auth0.com/js/lock/11.27.0/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/11.27.1/lock.min.js"></script>
 ```
 
 From [npm](https://npmjs.org)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.27.0",
+  "version": "11.27.1",
   "main": "build/lock.js",
   "ignore": [
     "lib-cov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.27.0",
+  "version": "11.27.1",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION
**Fixed**
- Remove top padding from wrapper element [\#1939](https://github.com/auth0/lock/pull/1939) ([stevehobbsdev](https://github.com/stevehobbsdev))
- Remove javascript:void(0) from links that do not navigate [\#1938](https://github.com/auth0/lock/pull/1938) ([stevehobbsdev](https://github.com/stevehobbsdev))
- Respect showTerms option for passwordless [\#1931](https://github.com/auth0/lock/pull/1931) ([saltukalakus](https://github.com/saltukalakus))
