### PR TITLE
Fixes typo "assests" to "assets"

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ var options = {
     placeholder: "enter your address",
     // The following properties are optional
     ariaLabel: "Address",
-    icon: "https://example.com/assests/address_icon.png",
+    icon: "https://example.com/assets/address_icon.png",
     prefill: "street 123",
     validator: function(address) {
       return {
@@ -475,7 +475,7 @@ var options = {
     ],
     // The following properties are optional
     ariaLabel: "Location",
-    icon: "https://example.com/assests/location_icon.png",
+    icon: "https://example.com/assets/location_icon.png",
     prefill: "us"
   }]
 }
@@ -495,7 +495,7 @@ var options = {
       cb(null, options);
     },
     ariaLabel: "Location",
-    icon: "https://example.com/assests/location_icon.png",
+    icon: "https://example.com/assets/location_icon.png",
     prefill: function(cb) {
       // obtain prefill, in case of error you call cb with the error in the
       // first arg instead of null


### PR DESCRIPTION
### Changes

This is simply changing a typo in the README from `assests` to `assets`.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
