### PR TITLE
More complete support for custom passwordless connections

### DIFF
--- a/src/connection/passwordless/actions.js
+++ b/src/connection/passwordless/actions.js
@@ -67,17 +67,17 @@ function resendEmailError(id, error) {
   swap(updateEntity, 'lock', id, setResendFailed);
 }
 
-function getPasswordlessConnectionName(defaultPasswordlessConnection) {
+function getPasswordlessConnectionName(m, defaultPasswordlessConnection) {
   const connections = l.connections(m, 'passwordless', defaultPasswordlessConnection);
-  
+
   return connections.size > 0 && l.useCustomPasswordlessConnection(m)
-        ? connections.first().get('name')
-        : defaultPasswordlessConnection;  
+    ? connections.first().get('name')
+    : defaultPasswordlessConnection;
 }
 
 function sendEmail(m, successFn, errorFn) {
   const params = {
-    connection: getPasswordlessConnectionName('email'),
+    connection: getPasswordlessConnectionName(m, 'email'),
     email: c.getFieldValue(m, 'email'),
     send: send(m)
   };
@@ -98,7 +98,7 @@ function sendEmail(m, successFn, errorFn) {
 export function sendSMS(id) {
   validateAndSubmit(id, ['phoneNumber'], m => {
     const params = {
-      connection: getPasswordlessConnectionName('sms'),
+      connection: getPasswordlessConnectionName(m, 'sms'),
       phoneNumber: phoneNumberWithDiallingCode(m),
       send: send(m)
     };
@@ -135,10 +135,10 @@ export function logIn(id) {
     ...authParams
   };
   if (isEmail(m)) {
-    params.connection = getPasswordlessConnectionName('email');
+    params.connection = getPasswordlessConnectionName(m, 'email');
     params.email = c.getFieldValue(m, 'email');
   } else {
-    params.connection = getPasswordlessConnectionName('sms');
+    params.connection = getPasswordlessConnectionName(m, 'sms');
     params.phoneNumber = phoneNumberWithDiallingCode(m);
   }
   swap(updateEntity, 'lock', id, l.setSubmitting, true);


### PR DESCRIPTION
### Changes

In a previous PR #1981 a new parameter `useCustomPasswordlessConnection` was introduced for the Lock configuration. The reason for that change was that it is possible to create passwordless connections outside of the default `sms` and `email`. That PR mentions that it can be done via Management API, and it would seem that this includes Terraform (https://github.com/auth0/terraform-provider-auth0) where it seems to be the **only** way to use passwordless connections. 

This PR "completes" the above-mentioned PR where the connection parameter in `connection/passwordless/actions.js -> logIn` was still hard-coded to either `sms` or `email`

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of the platform/language

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All code quality tools/guidelines have been run/followed
* [X] All relevant assets have been compiled
