### PR TITLE
[SDK-2588] Avoid multiple simultaneous HTTP calls

### DIFF
--- a/src/field/email/email_pane.jsx
+++ b/src/field/email/email_pane.jsx
@@ -37,13 +37,14 @@ export default class EmailPane extends React.Component {
     // TODO: invalidErrorHint and blankErrorHint are deprecated.
     // They are kept for backwards compatibiliy in the code for the customers overwriting
     // them with languageDictionary. They can be removed in the next major release.
-    const errMessage = value ? i18n.str('invalidErrorHint') || i18n.str('invalidEmailErrorHint')
-        : i18n.str('blankErrorHint') || i18n.str('blankEmailErrorHint');
+    const errMessage = value
+      ? i18n.str('invalidErrorHint') || i18n.str('invalidEmailErrorHint')
+      : i18n.str('blankErrorHint') || i18n.str('blankEmailErrorHint');
     const invalidHint = field.get('invalidHint') || errMessage;
 
     let isValid = (!forceInvalidVisibility || valid) && !c.isFieldVisiblyInvalid(lock, 'email');
     // Hide the error message for the blank email in Enterprise HRD only mode when the password field is hidden.
-    isValid = (forceInvalidVisibility && value === '') ? true : isValid;
+    isValid = forceInvalidVisibility && value === '' ? true : isValid;
 
     return (
       <EmailInput
@@ -54,6 +55,7 @@ export default class EmailPane extends React.Component {
         onChange={::this.handleChange}
         placeholder={placeholder}
         autoComplete={allowAutocomplete}
+        disabled={l.submitting(lock)}
       />
     );
   }

--- a/src/field/username/username_pane.jsx
+++ b/src/field/username/username_pane.jsx
@@ -80,6 +80,7 @@ export default class UsernamePane extends React.Component {
         onChange={::this.handleChange}
         placeholder={placeholder}
         autoComplete={allowAutocomplete}
+        disabled={l.submitting(lock)}
       />
     );
   }

--- a/src/ui/box/container.jsx
+++ b/src/ui/box/container.jsx
@@ -101,7 +101,7 @@ export default class Container extends React.Component {
     e.preventDefault();
     // Safari does not disable form submits when the submit button is disabled
     // on single input (eg. passwordless) forms, so disable it manually.
-    if (this.props.disableSubmitButton) {
+    if (this.props.isSubmitting) {
       return;
     }
 

--- a/src/ui/input/email_input.jsx
+++ b/src/ui/input/email_input.jsx
@@ -11,14 +11,15 @@ export default class EmailInput extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    const { invalidHint, isValid, value, onChange } = this.props;
+    const { invalidHint, isValid, value, disabled, onChange } = this.props;
     const { focused } = this.state;
 
     return (
       invalidHint != nextProps.invalidHint ||
       isValid != nextProps.isValid ||
       value != nextProps.value ||
-      focused != nextState.focused
+      focused != nextState.focused ||
+      disabled != nextProps.disabled
     );
   }
 

--- a/src/ui/input/username_input.jsx
+++ b/src/ui/input/username_input.jsx
@@ -11,14 +11,15 @@ export default class UsernameInput extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    const { invalidHint, isValid, value, onChange } = this.props;
+    const { invalidHint, isValid, value, disabled, onChange } = this.props;
     const { focused } = this.state;
 
     return (
       invalidHint != nextProps.invalidHint ||
       isValid != nextProps.isValid ||
       value != nextProps.value ||
-      focused != nextState.focused
+      focused != nextState.focused ||
+      disabled != nextProps.disabled
     );
   }
 


### PR DESCRIPTION
There appears to be a bug in lock that can result in multiple, simultaneuour, HTTP calls to the /login endpoint(s).

**To reproduce:**
In lock, try the following In Chrome:
• Ensure username/email and password are filled in
• Focus the username/email field
• hit enter twice fast

Network tab should show multiple calls to login.

In safari, this issue exists on both fields, not only username/email.

The reason the behavior is different in Chrome and Safari seems to be because Chrome avoids submitting the form when pressing enter in a disabled input. Password is the only field that is getting disabled when the form is being submitted.

The fix here is to ensure both username and email fields are also disabled while the form is being submitted.

On safari however, it appears that safari does not respect the disabled value and still submits the form. Therefor I changed the fix that was done in https://github.com/auth0/lock/pull/1968, by using the `isSubmitting` value instead of the `disableSubmitButton`

