### PR TITLE
feat: recaptcha enterprise on lockjs

### DIFF
--- a/src/__tests__/field/captcha.test.jsx
+++ b/src/__tests__/field/captcha.test.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import I from 'immutable';
 
 import CaptchaPane from '../../field/captcha/captcha_pane';
-import { ReCAPTCHA } from '../../field/captcha/recaptchav2';
+import { ReCAPTCHA } from '../../field/captcha/recaptcha';
 import CaptchaInput from '../../ui/input/captcha_input';
 
 const createLockMock = ({ provider = 'auth0', required = true, siteKey = '' } = {}) =>
@@ -48,6 +48,28 @@ describe('CaptchaPane', () => {
     });
 
     it('should render reCaptcha if provider is recaptchav2', () => {
+      expect(wrapper.find(ReCAPTCHA)).toHaveLength(1);
+    });
+
+    it('should pass the sitekey', () => {
+      expect(wrapper.find(ReCAPTCHA).props().sitekey).toBe('mySiteKey');
+    });
+  });
+
+  describe('recaptcha enterprise', () => {
+    let wrapper;
+    beforeAll(() => {
+      const lockMock = createLockMock({
+        provider: 'recaptcha_enterprise',
+        siteKey: 'mySiteKey'
+      });
+      const i8nMock = createI18nMock();
+      const onReloadMock = jest.fn();
+
+      wrapper = mount(<CaptchaPane lock={lockMock} onReload={onReloadMock} i18n={i8nMock} />);
+    });
+
+    it('should render reCaptcha if provider is recaptcha_enterprise', () => {
       expect(wrapper.find(ReCAPTCHA)).toHaveLength(1);
     });
 

--- a/src/__tests__/field/captcha/__snapshots__/recaptcha_enterprise.test.jsx.snap
+++ b/src/__tests__/field/captcha/__snapshots__/recaptcha_enterprise.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Recaptcha v2 should match the snapshot 1`] = `
+exports[`Recaptcha Enterprise should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ReCAPTCHA
@@ -9,7 +9,7 @@ ShallowWrapper {
         "id": "__lock-id__",
         "core": Immutable.Map {
           "captcha": Immutable.Map {
-            "provider": "recaptcha_v2",
+            "provider": "recaptcha_enterprise",
             "sitekey": "mySiteKey",
           },
           "transient": Immutable.Map {
@@ -23,7 +23,7 @@ ShallowWrapper {
     onChange={[Function]}
     onErrored={[Function]}
     onExpired={[Function]}
-    provider="recaptcha_v2"
+    provider="recaptcha_enterprise"
     sitekey="mySiteKey"
   />,
   Symbol(enzyme.__renderer__): Object {

--- a/src/__tests__/field/captcha/recaptcha_enterprise.test.jsx
+++ b/src/__tests__/field/captcha/recaptcha_enterprise.test.jsx
@@ -38,7 +38,7 @@ describe('Recaptcha Enterprise', () => {
       ReCAPTCHA.loadScript({ hl: 'en-US', provider: 'recaptcha_enterprise' }, document.body);
       expect(document.body.innerHTML).toContain('<div id="renderTest">');
       expect(document.body.innerHTML).toContain(
-        '<script src="https://www.google.com/recaptcha/enterprise.js?render=explicit'
+        '<script src="https://www.recaptcha.net/recaptcha/enterprise.js?render=explicit'
       );
     });
   });

--- a/src/__tests__/field/captcha/recaptcha_enterprise.test.jsx
+++ b/src/__tests__/field/captcha/recaptcha_enterprise.test.jsx
@@ -17,11 +17,11 @@ const createLockMock = ({ provider = 'none', sitekey = '' } = {}) =>
     }
   });
 
-describe('Recaptcha v2', () => {
+describe('Recaptcha Enterprise', () => {
   it('should match the snapshot', () => {
-    const mockLock = createLockMock({ provider: 'recaptcha_v2', sitekey: 'mySiteKey' });
+    const mockLock = createLockMock({ provider: 'recaptcha_enterprise', sitekey: 'mySiteKey' });
     const wrapper = shallow(
-      <ReCAPTCHA provider={'recaptcha_v2'} lock={mockLock} sitekey={'mySiteKey'} />
+      <ReCAPTCHA provider={'recaptcha_enterprise'} lock={mockLock} sitekey={'mySiteKey'} />
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -35,10 +35,10 @@ describe('Recaptcha v2', () => {
       document.getElementById('renderTest').remove();
     });
     it('injects the script', () => {
-      ReCAPTCHA.loadScript({ hl: 'en-US', provider: 'recaptcha_v2' }, document.body);
+      ReCAPTCHA.loadScript({ hl: 'en-US', provider: 'recaptcha_enterprise' }, document.body);
       expect(document.body.innerHTML).toContain('<div id="renderTest">');
       expect(document.body.innerHTML).toContain(
-        '<script src="https://www.google.com/recaptcha/api.js?hl=en-US'
+        '<script src="https://www.google.com/recaptcha/enterprise.js?render=explicit'
       );
     });
   });

--- a/src/__tests__/field/captcha/recaptchav2.test.jsx
+++ b/src/__tests__/field/captcha/recaptchav2.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import I from 'immutable';
 
-import { ReCAPTCHA } from '../../../field/captcha/recaptchav2';
+import { ReCAPTCHA } from '../../../field/captcha/recaptcha';
 
 const createLockMock = ({ provider = 'none', sitekey = '' } = {}) =>
   I.fromJS({

--- a/src/field/captcha/captcha_pane.jsx
+++ b/src/field/captcha/captcha_pane.jsx
@@ -7,7 +7,7 @@ import * as l from '../../core/index';
 import { swap, updateEntity } from '../../store/index';
 import * as captchaField from '../captcha';
 import { getFieldValue, isFieldVisiblyInvalid } from '../index';
-import { ReCAPTCHA } from './recaptchav2';
+import { ReCAPTCHA, isRecaptcha } from './recaptcha';
 
 export default class CaptchaPane extends React.Component {
   render() {
@@ -20,7 +20,9 @@ export default class CaptchaPane extends React.Component {
     const value = getFieldValue(lock, 'captcha');
     const isValid = !isFieldVisiblyInvalid(lock, 'captcha');
 
-    if (captcha.get('provider') === 'recaptcha_v2') {
+    const provider = captcha.get('provider');
+
+    if (isRecaptcha(provider)) {
       function handleChange(value) {
         swap(updateEntity, 'lock', lockId, captchaField.set, value);
       }
@@ -31,6 +33,7 @@ export default class CaptchaPane extends React.Component {
 
       return (
         <ReCAPTCHA
+          provider={provider}
           sitekey={captcha.get('siteKey')}
           onChange={handleChange}
           onExpired={reset}

--- a/src/field/captcha/recaptcha.jsx
+++ b/src/field/captcha/recaptcha.jsx
@@ -83,10 +83,10 @@ export class ReCAPTCHA extends React.Component {
   componentDidMount() {
     ReCAPTCHA.loadScript(this.props, document.body, (err, scriptNode) => {
       this.scriptNode = scriptNode;
-      const global = globalForProvider(this.props.provider);
+      const provider = globalForProvider(this.props.provider);
 
       // if this is enterprise then we change this to window.grecaptcha.enterprise.render
-      this.widgetId = global.render(this.ref.current, {
+      this.widgetId = provider.render(this.ref.current, {
         callback: this.changeHandler,
         'expired-callback': this.expiredHandler,
         'error-callback': this.erroredHandler,
@@ -96,8 +96,8 @@ export class ReCAPTCHA extends React.Component {
   }
 
   reset() {
-    const global = globalForProvider(this.props.provider);
-    global.reset(this.widgetId);
+    const provider = globalForProvider(this.props.provider);
+    provider.reset(this.widgetId);
   }
 
   render() {

--- a/src/field/captcha/recaptcha.jsx
+++ b/src/field/captcha/recaptcha.jsx
@@ -10,7 +10,7 @@ const RECAPTCHA_ENTERPRISE_PROVIDER = 'recaptcha_enterprise';
 export const isRecaptcha = provider =>
   provider === RECAPTCHA_ENTERPRISE_PROVIDER || provider === RECAPTCHA_V2_PROVIDER;
 
-const globalForProvider = provider => {
+const getRecaptchaProvider = provider => {
   switch (provider) {
     case RECAPTCHA_V2_PROVIDER:
       return window.grecaptcha;
@@ -83,7 +83,7 @@ export class ReCAPTCHA extends React.Component {
   componentDidMount() {
     ReCAPTCHA.loadScript(this.props, document.body, (err, scriptNode) => {
       this.scriptNode = scriptNode;
-      const provider = globalForProvider(this.props.provider);
+      const provider = getRecaptchaProvider(this.props.provider);
 
       // if this is enterprise then we change this to window.grecaptcha.enterprise.render
       this.widgetId = provider.render(this.ref.current, {
@@ -96,7 +96,7 @@ export class ReCAPTCHA extends React.Component {
   }
 
   reset() {
-    const provider = globalForProvider(this.props.provider);
+    const provider = getRecaptchaProvider(this.props.provider);
     provider.reset(this.widgetId);
   }
 

--- a/src/field/captcha/recaptcha.jsx
+++ b/src/field/captcha/recaptcha.jsx
@@ -24,7 +24,7 @@ const scriptForProvider = (provider, lang, callback) => {
     case RECAPTCHA_V2_PROVIDER:
       return `https://www.google.com/recaptcha/api.js?hl=${lang}&onload=${callback}`;
     case RECAPTCHA_ENTERPRISE_PROVIDER:
-      return `https://www.google.com/recaptcha/enterprise.js?render=explicit&hl=${lang}&onload=${callback}`;
+      return `https://www.recaptcha.net/recaptcha/enterprise.js?render=explicit&hl=${lang}&onload=${callback}`;
   }
 };
 

--- a/test/captcha_signup.test.js
+++ b/test/captcha_signup.test.js
@@ -109,7 +109,7 @@ describe('captcha on signup', function() {
     });
   });
 
-  describe('recaptchav2', () => {
+  describe('recaptcha', () => {
     describe('when the api returns a new challenge', function() {
       beforeEach(function(done) {
         this.stub = h.stubGetChallenge([recaptchav2Response]);


### PR DESCRIPTION
### Changes

- Support enterprise recaptcha on lockjs.


### References

[Corresponding PR on universal login prompts](https://github.com/auth0/universal-login-prompts/pull/1080)


### Testing

No flow changes - allows a captcha provider of recaptcha_enterprise to render a recaptcha widget

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] All code quality tools/guidelines have been run/followed
* [ ] All relevant assets have been compiled
* [ ] All active GitHub checks have passed
