### PR TITLE
fix ESD-12716: move CSS display override to render function to fix recaptcha on sign-up

### DIFF
--- a/src/field/captcha/recaptchav2.jsx
+++ b/src/field/captcha/recaptchav2.jsx
@@ -74,7 +74,7 @@ export class ReCAPTCHA extends React.Component {
 
   render() {
     /*
-      This is a hack for the following conflicting css-rule:
+      This is an override for the following conflicting css-rule:
 
       @media screen and (max-width: 480px)
       html.auth0-lock-html body > * {
@@ -83,13 +83,17 @@ export class ReCAPTCHA extends React.Component {
     */
     const fixInterval = setInterval(() => {
       let iframes = Array.from(document.querySelectorAll(`iframe[title="recaptcha challenge"]`));
+
       iframes = iframes.filter(iframe => iframe.parentNode.parentNode.style.display !== 'block');
+
       if (iframes.length === 0) {
         return;
       }
+
       iframes.forEach(iframe => {
         iframe.parentNode.parentNode.style.display = 'block';
       });
+
       clearInterval(fixInterval);
     }, 300);
 

--- a/src/field/captcha/recaptchav2.jsx
+++ b/src/field/captcha/recaptchav2.jsx
@@ -65,22 +65,6 @@ export class ReCAPTCHA extends React.Component {
         'error-callback': this.erroredHandler,
         sitekey: this.props.sitekey
       });
-      /*
-        This is a hack for the following conflicting css-rule:
-
-        @media screen and (max-width: 480px)
-        html.auth0-lock-html body > * {
-            display: none;
-        }
-      */
-      const fixInterval = setInterval(() => {
-        const iframe = document.querySelector(`iframe[title="recaptcha challenge"]`);
-        if (!iframe) {
-          return;
-        }
-        iframe.parentNode.parentNode.style.display = 'block';
-        clearInterval(fixInterval);
-      }, 300);
     });
   }
 
@@ -89,7 +73,26 @@ export class ReCAPTCHA extends React.Component {
   }
 
   render() {
-    // style={{ border: !this.props.isValid ? '1px solid #dd4b39' : ''}}
+    /*
+      This is a hack for the following conflicting css-rule:
+
+      @media screen and (max-width: 480px)
+      html.auth0-lock-html body > * {
+          display: none;
+      }
+    */
+    const fixInterval = setInterval(() => {
+      let iframes = Array.from(document.querySelectorAll(`iframe[title="recaptcha challenge"]`));
+      iframes = iframes.filter(iframe => iframe.parentNode.parentNode.style.display !== 'block');
+      if (iframes.length === 0) {
+        return;
+      }
+      iframes.forEach(iframe => {
+        iframe.parentNode.parentNode.style.display = 'block';
+      });
+      clearInterval(fixInterval);
+    }, 300);
+
     return (
       <div
         className={


### PR DESCRIPTION
### Changes

Move CSS override for `display` to the `render` function to fix recaptcha on sign-up.

### References

Please include relevant links supporting this change such as a:

- ESD-12716

### Testing

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
* [x] All active GitHub checks have passed
