### PR TITLE
Replace legacy CircleCI docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 executors:
   docker-executor:
     docker:
-      - image: circleci/node:14.15
+      - image: cimg/node:14.19
 jobs:
   build-and-test:
     executor: docker-executor


### PR DESCRIPTION
This PR replaces the "legacy" CircleCI docker image we're using for the new version.