### PR TITLE
Release 11.30.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [v11.30.5](https://github.com/auth0/lock/tree/v11.30.5) (2021-09-13)
+[Full Changelog](https://github.com/auth0/lock/compare/v11.30.4...v11.30.5)
+
+**Changed**
+
+[SDK-2708] Use `domain` value for client assets download instead of `cdn.*.auth0.com` [\#2029](https://github.com/auth0/lock/pull/2029) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
+**Fixed**
+
+Inline `util.format` and replace usage of `global` for `window` [\#2030](https://github.com/auth0/lock/pull/2030) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
 ## [v11.30.4](https://github.com/auth0/lock/tree/v11.30.4) (2021-07-12)
 [Full Changelog](https://github.com/auth0/lock/compare/v11.30.3...v11.30.4)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ From CDN
 
 ```html
 <!-- Latest patch release (recommended for production) -->
-<script src="https://cdn.auth0.com/js/lock/11.30.4/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/11.30.5/lock.min.js"></script>
 ```
 
 From [npm](https://npmjs.org)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.30.4",
+  "version": "11.30.5",
   "main": "build/lock.js",
   "ignore": [
     "lib-cov",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.30.4",
+  "version": "11.30.5",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION
**Changed**

[SDK-2708] Use `domain` value for client assets download instead of `cdn.*.auth0.com` [\#2029](https://github.com/auth0/lock/pull/2029) ([stevehobbsdev](https://github.com/stevehobbsdev))

**Fixed**

Inline `util.format` and replace usage of `global` for `window` [\#2030](https://github.com/auth0/lock/pull/2030) ([stevehobbsdev](https://github.com/stevehobbsdev))

[SDK-2708]: https://auth0team.atlassian.net/browse/SDK-2708