### PR TITLE
[ESD-13941] Implement a DOMPurify hook to enable target attributes on links

### DIFF
--- a/src/__tests__/i18n.test.js
+++ b/src/__tests__/i18n.test.js
@@ -6,6 +6,7 @@ import esDictionary from '../i18n/es';
 
 import * as sync from '../sync';
 import * as l from '../core/index';
+import { initSanitizer } from '../sanitizer';
 
 describe('i18n', () => {
   let syncSpy;
@@ -60,6 +61,23 @@ describe('i18n', () => {
       const html = i18n.html(m, 'test');
       expect(html.props.dangerouslySetInnerHTML.__html).not.toMatch(/javascript:alert/);
       expect(html.props.dangerouslySetInnerHTML.__html).toEqual('<img href="1" src="1">');
+    });
+
+    it('should allow target=_blank with noopener noreferrer attributes', () => {
+      initSanitizer();
+
+      const i18n = require('../i18n');
+
+      const strings = {
+        test: '<a href="#" target="_blank">link</a>'
+      };
+
+      const m = Immutable.fromJS({ i18n: { strings } });
+      const html = i18n.html(m, 'test');
+
+      expect(html.props.dangerouslySetInnerHTML.__html).toEqual(
+        '<a href="#" target="_blank" rel="noopener noreferrer">link</a>'
+      );
     });
   });
 });

--- a/src/core.js
+++ b/src/core.js
@@ -2,6 +2,8 @@ import { EventEmitter } from 'events';
 import { getEntity, observe, read } from './store/index';
 import { remove, render } from './ui/box';
 import webAPI from './core/web_api';
+import { initSanitizer } from './sanitizer';
+
 import {
   closeLock,
   resumeAuth,
@@ -62,10 +64,13 @@ export default class Base extends EventEmitter {
 
     this.id = idu.incremental();
     this.engine = engine;
+
     const hookRunner = ::this.runHook;
     const emitEventFn = this.emit.bind(this);
     const handleEventFn = this.on.bind(this);
+
     go(this.id);
+    initSanitizer();
 
     let m = setupLock(this.id, clientID, domain, options, hookRunner, emitEventFn, handleEventFn);
 

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -1,0 +1,22 @@
+import { addHook } from 'dompurify';
+
+export function initSanitizer() {
+  // Extracted from the example at
+  // https://github.com/cure53/DOMPurify/blob/main/demos/hooks-target-blank-demo.html
+  addHook('afterSanitizeAttributes', function(node) {
+    // set all elements owning target to target=_blank
+    if ('target' in node) {
+      node.setAttribute('target', '_blank');
+      // prevent https://www.owasp.org/index.php/Reverse_Tabnabbing
+      node.setAttribute('rel', 'noopener noreferrer');
+    }
+
+    // set non-HTML/MathML links to xlink:show=new
+    if (
+      !node.hasAttribute('target') &&
+      (node.hasAttribute('xlink:href') || node.hasAttribute('href'))
+    ) {
+      node.setAttribute('xlink:show', 'new');
+    }
+  });
+}


### PR DESCRIPTION
### Changes

This PR adds a hook for [DOMPurify](https://github.com/cure53/DOMPurify) that allows elements that are sanitized
using `DOMPurify.sanitize` to have `target="_blank"` attributes, while also
adding `rel="noopener noreferrer"` to the same element to mitigate against
[Tab Nabbing](https://owasp.org/www-community/attacks/Reverse_Tabnabbing).

The implementation provided in [this example](https://github.com/cure53/DOMPurify/blob/main/demos/hooks-target-blank-demo.html) serves our purposes, and has been integrated vertabim.

### References

Fixes `ESD-13941`

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All code quality tools/guidelines have been run/followed
* [X] All relevant assets have been compiled
