### PR TITLE
Release v11.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v11.29.1](https://github.com/auth0/lock/tree/v11.29.1) (2021-04-14)
+[Full Changelog](https://github.com/auth0/lock/compare/v11.29.0...v11.29.1)
+
+
+**Fixed**
+- fix ESD-12716: move CSS display override to render function to fix recaptcha on sign-up [\#1983](https://github.com/auth0/lock/pull/1983) ([jfromaniello](https://github.com/jfromaniello))
+
+
 ## [v11.29.0](https://github.com/auth0/lock/tree/v11.29.0) (2021-04-06)
 [Full Changelog](https://github.com/auth0/lock/compare/v11.28.1...v11.29.0)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ From CDN
 
 ```html
 <!-- Latest patch release (recommended for production) -->
-<script src="https://cdn.auth0.com/js/lock/11.29.0/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/11.29.1/lock.min.js"></script>
 ```
 
 From [npm](https://npmjs.org)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.29.0",
+  "version": "11.29.1",
   "main": "build/lock.js",
   "ignore": [
     "lib-cov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.29.0",
+  "version": "11.29.1",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION
[Full Changelog](https://github.com/auth0/lock/compare/v11.29.0...v11.29.1)

**Fixed**
- fix ESD-12716: move CSS display override to render function to fix recaptcha on sign-up [\#1983](https://github.com/auth0/lock/pull/1983) ([jfromaniello](https://github.com/jfromaniello))