### PR TITLE
Release 11.30.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v11.30.2](https://github.com/auth0/lock/tree/v11.30.2) (2021-06-11)
+[Full Changelog](https://github.com/auth0/lock/compare/v11.30.1...v11.30.2)
+
+
+**Changed**
+- [ESD-13941] Implement a DOMPurify hook to enable target attributes on links [\#2006](https://github.com/auth0/lock/pull/2006) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
+
 ## [v11.30.1](https://github.com/auth0/lock/tree/v11.30.1) (2021-06-04)
 [Full Changelog](https://github.com/auth0/lock/compare/v11.30.0...v11.30.1)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ From CDN
 
 ```html
 <!-- Latest patch release (recommended for production) -->
-<script src="https://cdn.auth0.com/js/lock/11.30.1/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/11.30.2/lock.min.js"></script>
 ```
 
 From [npm](https://npmjs.org)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.30.1",
+  "version": "11.30.2",
   "main": "build/lock.js",
   "ignore": [
     "lib-cov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.30.1",
+  "version": "11.30.2",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION
**Changed**
- [ESD-13941] Implement a DOMPurify hook to enable target attributes on links [\#2006](https://github.com/auth0/lock/pull/2006) ([stevehobbsdev](https://github.com/stevehobbsdev))




[ESD-13941]: https://auth0team.atlassian.net/browse/ESD-13941