### PR TITLE
Remove Bower publishing from Jenkins CI script

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -42,28 +42,6 @@ cdn_release()
   success "$NPM_NAME ($1) uploaded to cdn"
 }
 
-bower_release()
-{
-  # Check if tag exists
-  TAG_NAME="v$VERSION"
-  TAG_EXISTS=$(git tag -l "$TAG_NAME")
-
-  if [ ! -z "$TAG_EXISTS" ]; then
-    verbose "There is already a tag $TAG_EXISTS in git. Skipping git deploy."
-  else
-    verbose "Deploying $VERSION to git"
-
-    LAST_COMMIT=$(git log -1 --pretty=%B)
-    grep -v -e '^build$' -e '^build/$' .gitignore > /tmp/.gitignore
-    mv /tmp/.gitignore .gitignore
-    git add --force build/*
-    git commit -am "$TAG_NAME"
-    git tag "$TAG_NAME" -m "$LAST_COMMIT"
-    git push origin $TAG_NAME
-    success "$NPM_NAME version ready for bower"
-  fi
-}
-
 npm_release()
 {
   verbose "Checking if version $1 of $NPM_NAME is already available in npm…"
@@ -94,10 +72,7 @@ rm -f build/*.js
 # Build & Release Webpack Bundle
 yarn dist build
 git checkout -b dist
-bower_release
-new_line
 cdn_release "$VERSION"
 new_line
-
 git checkout master
 git branch -D dist

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -42,26 +42,6 @@ cdn_release()
   success "$NPM_NAME ($1) uploaded to cdn"
 }
 
-npm_release()
-{
-  verbose "Checking if version $1 of $NPM_NAME is already available in npm…"
-
-  NPM_EXISTS=$(npm info -s $NPM_NAME@$1 version)
-
-  if [ ! -z "$NPM_EXISTS" ] && [ "$NPM_EXISTS" == "$1" ]; then
-    verbose "There is already a version $NPM_EXISTS in npm. Skipping npm publish…"
-  else
-    if [ ! -z "$STABLE" ]; then
-      verbose "Deploying $1 to npm"
-      npm publish
-    else
-      verbose "Deploying $1 to npm with tag $NPM_TAG"
-      npm publish --tag "$NPM_TAG"
-    fi
-    success "$NPM_NAME uploaded to npm registry"
-  fi
-}
-
 # Test
 yarn test
 yarn test:e2e


### PR DESCRIPTION
### Changes

This PR prevents the CI script from creating the release tag and modifying the release archive for Bower. Instead, that step will be performed manually in the short term until an alternative solution can be developed.

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All code quality tools/guidelines have been run/followed
* [X] All relevant assets have been compiled
