### PR TITLE
Add captcha to passwordless login screens

### DIFF
--- a/src/__tests__/engine/passwordless/__snapshots__/social_or_email_login_screen.test.js.snap
+++ b/src/__tests__/engine/passwordless/__snapshots__/social_or_email_login_screen.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`email passwordless renders correctly 1`] = `
+<div>
+  <div
+    data-__type="social_buttons_pane"
+    data-instructions="socialLoginInstructions"
+    data-labelFn={[Function]}
+    data-lock="model"
+    data-signUp={true}
+  />
+  <div
+    data-__type="pane_separator"
+  />
+  <p>
+    passwordlessEmailAlternativeInstructions
+  </p>
+  <div
+    data-__type="email_pane"
+    data-i18n={
+      Object {
+        "html": [Function],
+        "str": [Function],
+      }
+    }
+    data-lock="model"
+    data-placeholder="emailInputPlaceholder"
+    data-strictValidation={false}
+  />
+</div>
+`;

--- a/src/__tests__/engine/passwordless/__snapshots__/social_or_phone_number_login_screen.test.js.snap
+++ b/src/__tests__/engine/passwordless/__snapshots__/social_or_phone_number_login_screen.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`email passwordless renders a captcha 1`] = `
+exports[`sms passwordless renders a captcha 1`] = `
 <div>
   <div
     data-__type="social_buttons_pane"
@@ -12,20 +12,12 @@ exports[`email passwordless renders a captcha 1`] = `
   <div
     data-__type="pane_separator"
   />
-  <p>
-    passwordlessEmailAlternativeInstructions
-  </p>
   <div
-    data-__type="email_pane"
-    data-i18n={
-      Object {
-        "html": [Function],
-        "str": [Function],
-      }
-    }
+    data-__type="phone_number_pane"
+    data-instructions="passwordlessSMSAlternativeInstructions"
+    data-invalidHint="phoneNumberInputInvalidHint"
     data-lock="model"
-    data-placeholder="emailInputPlaceholder"
-    data-strictValidation={false}
+    data-placeholder="phoneNumberInputPlaceholder"
   />
   <div
     data-__type="captcha_pane"
@@ -41,7 +33,7 @@ exports[`email passwordless renders a captcha 1`] = `
 </div>
 `;
 
-exports[`email passwordless renders correctly 1`] = `
+exports[`sms passwordless renders correctly 1`] = `
 <div>
   <div
     data-__type="social_buttons_pane"
@@ -53,20 +45,12 @@ exports[`email passwordless renders correctly 1`] = `
   <div
     data-__type="pane_separator"
   />
-  <p>
-    passwordlessEmailAlternativeInstructions
-  </p>
   <div
-    data-__type="email_pane"
-    data-i18n={
-      Object {
-        "html": [Function],
-        "str": [Function],
-      }
-    }
+    data-__type="phone_number_pane"
+    data-instructions="passwordlessSMSAlternativeInstructions"
+    data-invalidHint="phoneNumberInputInvalidHint"
     data-lock="model"
-    data-placeholder="emailInputPlaceholder"
-    data-strictValidation={false}
+    data-placeholder="phoneNumberInputPlaceholder"
   />
 </div>
 `;

--- a/src/__tests__/engine/passwordless/social_or_email_login_screen.test.js
+++ b/src/__tests__/engine/passwordless/social_or_email_login_screen.test.js
@@ -1,101 +1,55 @@
 import React from 'react';
-import { expectShallowComponent } from 'testUtils';
-import { mockComponent } from 'testUtils';
-// import SocialOrEmailLoginScreen from 'engine/passwordless/social_or_email_login_screen'
+import { mount } from 'enzyme';
+
+import { expectComponent, extractPropsFromWrapper, mockComponent } from 'testUtils';
+
+//there's a circular dependency with this module, so we need to mock it
+jest.mock('engine/classic');
 
 jest.mock('field/social/social_buttons_pane', () => mockComponent('social_buttons_pane'));
+// jest.mock('core/error_screen', () => mockComponent('error_screen'));
+// jest.mock('core/loading_screen', () => mockComponent('loading_screen'));
 jest.mock('field/email/email_pane', () => mockComponent('email_pane'));
 // jest.mock('field/captcha/captcha_pane', () => mockComponent('captcha_pane'));
 jest.mock('core/pane_separator', () => mockComponent('pane_separator'));
 jest.mock('connection/database/sign_up_terms', () => mockComponent('sign_up_terms'));
-// jest.mock('engine/passwordless/social_or_email_login_screen', () => mockComponent('social_or_email_login_screen'));
+jest.mock('connection/passwordless/index', () => ({
+  isEmail: jest.fn()
+}));
 
-const getScreen = () => {
-  const SocialOrEmailScreen = require('engine/passwordless/social_or_email_login_screen').default;
-  return new SocialOrEmailScreen();
-};
 
 const getComponent = () => {
-  // return null;
-  console.log('hiii' + getScreen());
-  console.log(getScreen().render());
-  return getScreen().render();
+  const SocialOrEmailScreen = require('engine/passwordless/social_or_email_login_screen').default;
+  const screen = new SocialOrEmailScreen();
+  return screen.render();
 };
 
-describe('social or email login screen', () => {
+describe('email passwordless', () => {
   beforeEach(() => {
     jest.resetModules();
-    jest.mock('core/index', () => ({
-      hasSomeConnections: () => true,
-      prefill: () => ({
-        toJS() {
-          return {
-            email: 'prefill@example.com',
-            phoneNumber: '12354'
-          };
-        }
-      })
-    }));
-    jest.mock('field/email', () => ({
-      setEmail: jest.fn(m => m)
-    }));
-    jest.mock('field/phone_number', () => ({
-      setPhoneNumber: jest.fn(m => m)
-    }));
-    console.log('hi');
-  });
 
+    jest.mock('connection/database/index', () => ({
+      hasScreen: () => false
+    }));
+
+    jest.mock('connection/database/actions', () => ({
+      cancelMFALogin: jest.fn(),
+      logIn: jest.fn()
+    }));
+
+    jest.mock('core/signed_in_confirmation', () => ({
+      renderSignedInConfirmation: jest.fn()
+    }));
+  });
   const defaultProps = {
     i18n: {
-      str: (...keys) => keys.join(','),
-      group: (...keys) => keys.join(','),
-      html: (...keys) => keys.join(',')
+      str: (...keys) => keys.join(',')
     },
     model: 'model'
   };
-
-  //   it('renders correctly', async () => {
-  //     expectShallowComponent(<SocialOrEmailLoginScreen {...defaultProps} />).toMatchSnapshot();
-  //   });
-
-  it('renders empty div by default', () => {
+  it('renders correctly', () => {
     const Component = getComponent();
 
     expectComponent(<Component {...defaultProps} />).toMatchSnapshot();
   });
-
-  //   it('renders a captcha', () => {
-  //     require('core/index').captcha.mockReturnValue({
-  //       get() {
-  //         return true;
-  //       }
-  //     });
-
-  //     expectShallowComponent(<SocialOrEmailLoginScreen {...defaultProps} />).toMatchSnapshot();
-  //   });
-
-  //   it('hides the captcha for SSO connections', () => {
-  //     require('core/index').captcha.mockReturnValue({
-  //       get() {
-  //         return true;
-  //       }
-  //     });
-
-  //     require('engine/classic').isSSOEnabled.mockReturnValue(true);
-
-  //     expectShallowComponent(<LoginPane {...defaultProps} />).toMatchSnapshot();
-  //   });
-
-  //   it('shows the captcha for SSO (ADFS) connections', () => {
-  //     require('core/index').captcha.mockReturnValue({
-  //       get() {
-  //         return true;
-  //       }
-  //     });
-
-  //     require('engine/classic').isSSOEnabled.mockReturnValue(true);
-  //     require('connection/enterprise').isHRDDomain.mockReturnValue(true);
-
-  //     expectShallowComponent(<LoginPane {...defaultProps} />).toMatchSnapshot();
-  //   });
 });

--- a/src/__tests__/engine/passwordless/social_or_email_login_screen.test.js
+++ b/src/__tests__/engine/passwordless/social_or_email_login_screen.test.js
@@ -1,10 +1,12 @@
+import { keyDefinitions } from 'puppeteer';
 import React from 'react';
-import { mount } from 'enzyme';
 
 import { expectComponent, extractPropsFromWrapper, mockComponent } from 'testUtils';
 
 //there's a circular dependency with this module, so we need to mock it
-jest.mock('engine/classic');
+// jest.mock('engine/classic');
+jest.mock('connection/enterprise');
+jest.mock('core/index');
 
 jest.mock('field/social/social_buttons_pane', () => mockComponent('social_buttons_pane'));
 // jest.mock('core/error_screen', () => mockComponent('error_screen'));
@@ -16,7 +18,6 @@ jest.mock('connection/database/sign_up_terms', () => mockComponent('sign_up_term
 jest.mock('connection/passwordless/index', () => ({
   isEmail: jest.fn()
 }));
-
 
 const getComponent = () => {
   const SocialOrEmailScreen = require('engine/passwordless/social_or_email_login_screen').default;
@@ -40,13 +41,24 @@ describe('email passwordless', () => {
     jest.mock('core/signed_in_confirmation', () => ({
       renderSignedInConfirmation: jest.fn()
     }));
+
+    jest.mock('connection/enterprise', () => ({
+      isHRDEmailValid: jest.fn(() => false)
+    }));
+
+    jest.mock('core/index', () => ({
+      hasSomeConnections: jest.fn(() => true)
+    }));
   });
+
   const defaultProps = {
     i18n: {
-      str: (...keys) => keys.join(',')
+      str: (...keys) => keys.join(','),
+      html: (...keys) => keys.join(',')
     },
     model: 'model'
   };
+
   it('renders correctly', () => {
     const Component = getComponent();
 

--- a/src/__tests__/engine/passwordless/social_or_email_login_screen.test.js
+++ b/src/__tests__/engine/passwordless/social_or_email_login_screen.test.js
@@ -3,16 +3,12 @@ import React from 'react';
 
 import { expectComponent, extractPropsFromWrapper, mockComponent } from 'testUtils';
 
-//there's a circular dependency with this module, so we need to mock it
-// jest.mock('engine/classic');
 jest.mock('connection/enterprise');
 jest.mock('core/index');
 
 jest.mock('field/social/social_buttons_pane', () => mockComponent('social_buttons_pane'));
-// jest.mock('core/error_screen', () => mockComponent('error_screen'));
-// jest.mock('core/loading_screen', () => mockComponent('loading_screen'));
 jest.mock('field/email/email_pane', () => mockComponent('email_pane'));
-// jest.mock('field/captcha/captcha_pane', () => mockComponent('captcha_pane'));
+jest.mock('field/captcha/captcha_pane', () => mockComponent('captcha_pane'));
 jest.mock('core/pane_separator', () => mockComponent('pane_separator'));
 jest.mock('connection/database/sign_up_terms', () => mockComponent('sign_up_terms'));
 jest.mock('connection/passwordless/index', () => ({
@@ -61,6 +57,18 @@ describe('email passwordless', () => {
 
   it('renders correctly', () => {
     const Component = getComponent();
+
+    expectComponent(<Component {...defaultProps} />).toMatchSnapshot();
+  });
+
+  it('renders a captcha', () => {
+    const Component = getComponent();
+
+    require('core/index').captcha.mockReturnValue({
+      get() {
+        return true;
+      }
+    });
 
     expectComponent(<Component {...defaultProps} />).toMatchSnapshot();
   });

--- a/src/__tests__/engine/passwordless/social_or_email_login_screen.test.js
+++ b/src/__tests__/engine/passwordless/social_or_email_login_screen.test.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import { expectShallowComponent } from 'testUtils';
+import { mockComponent } from 'testUtils';
+// import SocialOrEmailLoginScreen from 'engine/passwordless/social_or_email_login_screen'
+
+jest.mock('field/social/social_buttons_pane', () => mockComponent('social_buttons_pane'));
+jest.mock('field/email/email_pane', () => mockComponent('email_pane'));
+// jest.mock('field/captcha/captcha_pane', () => mockComponent('captcha_pane'));
+jest.mock('core/pane_separator', () => mockComponent('pane_separator'));
+jest.mock('connection/database/sign_up_terms', () => mockComponent('sign_up_terms'));
+// jest.mock('engine/passwordless/social_or_email_login_screen', () => mockComponent('social_or_email_login_screen'));
+
+const getScreen = () => {
+  const SocialOrEmailScreen = require('engine/passwordless/social_or_email_login_screen').default;
+  return new SocialOrEmailScreen();
+};
+
+const getComponent = () => {
+  // return null;
+  console.log('hiii' + getScreen());
+  console.log(getScreen().render());
+  return getScreen().render();
+};
+
+describe('social or email login screen', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.mock('core/index', () => ({
+      hasSomeConnections: () => true,
+      prefill: () => ({
+        toJS() {
+          return {
+            email: 'prefill@example.com',
+            phoneNumber: '12354'
+          };
+        }
+      })
+    }));
+    jest.mock('field/email', () => ({
+      setEmail: jest.fn(m => m)
+    }));
+    jest.mock('field/phone_number', () => ({
+      setPhoneNumber: jest.fn(m => m)
+    }));
+    console.log('hi');
+  });
+
+  const defaultProps = {
+    i18n: {
+      str: (...keys) => keys.join(','),
+      group: (...keys) => keys.join(','),
+      html: (...keys) => keys.join(',')
+    },
+    model: 'model'
+  };
+
+  //   it('renders correctly', async () => {
+  //     expectShallowComponent(<SocialOrEmailLoginScreen {...defaultProps} />).toMatchSnapshot();
+  //   });
+
+  it('renders empty div by default', () => {
+    const Component = getComponent();
+
+    expectComponent(<Component {...defaultProps} />).toMatchSnapshot();
+  });
+
+  //   it('renders a captcha', () => {
+  //     require('core/index').captcha.mockReturnValue({
+  //       get() {
+  //         return true;
+  //       }
+  //     });
+
+  //     expectShallowComponent(<SocialOrEmailLoginScreen {...defaultProps} />).toMatchSnapshot();
+  //   });
+
+  //   it('hides the captcha for SSO connections', () => {
+  //     require('core/index').captcha.mockReturnValue({
+  //       get() {
+  //         return true;
+  //       }
+  //     });
+
+  //     require('engine/classic').isSSOEnabled.mockReturnValue(true);
+
+  //     expectShallowComponent(<LoginPane {...defaultProps} />).toMatchSnapshot();
+  //   });
+
+  //   it('shows the captcha for SSO (ADFS) connections', () => {
+  //     require('core/index').captcha.mockReturnValue({
+  //       get() {
+  //         return true;
+  //       }
+  //     });
+
+  //     require('engine/classic').isSSOEnabled.mockReturnValue(true);
+  //     require('connection/enterprise').isHRDDomain.mockReturnValue(true);
+
+  //     expectShallowComponent(<LoginPane {...defaultProps} />).toMatchSnapshot();
+  //   });
+});

--- a/src/__tests__/engine/passwordless/social_or_phone_number_login_screen.test.js
+++ b/src/__tests__/engine/passwordless/social_or_phone_number_login_screen.test.js
@@ -6,7 +6,7 @@ jest.mock('connection/enterprise');
 jest.mock('core/index');
 
 jest.mock('field/social/social_buttons_pane', () => mockComponent('social_buttons_pane'));
-jest.mock('field/email/email_pane', () => mockComponent('email_pane'));
+jest.mock('field/phone-number/phone_number_pane', () => mockComponent('phone_number_pane'));
 jest.mock('field/captcha/captcha_pane', () => mockComponent('captcha_pane'));
 jest.mock('core/pane_separator', () => mockComponent('pane_separator'));
 jest.mock('connection/database/sign_up_terms', () => mockComponent('sign_up_terms'));
@@ -15,12 +15,12 @@ jest.mock('connection/passwordless/index', () => ({
 }));
 
 const getComponent = () => {
-  const SocialOrEmailScreen = require('engine/passwordless/social_or_email_login_screen').default;
-  const screen = new SocialOrEmailScreen();
+  const SocialOrPhoneNumberScreen = require('engine/passwordless/social_or_phone_number_login_screen').default;
+  const screen = new SocialOrPhoneNumberScreen();
   return screen.render();
 };
 
-describe('email passwordless', () => {
+describe('sms passwordless', () => {
   beforeEach(() => {
     jest.resetModules();
     jest.resetAllMocks();

--- a/src/engine/passwordless/social_or_email_login_screen.jsx
+++ b/src/engine/passwordless/social_or_email_login_screen.jsx
@@ -51,8 +51,8 @@ const Component = ({ i18n, model }) => {
 
   const captchaPane =
   l.captcha(model) &&
-  l.captcha(model).get('required') &&
-  (isHRDDomain(model, databaseUsernameValue(model))) ? (
+  l.captcha(model).get('required')
+  ? (
     <CaptchaPane i18n={i18n} lock={model} onReload={() => swapCaptcha(l.id(model), false)} />
   ) : null;
 

--- a/src/engine/passwordless/social_or_email_login_screen.jsx
+++ b/src/engine/passwordless/social_or_email_login_screen.jsx
@@ -10,8 +10,6 @@ import { toggleTermsAcceptance } from '../../connection/passwordless/actions';
 import { requestPasswordlessEmail } from '../../connection/passwordless/actions';
 import { renderEmailSentConfirmation } from '../../connection/passwordless/email_sent_confirmation';
 import { renderSignedInConfirmation } from '../../core/signed_in_confirmation';
-import { isHRDDomain } from '../../connection/enterprise';
-import { databaseUsernameValue } from '../../connection/database';
 import * as l from '../../core/index';
 
 import SignUpTerms from '../../connection/database/sign_up_terms';

--- a/src/engine/passwordless/social_or_email_login_screen.jsx
+++ b/src/engine/passwordless/social_or_email_login_screen.jsx
@@ -52,7 +52,7 @@ const Component = ({ i18n, model }) => {
   const captchaPane =
   l.captcha(model) &&
   l.captcha(model).get('required') &&
-  (isHRDDomain(model, databaseUsernameValue(model)) || !sso) ? (
+  (isHRDDomain(model, databaseUsernameValue(model))) ? (
     <CaptchaPane i18n={i18n} lock={model} onReload={() => swapCaptcha(l.id(model), false)} />
   ) : null;
 

--- a/src/engine/passwordless/social_or_email_login_screen.jsx
+++ b/src/engine/passwordless/social_or_email_login_screen.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import Screen from '../../core/screen';
 import EmailPane from '../../field/email/email_pane';
 import SocialButtonsPane from '../../field/social/social_buttons_pane';
+// import CaptchaPane from '../../field/captcha/captcha_pane';
+// import { swapCaptcha } from '../captcha';
 import PaneSeparator from '../../core/pane_separator';
 import { mustAcceptTerms, termsAccepted, showTerms } from '../../connection/passwordless/index';
 import { toggleTermsAcceptance } from '../../connection/passwordless/actions';
@@ -45,12 +47,20 @@ const Component = ({ i18n, model }) => {
 
   const separator = social && email ? <PaneSeparator /> : null;
 
+  // const captchaPane =
+  // l.captcha(model) &&
+  // l.captcha(model).get('required') &&
+  // (isHRDDomain(model, databaseUsernameValue(model)) || !sso) ? (
+  //   <CaptchaPane i18n={i18n} lock={model} onReload={() => swapCaptcha(l.id(model), false)} />
+  // ) : null;
+
   return (
     <div>
       {social}
       {separator}
       {header}
       {email}
+      {/* {captchaPane} */}
     </div>
   );
 };

--- a/src/engine/passwordless/social_or_email_login_screen.jsx
+++ b/src/engine/passwordless/social_or_email_login_screen.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Screen from '../../core/screen';
 import EmailPane from '../../field/email/email_pane';
 import SocialButtonsPane from '../../field/social/social_buttons_pane';
-// import CaptchaPane from '../../field/captcha/captcha_pane';
-// import { swapCaptcha } from '../captcha';
+import CaptchaPane from '../../field/captcha/captcha_pane';
+import { swapCaptcha } from '../../connection/captcha';
 import PaneSeparator from '../../core/pane_separator';
 import { mustAcceptTerms, termsAccepted, showTerms } from '../../connection/passwordless/index';
 import { toggleTermsAcceptance } from '../../connection/passwordless/actions';
@@ -47,12 +47,12 @@ const Component = ({ i18n, model }) => {
 
   const separator = social && email ? <PaneSeparator /> : null;
 
-  // const captchaPane =
-  // l.captcha(model) &&
-  // l.captcha(model).get('required') &&
-  // (isHRDDomain(model, databaseUsernameValue(model)) || !sso) ? (
-  //   <CaptchaPane i18n={i18n} lock={model} onReload={() => swapCaptcha(l.id(model), false)} />
-  // ) : null;
+  const captchaPane =
+  l.captcha(model) &&
+  l.captcha(model).get('required') &&
+  (isHRDDomain(model, databaseUsernameValue(model)) || !sso) ? (
+    <CaptchaPane i18n={i18n} lock={model} onReload={() => swapCaptcha(l.id(model), false)} />
+  ) : null;
 
   return (
     <div>
@@ -60,7 +60,7 @@ const Component = ({ i18n, model }) => {
       {separator}
       {header}
       {email}
-      {/* {captchaPane} */}
+      {captchaPane}
     </div>
   );
 };

--- a/src/engine/passwordless/social_or_email_login_screen.jsx
+++ b/src/engine/passwordless/social_or_email_login_screen.jsx
@@ -10,6 +10,8 @@ import { toggleTermsAcceptance } from '../../connection/passwordless/actions';
 import { requestPasswordlessEmail } from '../../connection/passwordless/actions';
 import { renderEmailSentConfirmation } from '../../connection/passwordless/email_sent_confirmation';
 import { renderSignedInConfirmation } from '../../core/signed_in_confirmation';
+import { isHRDDomain } from '../../connection/enterprise';
+import { databaseUsernameValue } from '../../connection/database';
 import * as l from '../../core/index';
 
 import SignUpTerms from '../../connection/database/sign_up_terms';

--- a/src/engine/passwordless/social_or_phone_number_login_screen.jsx
+++ b/src/engine/passwordless/social_or_phone_number_login_screen.jsx
@@ -40,8 +40,7 @@ const Component = ({ i18n, model }) => {
 
   const captchaPane =
   l.captcha(model) &&
-  l.captcha(model).get('required') &&
-  (isHRDDomain(model, databaseUsernameValue(model))) ? (
+  l.captcha(model).get('required') ? (
     <CaptchaPane i18n={i18n} lock={model} onReload={() => swapCaptcha(l.id(model), false)} />
   ) : null;
 

--- a/src/engine/passwordless/social_or_phone_number_login_screen.jsx
+++ b/src/engine/passwordless/social_or_phone_number_login_screen.jsx
@@ -41,7 +41,7 @@ const Component = ({ i18n, model }) => {
   const captchaPane =
   l.captcha(model) &&
   l.captcha(model).get('required') &&
-  (isHRDDomain(model, databaseUsernameValue(model)) || !sso) ? (
+  (isHRDDomain(model, databaseUsernameValue(model))) ? (
     <CaptchaPane i18n={i18n} lock={model} onReload={() => swapCaptcha(l.id(model), false)} />
   ) : null;
 

--- a/src/engine/passwordless/social_or_phone_number_login_screen.jsx
+++ b/src/engine/passwordless/social_or_phone_number_login_screen.jsx
@@ -12,8 +12,6 @@ import { renderOptionSelection } from '../../field/index';
 import { mustAcceptTerms, termsAccepted, showTerms } from '../../connection/passwordless/index';
 import { toggleTermsAcceptance } from '../../connection/passwordless/actions';
 import SignUpTerms from '../../connection/database/sign_up_terms';
-import { isHRDDomain } from '../../connection/enterprise';
-import { databaseUsernameValue } from '../../connection/database';
 
 const Component = ({ i18n, model }) => {
   const social = l.hasSomeConnections(model, 'social') ? (

--- a/src/engine/passwordless/social_or_phone_number_login_screen.jsx
+++ b/src/engine/passwordless/social_or_phone_number_login_screen.jsx
@@ -3,6 +3,7 @@ import Screen from '../../core/screen';
 import { sendSMS } from '../../connection/passwordless/actions';
 import PhoneNumberPane from '../../field/phone-number/phone_number_pane';
 import SocialButtonsPane from '../../field/social/social_buttons_pane';
+import CaptchaPane from '../../field/captcha/captcha_pane';
 import { renderSignedInConfirmation } from '../../core/signed_in_confirmation';
 import PaneSeparator from '../../core/pane_separator';
 import * as l from '../../core/index';
@@ -11,6 +12,8 @@ import { renderOptionSelection } from '../../field/index';
 import { mustAcceptTerms, termsAccepted, showTerms } from '../../connection/passwordless/index';
 import { toggleTermsAcceptance } from '../../connection/passwordless/actions';
 import SignUpTerms from '../../connection/database/sign_up_terms';
+import { isHRDDomain } from '../../connection/enterprise';
+import { databaseUsernameValue } from '../../connection/database';
 
 const Component = ({ i18n, model }) => {
   const social = l.hasSomeConnections(model, 'social') ? (
@@ -35,6 +38,13 @@ const Component = ({ i18n, model }) => {
     />
   ) : null;
 
+  const captchaPane =
+  l.captcha(model) &&
+  l.captcha(model).get('required') &&
+  (isHRDDomain(model, databaseUsernameValue(model)) || !sso) ? (
+    <CaptchaPane i18n={i18n} lock={model} onReload={() => swapCaptcha(l.id(model), false)} />
+  ) : null;
+
   const separator = social && phoneNumber ? <PaneSeparator /> : null;
 
   return (
@@ -42,6 +52,7 @@ const Component = ({ i18n, model }) => {
       {social}
       {separator}
       {phoneNumber}
+      {captchaPane}
     </div>
   );
 };


### PR DESCRIPTION
### Changes

- Added captcha pane to passwordless login flows, in both `social_and_email_login_screen` and `social_and_phone_number_login_screen`.

### References


### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
