### PR TITLE
[SDK-2412] Add event for SSO data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Lock will emit events during its lifecycle.
 - `signup error`: emitted when signup fails. Has the error as an argument.
 - `federated login`: emitted when the user clicks on a social connection button. Has the connection name and the strategy as arguments.
 - `sso login`: emitted when the user clicks on an enterprise SSO connection button. Has the lock ID, connection object, and field name as arguments.
+- `ssodata fetched`: emitted when the SSOData endpoint was called, usually as a result of an internal `checkSession` call. Has the error and the SSOData object as arguments.
 
 ### show(options)
 

--- a/src/__tests__/core/remote_data.test.js
+++ b/src/__tests__/core/remote_data.test.js
@@ -1,38 +1,47 @@
+import * as l from '../../core/index';
+
 const getSyncRemoteData = () => require('core/remote_data').syncRemoteData;
+
+jest.mock('sync', () => jest.fn());
+
+jest.mock('connection/enterprise', () => ({
+  isADEnabled: () => true
+}));
+
+jest.mock('core/index', () => ({
+  useTenantInfo: () => true,
+  id: () => 'id',
+  emitEvent: jest.fn()
+}));
+
+jest.mock('core/sso/data', () => ({
+  fetchSSOData: jest.fn((id, adEnabled, cb) => cb(null, {}))
+}));
 
 describe('remote_data.syncRemoteData()', () => {
   beforeEach(() => {
-    jest.resetModules();
-
-    jest.mock('sync', () => jest.fn());
-
-    jest.mock('connection/enterprise', () => ({
-      isADEnabled: () => true
-    }));
-
-    jest.mock('core/index', () => ({
-      useTenantInfo: () => true,
-      id: () => 'id'
-    }));
-
-    jest.mock('core/sso/data', () => ({
-      fetchSSOData: jest.fn()
-    }));
+    jest.resetAllMocks();
   });
+
   describe('calls getSSOData with AD information', () => {
     [true, false].forEach(isAdEnabled => {
       it(`when isADEnabled is ${isAdEnabled}`, () => {
         require('connection/enterprise').isADEnabled = () => isAdEnabled;
+
         const syncRemoteData = getSyncRemoteData();
         syncRemoteData();
+
         const ssoCall = require('sync').mock.calls.find(c => c[1] === 'sso');
-        ssoCall[2].syncFn('model', 'callback');
+        ssoCall[2].syncFn('model', jest.fn());
+
         const [
           id,
           sendADInformation,
           callback
         ] = require('core/sso/data').fetchSSOData.mock.calls[0];
+
         expect(sendADInformation).toBe(isAdEnabled);
+        expect(l.emitEvent).toHaveBeenCalledWith('model', 'ssodata fetched', expect.anything());
       });
     });
   });

--- a/src/__tests__/core/remote_data.test.js
+++ b/src/__tests__/core/remote_data.test.js
@@ -20,7 +20,7 @@ jest.mock('core/sso/data', () => ({
 
 describe('remote_data.syncRemoteData()', () => {
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   describe('calls getSSOData with AD information', () => {
@@ -34,11 +34,7 @@ describe('remote_data.syncRemoteData()', () => {
         const ssoCall = require('sync').mock.calls.find(c => c[1] === 'sso');
         ssoCall[2].syncFn('model', jest.fn());
 
-        const [
-          id,
-          sendADInformation,
-          callback
-        ] = require('core/sso/data').fetchSSOData.mock.calls[0];
+        const [, sendADInformation, ,] = require('core/sso/data').fetchSSOData.mock.calls[0];
 
         expect(sendADInformation).toBe(isAdEnabled);
         expect(l.emitEvent).toHaveBeenCalledWith('model', 'ssodata fetched', expect.anything());

--- a/src/core.js
+++ b/src/core.js
@@ -55,7 +55,8 @@ export default class Base extends EventEmitter {
       'socialOrPhoneNumber submit',
       'socialOrEmail submit',
       'vcode submit',
-      'federated login'
+      'federated login',
+      'ssodata fetched'
     ];
 
     this.id = idu.incremental();

--- a/src/core.js
+++ b/src/core.js
@@ -56,7 +56,8 @@ export default class Base extends EventEmitter {
       'socialOrEmail submit',
       'vcode submit',
       'federated login',
-      'ssodata fetched'
+      'ssodata fetched',
+      'sso login'
     ];
 
     this.id = idu.incremental();

--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -27,7 +27,7 @@ export function syncRemoteData(m) {
     syncFn: (m, cb) => {
       fetchSSOData(l.id(m), isADEnabled(m), (...args) => {
         l.emitEvent(m, 'ssodata fetched', args);
-        cb();
+        cb(...args);
       });
     },
     successFn: (m, result) => m.mergeIn(['sso'], Immutable.fromJS(result)),

--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -24,7 +24,12 @@ export function syncRemoteData(m) {
   m = sync(m, 'sso', {
     conditionFn: m => l.auth.sso(m) && l.ui.rememberLastLogin(m),
     waitFn: m => isSuccess(m, 'client'),
-    syncFn: (m, cb) => fetchSSOData(l.id(m), isADEnabled(m), cb),
+    syncFn: (m, cb) =>
+      fetchSSOData(l.id(m), isADEnabled(m), (...args) => {
+        console.log('Emitting', isADEnabled(m));
+        l.emitEvent(m, 'ssodata fetched', args);
+        cb();
+      }),
     successFn: (m, result) => m.mergeIn(['sso'], Immutable.fromJS(result)),
     errorFn: (m, error) => {
       if (error.error === 'consent_required') {

--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -24,12 +24,12 @@ export function syncRemoteData(m) {
   m = sync(m, 'sso', {
     conditionFn: m => l.auth.sso(m) && l.ui.rememberLastLogin(m),
     waitFn: m => isSuccess(m, 'client'),
-    syncFn: (m, cb) =>
+    syncFn: (m, cb) => {
       fetchSSOData(l.id(m), isADEnabled(m), (...args) => {
-        console.log('Emitting', isADEnabled(m));
         l.emitEvent(m, 'ssodata fetched', args);
         cb();
-      }),
+      });
+    },
     successFn: (m, result) => m.mergeIn(['sso'], Immutable.fromJS(result)),
     errorFn: (m, error) => {
       if (error.error === 'consent_required') {

--- a/support/index.html
+++ b/support/index.html
@@ -35,6 +35,7 @@
         <div class="col-sm-12">
           <div id="btn-show-lock" class="btn btn-default">Show Lock</div>
           <div id="btn-show-passwordless" class="btn btn-default">Show Lock+Passwordless</div>
+          <div id="btn-logout" class="btn btn-default">Log out</div>
         </div>
       </div>
       <hr />
@@ -101,7 +102,8 @@
           'socialOrPhoneNumber submit',
           'socialOrEmail submit',
           'vcode submit',
-          'federated login'
+          'federated login',
+          'ssodata fetched'
         ];
         validEvents.forEach(function(e) {
           instance.on(e, function() {
@@ -187,6 +189,10 @@
             }
           });
         });
+        $('#btn-logout').on('click', function() {
+          var lock = new Auth0Lock(clientId, domain, defaultOptions);
+          lock.logout();
+        })
 
         //make sure we initialize Lock so we can parse the hash
         var lastUsed = window.localStorage.lastUsed;


### PR DESCRIPTION
### Changes

This PR adds a new event `ssodata fetched` that can be used to determine when the SSO Data endpoint is used as part of a call to `checkSession` (part of the API exposed by Auth0.js, which is used by Lock). An example of using this event might be to determine when the user has been silently authenticated, to then perform some other action.

### References

Raised by internal service desk ticket.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] All code quality tools/guidelines have been run/followed
* [ ] All relevant assets have been compiled
* [ ] All active GitHub checks have passed
