### PR TITLE
Disable form submit manually for passwordless Safari

### DIFF
--- a/src/__tests__/ui/box/container.test.jsx
+++ b/src/__tests__/ui/box/container.test.jsx
@@ -54,6 +54,24 @@ describe('Container', () => {
     expect(mock.calls.length).toBe(0);
   });
 
+  it('should submit the form when the submit button is not disabled', () => {
+    const c = getContainer({ disableSubmitButton: false });
+    const connectionResolverMock = jest.fn();
+    require('core/index').connectionResolver = () => connectionResolverMock;
+
+    c.handleSubmit(mockEvent);
+    expect(connectionResolverMock).toHaveBeenCalled();
+  });
+
+  it('should not submit the form when the submit button is disabled', () => {
+    const c = getContainer({ disableSubmitButton: true });
+    const connectionResolverMock = jest.fn();
+    require('core/index').connectionResolver = () => connectionResolverMock;
+
+    c.handleSubmit(mockEvent);
+    expect(connectionResolverMock).not.toHaveBeenCalled();
+  });
+
   describe('with a custom `connectionResolver`', () => {
     let connectionResolverMock;
     let setResolvedConnectionMock;

--- a/src/ui/box/container.jsx
+++ b/src/ui/box/container.jsx
@@ -99,6 +99,11 @@ export default class Container extends React.Component {
 
   handleSubmit(e) {
     e.preventDefault();
+    // Safari does not disable form submits when the submit button is disabled
+    // on single input (eg. passwordless) forms, so disable it manually.
+    if (this.props.disableSubmitButton) {
+      return;
+    }
 
     this.checkConnectionResolver(() => {
       const { submitHandler } = this.props;


### PR DESCRIPTION
### Changes

The passwordless login window does not honor the "mustAcceptTerms" flag set to true on Safari. A user is still able to hit the return key to send the magic link. (note that the submit button remains correctly disabled). This issue is not present on the latest version of chrome.

Lock relys on the submit button being disabled to prevent a user from submitting the form when they hit Enter.

This works on Chrome and forms with more than one field (which is why it only effects Passwordless), but Safari has a rule that states: If you have one text input Safari will submit the form regardless of a disabled submit button. If you have two text inputs or more Safari will not submit the form if the submit button is dsiabled.

We can manually prevent the form from submitting by adding an additional check for `props.disableSubmitButton` - which should make the browsers behave the same. The risk is that we get a false positive if `props.disableSubmitButton` is inadvertently set to `true`, but I can't see anywhere in Lock where that would be the case.

### References

Safari bugs: https://bugs.webkit.org/show_bug.cgi?id=9756 and https://bugs.webkit.org/show_bug.cgi?id=16886
fixes #1967 

### Testing

I've added some unit tests and checked that the regular Login/Signup forms are not inadvertently blocked when the `mustAcceptTerms` is disabled and the user switches between form types.

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] All code quality tools/guidelines have been run/followed
* [ ] All relevant assets have been compiled
* [ ] All active GitHub checks have passed
