### PR TITLE
Security upgrade node-fetch to 2.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "dompurify": "^2.3.4",
     "immutable": "^3.7.3",
     "jsonp": "^0.2.1",
-    "node-fetch": "^2.6.6",
+    "node-fetch": "^2.6.7",
     "password-sheriff": "^1.1.1",
     "prop-types": "^15.8.0",
     "qs": "^6.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7439,10 +7439,10 @@ node-fetch@2.6.1, node-fetch@^1.0.1, node-fetch@^2.6.1:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-fetch@^2.6.6:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
-  integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
Relates to: #2084 

This PR bumps the node-fetch dependency version from 2.6.6 to 2.6.7 to resolve a security vulnerability around forwarded headers within that release. See: https://github.com/node-fetch/node-fetch/releases/tag/v2.6.7