### PR TITLE
Remove padding from screen tabs

### DIFF
--- a/css/index.styl
+++ b/css/index.styl
@@ -182,9 +182,6 @@ loadingSize = 30px
     +breakpoint("mobile")
       overflow-x inherit
 
-  .auth0-lock-content-body-wrapper
-    padding-top 10px
-
   .auth0-lock-close-button, .auth0-lock-back-button
     -webkit-box-sizing content-box !important
     -moz-box-sizing content-box !important


### PR DESCRIPTION
### Changes

This PR removes the padding from the screen tabs control that was mistakenly
reintroduced in #1949.

Fixes #1970.

**Before**

![image](https://user-images.githubusercontent.com/766403/109790861-ba796580-7c09-11eb-8469-2c10510f75a3.png)

**After**

![image](https://user-images.githubusercontent.com/766403/109790663-8c942100-7c09-11eb-8347-76c8137bce54.png)

### Testing

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] All code quality tools/guidelines have been run/followed
* [X] All relevant assets have been compiled
* [X] All active GitHub checks have passed
