### PR TITLE
Update auth0-js and support legacySameSiteCookie option

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,11 +415,11 @@ Specify your hooks using a new `hooks` configuration item when setting up the li
 ```js
 new Auth0Lock('client ID', 'domain', {
   hooks: {
-    loggingIn: function(context, cb) {
+    loggingIn: function (context, cb) {
       console.log('Hello from the login hook!');
       cb();
     },
-    signingUp: function(context, cb) {
+    signingUp: function (context, cb) {
       console.log('Hello from the sign-up hook!');
       cb();
     }
@@ -434,12 +434,12 @@ The developer can throw an error to block the login or sign-up process. The deve
 ```js
 new Auth0Lock('client ID', 'domain', {
   hooks: {
-    loggingIn: function(context, cb) {
+    loggingIn: function (context, cb) {
       // Throw an object with code: `hook_error` to display this on the Login screen
       throw { code: 'hook_error', description: 'There was an error in the login hook!' };
 
       // Throw something generic to show a fallback error message
-      throw "Some error happened";
+      throw 'Some error happened';
     }
   }
 });
@@ -453,6 +453,7 @@ new Auth0Lock('client ID', 'domain', {
 - **languageBaseUrl {String}**: Overrides the language source URL for Auth0's provided translations. By default it uses to Auth0's CDN URL `https://cdn.auth0.com`.
 - **hashCleanup {Boolean}**: When enabled, it will remove the hash part of the callback URL after the user authentication. Defaults to `true`.
 - **connectionResolver {Function}**: When in use, provides an extensibility point to make it possible to choose which connection to use based on the username information. Has `username`, `context`, and `callback` as parameters. The callback expects an object like: `{type: 'database', name: 'connection name'}`. **This only works for database connections.** Keep in mind that this resolver will run in the form's `onSubmit` event, so keep it simple and fast. **This is a beta feature. If you find a bug, please open a GitHub [issue](https://github.com/auth0/lock/issues/new).**
+- **legacySameSiteCookie**: If `false`, no compatibility cookies will be created for those browsers that do not understand the `SameSite` attribute. Defaults to `true`
 
 ```js
 var options = {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "webpack-dev-server": "^2.3.0"
   },
   "dependencies": {
-    "auth0-js": "^9.18.0",
+    "auth0-js": "^9.18.1",
     "auth0-password-policies": "^1.0.2",
     "blueimp-md5": "^2.19.0",
     "classnames": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "webpack-dev-server": "^2.3.0"
   },
   "dependencies": {
-    "auth0-js": "^9.18.1",
+    "auth0-js": "^9.19.0",
     "auth0-password-policies": "^1.0.2",
     "blueimp-md5": "^2.19.0",
     "classnames": "^2.3.1",

--- a/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
+++ b/src/__tests__/core/web_api/__snapshots__/p2_api.test.js.snap
@@ -39,6 +39,7 @@ Object {
   "clientID": "cid",
   "domain": "me.auth0.com",
   "leeway": 30,
+  "legacySameSiteCookie": undefined,
   "nonce": "nonce",
   "overrides": Object {
     "__jwks_uri": "https://jwks.com",
@@ -72,6 +73,7 @@ Object {
   "clientID": "cid",
   "domain": "me.auth0.com",
   "leeway": 60,
+  "legacySameSiteCookie": undefined,
   "nonce": "nonce",
   "overrides": Object {
     "__jwks_uri": "https://jwks.com",

--- a/src/core/web_api/p2_api.js
+++ b/src/core/web_api/p2_api.js
@@ -46,7 +46,8 @@ class Auth0APIClient {
       _telemetryInfo: telemetry,
       state,
       nonce,
-      scope
+      scope,
+      legacySameSiteCookie: opts.legacySameSiteCookie
     });
 
     this.authOpt = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,10 +760,10 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-auth0-js@^9.18.1:
-  version "9.18.1"
-  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.18.1.tgz#1a3b3c7431c086bcd51aa07562bd09ba5c125ba7"
-  integrity sha512-inGWJ11k7+si/B0LJjip8GUQXhfVWN/Ne3IOtmnTJTKDpiXiq+lDFz6y04jaFyOEmvpmn7Gp6SmawTGtoFVJQw==
+auth0-js@^9.19.0:
+  version "9.19.0"
+  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.19.0.tgz#09fcf97465c5a9a93b23c63056f9e45d8d4b3be2"
+  integrity sha512-PbzzGqtcfUZj3jnPqEcJYoWH+YNMmHI9woRYBY1VZn+GaU5NIWR1H/2ZAx5ZERZXvte6qQsu2FDNB8V+1N9Ahg==
   dependencies:
     base64-js "^1.5.1"
     idtoken-verifier "^2.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,10 +760,10 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-auth0-js@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.18.0.tgz#4d69b93401ce39583d21e3aeae04c323a9f518e7"
-  integrity sha512-pTQyRLjWAXl7nUHfyFRWhDHMRtQpRJYKU5m3MdPNwem8iQR7KI4c3eHmVV90hpW6gM9jdjNjSmEPyHTxeaqxBA==
+auth0-js@^9.18.1:
+  version "9.18.1"
+  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-9.18.1.tgz#1a3b3c7431c086bcd51aa07562bd09ba5c125ba7"
+  integrity sha512-inGWJ11k7+si/B0LJjip8GUQXhfVWN/Ne3IOtmnTJTKDpiXiq+lDFz6y04jaFyOEmvpmn7Gp6SmawTGtoFVJQw==
   dependencies:
     base64-js "^1.5.1"
     idtoken-verifier "^2.2.2"


### PR DESCRIPTION
### Changes

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

This PR updates auth0-js to include new functionality from Auth0.js, as well as supporting the `legacySameSiteCookie` option so that it can be passed through from Lock users.

### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

https://github.com/auth0/auth0.js/pull/1232

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
- [x] All relevant assets have been compiled
