### PR TITLE
[ESD-22705] Don't pass function to ConfirmationPane unless closable is enabled

### DIFF
--- a/src/__tests__/connection/passwordless/__snapshots__/email_sent_confirmation.test.jsx.snap
+++ b/src/__tests__/connection/passwordless/__snapshots__/email_sent_confirmation.test.jsx.snap
@@ -5,33 +5,6 @@ exports[`EmailSentConfirmation renders correctly 1`] = `
   className="auth0-lock-confirmation"
 >
   <span
-    aria-label="close"
-    className="auth0-lock-close-button"
-    id="__lock-id__-close-button"
-    onClick={[Function]}
-    onKeyPress={[Function]}
-    role="button"
-    tabIndex={0}
-  >
-    <svg
-      aria-hidden="true"
-      enableBackground="new 0 0 128 128"
-      focusable="false"
-      version="1.1"
-      viewBox="0 0 128 128"
-      xmlSpace="preserve"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlnsXlink="http://www.w3.org/1999/xlink"
-    >
-      <g>
-        <polygon
-          fill="#373737"
-          points="123.5429688,11.59375 116.4765625,4.5185547 64.0019531,56.9306641 11.5595703,4.4882813     4.4882813,11.5595703 56.9272461,63.9970703 4.4570313,116.4052734 11.5244141,123.4814453 63.9985352,71.0683594     116.4423828,123.5117188 123.5126953,116.4414063 71.0732422,64.0019531   "
-        />
-      </g>
-    </svg>
-  </span>
-  <span
     aria-label="back"
     className="auth0-lock-back-button"
     id="__lock-id__-back-button"

--- a/src/connection/passwordless/email_sent_confirmation.jsx
+++ b/src/connection/passwordless/email_sent_confirmation.jsx
@@ -80,7 +80,7 @@ class Resend extends React.Component {
 export default class EmailSentConfirmation extends React.Component {
   render() {
     const { lock } = this.props;
-    const closeHandler = l.ui.closable(lock) ? this.handleClose : undefined;
+    const closeHandler = l.ui.closable(lock) ? ::this.handleClose : undefined;
     const labels = {
       failed: i18n.str(lock, 'failedLabel'),
       resend: i18n.str(lock, 'resendLabel'),
@@ -93,7 +93,7 @@ export default class EmailSentConfirmation extends React.Component {
       <SuccessPane
         lock={lock}
         backHandler={() => this.handleBack()}
-        closeHandler={() => closeHandler()}
+        closeHandler={closeHandler}
       >
         <p>{i18n.html(lock, ['success', 'magicLink'], c.email(lock))}</p>
         <Resend labels={labels} lock={lock} />


### PR DESCRIPTION
### Changes

Don't always provide a function to `SuccessPane` instead pass the `closeHandler` variable so that `SuccessPane` can correctly distinguish whether to show the close buttong

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->
### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

This change updates the snapshot as `closable` is false in that test.

In order to test in the playground change `closable` to `false` and `passwordlessMethod` to `link` in `support/index.html`

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
