### PR TITLE
ship/node-publish should require build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,8 @@ workflows:
           context:
             - browserstack-env
       - ship/node-publish:
+          requires:
+            - build-and-test
           pkg-manager: yarn
           context:
             - publish-npm


### PR DESCRIPTION
The browserstack tests are not required by the build currently, which is why it doesn't also rely on the `browserstack` job.
