### PR TITLE
[SDK-3657] Render sign up confirmation before sign in

### DIFF
--- a/src/engine/classic/sign_up_screen.jsx
+++ b/src/engine/classic/sign_up_screen.jsx
@@ -105,8 +105,8 @@ export default class SignUp extends Screen {
 
   renderAuxiliaryPane(lock) {
     return (
-      renderSignedInConfirmation(lock) ||
       renderSignedUpConfirmation(lock) ||
+      renderSignedInConfirmation(lock) ||
       renderOptionSelection(lock)
     );
   }


### PR DESCRIPTION
### Changes

When a user signs up, if they are logged in as part of the sign up process then the `success.logIn` message is shown rather than the `success.signUp` message as the `renderSignedInConfirmation` function is called first. So call `renderSignedUpConfirmation` first to ensure the correct message is shown

### References

#2159 

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
