### PR TITLE
[SDK-2383] Support custom passwordless connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Initializes a new instance of `Auth0LockPasswordless` configured with your appli
 
 If both SMS and email passwordless connections are enabled [in the dashboard](https://manage.auth0.com/#/connections/passwordless), Lock will pick email by default. If you want to conditionally pick email or SMS, use the [`allowedConnections`](#ui-options) option, for example: `allowedConnections: ['sms']`.
 
+If using an [additional passwordless connection](#additional-passwordless-connections) that has been created through the Management API, you must specify the connection in `allowedConnections` and also enable the `useCustomPasswordlessConnection` flag in the options.
+
 For more information, read our [passwordless docs](https://auth0.com/docs/connections/passwordless).
 
 #### Example
@@ -370,6 +372,18 @@ var options = {
 #### Passwordless options
 
 - **passwordlessMethod {String}**: When using `Auth0LockPasswordless` with an email connection, you can use this option to pick between sending a [code](https://auth0.com/docs/connections/passwordless/spa-email-code) or a [magic link](https://auth0.com/docs/connections/passwordless/spa-email-link) to authenticate the user. Available values for email connections are `code` and `link`. Defaults to `code`. SMS passwordless connections will always use `code`.
+- **useCustomPasswordlessConnection {Boolean}**: Enables the use of a custom passwordless connection (see below).
+
+#### Additional passwordless connections
+
+By default, only two passwordless connections are available: `email` and `sms`. However, it is possible to create additional passwordless connections that employ the `email` or `sms` strategy through the Management API. To use these connections in Lock, you must:
+
+1. Specify the custom connection in the `allowedConnections` option, and
+2. Enable the `useCustomPasswordlessConnection` flag in the options
+
+Users logging in using this connection should then be associated with the correct passwordless connection and this can be verified in [the logs](https://manage.auth0.com/#/logs).
+
+**Note:** If you specify more than one connection in `allowedConnections`, the first one will always be used.
 
 #### Hooks
 

--- a/src/__tests__/connection/passwordless/__snapshots__/passwordless.actions.test.js.snap
+++ b/src/__tests__/connection/passwordless/__snapshots__/passwordless.actions.test.js.snap
@@ -258,6 +258,18 @@ Array [
 ]
 `;
 
+exports[`passwordless actions sendSMS() calls startPasswordless with a custom SMS connection 1`] = `
+Array [
+  "id",
+  Object {
+    "connection": "custom-connection",
+    "phoneNumber": "phoneNumberWithDiallingCode",
+    "send": "send",
+  },
+  [Function],
+]
+`;
+
 exports[`passwordless actions sendSMS() calls validateAndSubmit() 1`] = `
 Array [
   "id",

--- a/src/__tests__/connection/passwordless/__snapshots__/passwordless.actions.test.js.snap
+++ b/src/__tests__/connection/passwordless/__snapshots__/passwordless.actions.test.js.snap
@@ -116,6 +116,18 @@ Array [
 ]
 `;
 
+exports[`passwordless actions requestPasswordlessEmail() calls startPasswordless with a custom email connection name 1`] = `
+Array [
+  "id",
+  Object {
+    "connection": "custom-connection",
+    "email": "email",
+    "send": "send",
+  },
+  [Function],
+]
+`;
+
 exports[`passwordless actions requestPasswordlessEmail() calls validateAndSubmit() 1`] = `
 Array [
   "id",

--- a/src/__tests__/connection/passwordless/passwordless.actions.test.js
+++ b/src/__tests__/connection/passwordless/passwordless.actions.test.js
@@ -49,7 +49,8 @@ describe('passwordless actions', () => {
         })
       },
       emitAuthorizationErrorEvent: jest.fn(),
-      connections: jest.fn()
+      connections: jest.fn(),
+      useCustomPasswordlessConnection: jest.fn(() => false)
     }));
     jest.mock('store/index', () => ({
       read: jest.fn(() => 'model'),
@@ -84,6 +85,8 @@ describe('passwordless actions', () => {
           }
         ])
       );
+
+      require('core/index').useCustomPasswordlessConnection.mockReturnValue(true);
 
       require('core/actions').validateAndSubmit.mock.calls[0][2]('model');
       expectMockToMatch(require('core/web_api').startPasswordless, 1);

--- a/src/__tests__/connection/passwordless/passwordless.actions.test.js
+++ b/src/__tests__/connection/passwordless/passwordless.actions.test.js
@@ -1,3 +1,4 @@
+import Immutable from 'immutable';
 import passwordless from 'connection/passwordless/actions';
 import { expectMockToMatch } from 'testUtils';
 
@@ -47,7 +48,8 @@ describe('passwordless actions', () => {
           })
         })
       },
-      emitAuthorizationErrorEvent: jest.fn()
+      emitAuthorizationErrorEvent: jest.fn(),
+      connections: jest.fn()
     }));
     jest.mock('store/index', () => ({
       read: jest.fn(() => 'model'),
@@ -57,6 +59,8 @@ describe('passwordless actions', () => {
     }));
 
     actions = require('connection/passwordless/actions');
+
+    require('core/index').connections.mockImplementation(() => Immutable.fromJS([]));
   });
   describe('requestPasswordlessEmail()', () => {
     it('calls validateAndSubmit()', () => {
@@ -65,6 +69,22 @@ describe('passwordless actions', () => {
     });
     it('calls startPasswordless', () => {
       actions.requestPasswordlessEmail('id');
+      require('core/actions').validateAndSubmit.mock.calls[0][2]('model');
+      expectMockToMatch(require('core/web_api').startPasswordless, 1);
+    });
+    it('calls startPasswordless with a custom email connection name', () => {
+      actions.requestPasswordlessEmail('id');
+
+      require('core/index').connections.mockImplementation(() =>
+        Immutable.fromJS([
+          {
+            name: 'custom-connection',
+            strategy: 'email',
+            type: 'passwordless'
+          }
+        ])
+      );
+
       require('core/actions').validateAndSubmit.mock.calls[0][2]('model');
       expectMockToMatch(require('core/web_api').startPasswordless, 1);
     });

--- a/src/__tests__/connection/passwordless/passwordless.actions.test.js
+++ b/src/__tests__/connection/passwordless/passwordless.actions.test.js
@@ -166,6 +166,22 @@ describe('passwordless actions', () => {
       require('core/actions').validateAndSubmit.mock.calls[0][2]('model');
       expectMockToMatch(require('core/web_api').startPasswordless, 1);
     });
+    it('calls startPasswordless with a custom SMS connection', () => {
+      actions.sendSMS('id');
+
+      require('core/index').connections.mockImplementation(() =>
+        Immutable.fromJS([
+          {
+            name: 'custom-connection',
+            strategy: 'sms',
+            type: 'passwordless'
+          }
+        ])
+      );
+
+      require('core/actions').validateAndSubmit.mock.calls[0][2]('model');
+      expectMockToMatch(require('core/web_api').startPasswordless, 1);
+    });
     it('calls setPasswordlessStarted() on success', () => {
       actions.sendSMS('id');
       require('core/actions').validateAndSubmit.mock.calls[0][2]('model');

--- a/src/__tests__/connection/passwordless/passwordless.actions.test.js
+++ b/src/__tests__/connection/passwordless/passwordless.actions.test.js
@@ -182,7 +182,9 @@ describe('passwordless actions', () => {
         ])
       );
 
+      require('core/index').useCustomPasswordlessConnection.mockReturnValue(true);
       require('core/actions').validateAndSubmit.mock.calls[0][2]('model');
+
       expectMockToMatch(require('core/web_api').startPasswordless, 1);
     });
     it('calls setPasswordlessStarted() on success', () => {

--- a/src/__tests__/core/__snapshots__/index.test.js.snap
+++ b/src/__tests__/core/__snapshots__/index.test.js.snap
@@ -86,6 +86,7 @@ Object {
     "rememberLastLogin": true,
     "scrollGlobalMessagesIntoView": true,
   },
+  "useCustomPasswordlessConnection": false,
   "useTenantInfo": false,
 }
 `;

--- a/src/connection/passwordless/actions.js
+++ b/src/connection/passwordless/actions.js
@@ -68,8 +68,11 @@ function resendEmailError(id, error) {
 }
 
 function sendEmail(m, successFn, errorFn) {
+  const connections = l.connections(m, 'passwordless', 'email');
+  const connectionName = connections.size > 0 ? connections.first().get('name') : 'email';
+
   const params = {
-    connection: 'email',
+    connection: connectionName,
     email: c.getFieldValue(m, 'email'),
     send: send(m)
   };

--- a/src/connection/passwordless/actions.js
+++ b/src/connection/passwordless/actions.js
@@ -96,7 +96,10 @@ function sendEmail(m, successFn, errorFn) {
 export function sendSMS(id) {
   validateAndSubmit(id, ['phoneNumber'], m => {
     const connections = l.connections(m, 'passwordless', 'sms');
-    const connectionName = connections.size > 0 ? connections.first().get('name') : 'sms';
+    const connectionName =
+      connections.size > 0 && l.useCustomPasswordlessConnection(m)
+        ? connections.first().get('name')
+        : 'sms';
 
     const params = {
       connection: connectionName,

--- a/src/connection/passwordless/actions.js
+++ b/src/connection/passwordless/actions.js
@@ -69,7 +69,10 @@ function resendEmailError(id, error) {
 
 function sendEmail(m, successFn, errorFn) {
   const connections = l.connections(m, 'passwordless', 'email');
-  const connectionName = connections.size > 0 ? connections.first().get('name') : 'email';
+  const connectionName =
+    connections.size > 0 && l.useCustomPasswordlessConnection(m)
+      ? connections.first().get('name')
+      : 'email';
 
   const params = {
     connection: connectionName,

--- a/src/connection/passwordless/actions.js
+++ b/src/connection/passwordless/actions.js
@@ -92,8 +92,11 @@ function sendEmail(m, successFn, errorFn) {
 
 export function sendSMS(id) {
   validateAndSubmit(id, ['phoneNumber'], m => {
+    const connections = l.connections(m, 'passwordless', 'sms');
+    const connectionName = connections.size > 0 ? connections.first().get('name') : 'sms';
+
     const params = {
-      connection: 'sms',
+      connection: connectionName,
       phoneNumber: phoneNumberWithDiallingCode(m),
       send: send(m)
     };

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -29,6 +29,8 @@ export function setup(id, clientID, domain, options, hookRunner, emitEventFn, ha
       useTenantInfo: options.__useTenantInfo || false,
       hashCleanup: options.hashCleanup === false ? false : true,
       allowedConnections: Immutable.fromJS(options.allowedConnections || []),
+      useCustomPasswordlessConnection:
+        options.useCustomPasswordlessConnection === true ? true : false,
       ui: extractUIOptions(id, options),
       defaultADUsernameFromEmailPrefix:
         options.defaultADUsernameFromEmailPrefix === false ? false : true,
@@ -517,13 +519,22 @@ export function filterConnections(m) {
 
   const order = allowed.count() === 0 ? _ => 0 : c => allowed.indexOf(c.get('name'));
 
-  return tset(
+  m = tset(
     m,
     'connections',
     clientConnections(m).map(cs => {
       return cs.filter(c => order(c) >= 0).sort((c1, c2) => order(c1) - order(c2));
     })
   );
+
+  console.log(clientConnections(m).toJS());
+  console.log(connections(m).toJS());
+
+  return m;
+}
+
+export function useCustomPasswordlessConnection(m) {
+  return get(m, 'useCustomPasswordlessConnection');
 }
 
 export function runHook(m, str, ...args) {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -519,18 +519,13 @@ export function filterConnections(m) {
 
   const order = allowed.count() === 0 ? _ => 0 : c => allowed.indexOf(c.get('name'));
 
-  m = tset(
+  return tset(
     m,
     'connections',
     clientConnections(m).map(cs => {
       return cs.filter(c => order(c) >= 0).sort((c1, c2) => order(c1) - order(c2));
     })
   );
-
-  console.log(clientConnections(m).toJS());
-  console.log(connections(m).toJS());
-
-  return m;
 }
 
 export function useCustomPasswordlessConnection(m) {


### PR DESCRIPTION
This PR fixes an issue where custom/additional passwordless connections cannot be used from Lock.

Normally, only 1 email and 1 SMS passwordless connection can be created through the Manage dashboard. However, one can create additional passwordless connections using the Management API that use either the email or SMS strategy. Lock however has until now been hardcoded to always use `email` or `sms` connections and had no ability to use a custom passwordless connection that had been created.

This PR enables that scenario, behind a new option `useCustomPasswordlessConnection`. The flag is necessary as an opt-in, as this could otherwise be a breaking change for those who have additional passwordless connections set up in the dashboard but were unaware they were actually not being used.

To enable:

```js
var options = {
  allowedConnections: ['custom-email'],
  useCustomPasswordlessConnection: true
}

var lockPasswordless = new Auth0LockPasswordless(clientId, domain, options);
```

### References

Raised through an internal service desk ticket.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
