### PR TITLE
release v12.0.0-beta.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@0.2.0
+  ship: auth0/ship@0
 executors:
   docker-executor:
     docker:
@@ -88,3 +88,4 @@ workflows:
             branches:
               only:
                 - master
+                - beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,47 +1,73 @@
 # Change Log
 
+## [v12.0.0-beta.0](https://github.com/auth0/lock/tree/v12.0.0-beta.0) (2022-12-08)
+
+[Full Changelog](https://github.com/auth0/lock/compare/v11.34.2...v12.0.0-beta.0)
+
+:warning: This is a **beta release** of Lock.js v12 that includes an upgrade to React 18, and should not be used in production. If you find any issues, please [submit a bug report](https://github.com/auth0/lock/issues/new?assignees=&labels=bug+report,v12-beta&template=report_a_bug.md&title=).
+
+**Changed**
+
+- Upgrade to React 18 [\#2209](https://github.com/auth0/lock/pull/2209) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- Upgrade to Webpack 5, Jest 29, Babel 8 [\#2213](https://github.com/auth0/lock/pull/2213) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- bump dependencies to latest patch and fix typos [\#2210](https://github.com/auth0/lock/pull/2210) ([piwysocki](https://github.com/piwysocki))
+
 ## [v11.34.2](https://github.com/auth0/lock/tree/v11.34.2) (2022-10-10)
+
 [Full Changelog](https://github.com/auth0/lock/compare/v11.34.1...v11.34.2)
 
 **Fixed**
+
 - [SDK-3657] Render sign up confirmation before sign in [\#2180](https://github.com/auth0/lock/pull/2180) ([ewanharris](https://github.com/ewanharris))
 
 ## [v11.34.1](https://github.com/auth0/lock/tree/v11.34.1) (2022-09-29)
+
 [Full Changelog](https://github.com/auth0/lock/compare/v11.34.0...v11.34.1)
 
 **Fixed**
+
 - [ESD-22705] Don't pass function to ConfirmationPane unless closable is enabled [\#2176](https://github.com/auth0/lock/pull/2176) ([ewanharris](https://github.com/ewanharris))
 
 **Security**
+
 - [ESD-22866] Disable spellcheck and autocorrect on all sensitive input fields [\#2178](https://github.com/auth0/lock/pull/2178) ([ewanharris](https://github.com/ewanharris))
 
 ## [v11.34.0](https://github.com/auth0/lock/tree/v11.34.0) (2022-09-14)
+
 [Full Changelog](https://github.com/auth0/lock/compare/v11.33.3...v11.34.0)
 
 **Added**
+
 - FDR-297: Adding okta for enterprise [\#2172](https://github.com/auth0/lock/pull/2172) ([jamescgarrett](https://github.com/jamescgarrett))
 
 ## [v11.33.3](https://github.com/auth0/lock/tree/v11.33.3) (2022-08-16)
+
 [Full Changelog](https://github.com/auth0/lock/compare/v11.33.2...v11.33.3)
 
 **Added**
+
 - IAMRISK-1725 Add password_leaked error label for Signup [\#2160](https://github.com/auth0/lock/pull/2160) ([robinbijlani](https://github.com/robinbijlani))
 
 ## [v11.33.2](https://github.com/auth0/lock/tree/v11.33.2) (2022-06-29)
+
 [Full Changelog](https://github.com/auth0/lock/compare/v11.33.1...v11.33.2)
 
 **Changed**
+
 - Bump qs from 6.10.5 to 6.11.0 [\#2147](https://github.com/auth0/lock/pull/2147) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump shell-quote from 1.7.2 to 1.7.3 [\#2145](https://github.com/auth0/lock/pull/2145) ([dependabot[bot]](https://github.com/apps/dependabot))
 - Bump prettier from 2.7.0 to 2.7.1 [\#2144](https://github.com/auth0/lock/pull/2144) ([dependabot[bot]](https://github.com/apps/dependabot))
 
 ## [v11.33.1](https://github.com/auth0/lock/tree/v11.33.1) (2022-06-14)
+
 [Full Changelog](https://github.com/auth0/lock/compare/v11.33.0...v11.33.1)
 
 **Fixed**
+
 - Move captcha pane below additional signup fields in UI [\#2135](https://github.com/auth0/lock/pull/2135) ([stevehobbsdev](https://github.com/stevehobbsdev))
 
 **Security**
+
 - [Snyk] Upgrade dompurify from 2.3.6 to 2.3.7 [\#2132](https://github.com/auth0/lock/pull/2132) ([snyk-bot](https://github.com/snyk-bot))
 
 ## [v11.33.0](https://github.com/auth0/lock/tree/v11.33.0) (2022-05-05)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@
 
 > :warning: This is a beta release for Lock.js v12 that includes an upgrade to React 18. Getting issues? Please [submit a bug report](https://github.com/auth0/lock/issues/new?assignees=&labels=bug+report,v12-beta&template=report_a_bug.md&title=).
 
-## Documentation 
+## Documentation
 
 - [Docs Site](https://auth0.com/docs) - explore our Docs site and learn more about Auth0.
 
 ## Getting Started
+
 ### Browser Compatibility
 
 We ensure browser compatibility in Chrome, Safari, Firefox and IE >= 10.
@@ -28,7 +29,7 @@ From CDN
 
 ```html
 <!-- Latest patch release (recommended for production) -->
-<script src="https://cdn.auth0.com/js/lock/11.34.2/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/12.0.0/lock.min.js"></script>
 ```
 
 ### Configure Auth0
@@ -42,34 +43,34 @@ Create a **Single Page Application** in the [Auth0 Dashboard](https://manage.aut
 > - Scroll down and click on the "Show Advanced Settings" link.
 > - Under "Advanced Settings", click on the "OAuth" tab.
 > - Ensure that "JsonWebToken Signature Algorithm" is set to `RS256` and that "OIDC Conformant" is enabled.
-Next, configure the following URLs for your application under the "Application URIs" section of the "Settings" page:
+>   Next, configure the following URLs for your application under the "Application URIs" section of the "Settings" page:
 
 - **Allowed Callback URLs**: `http://localhost:3000`
 - **Allowed Logout URLs**: `http://localhost:3000`
 - **Allowed Web Origins**: `http://localhost:3000`
 
 > These URLs should reflect the origins that your application is running on. **Allowed Callback URLs** may also include a path, depending on where you're handling the callback (see below).
-Take note of the **Client ID** and **Domain** values under the "Basic Information" section. You'll need these values in the next step.
+> Take note of the **Client ID** and **Domain** values under the "Basic Information" section. You'll need these values in the next step.
 
 ### Configure the SDK
 
-Create either an `Auth0Lock` or `Auth0LockPasswordless` instance. 
+Create either an `Auth0Lock` or `Auth0LockPasswordless` instance.
 
 #### Auth0Lock
 
-````js
+```js
 import { Auth0Lock } from 'auth0-lock';
 
 const lock = new Auth0Lock('{YOUR_AUTH0_CLIENT_ID}', '{YOUR_AUTH0_DOMAIN}');
-````
+```
 
 #### Auth0LockPasswordless
 
-````js
+```js
 import { Auth0LockPasswordless } from 'auth0-lock';
 
 const lock = new Auth0LockPasswordless('{YOUR_AUTH0_CLIENT_ID}', '{YOUR_AUTH0_DOMAIN}');
-````
+```
 
 ### Logging In
 
@@ -79,7 +80,7 @@ You can then configure a listener for the `authenticated` event to retrieve an a
 <button id="login">Click to Login</button>
 ```
 
-````js
+```js
 lock.on('authenticated', function (authResult) {
   lock.getUserInfo(authResult.accessToken, function (error, profileResult) {
     if (error) {
@@ -97,7 +98,7 @@ lock.on('authenticated', function (authResult) {
 document.getElementById('login').addEventListener('click', () => {
   lock.show()
 });.
-````
+```
 
 For other comprehensive examples and documentation on the configuration options, see the [EXAMPLES.md](https://github.com/auth0/lock/blob/master/EXAMPLES.md) document.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "11.34.2",
+  "version": "12.0.0-beta.0",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION
:warning: This is a **beta release** of Lock.js v12 that includes an upgrade to React 18, and should not be used in production. If you find any issues, please [submit a bug report](https://github.com/auth0/lock/issues/new?assignees=&labels=bug+report,v12-beta&template=report_a_bug.md&title=).

**Changed**

- Upgrade to React 18 [\#2209](https://github.com/auth0/lock/pull/2209) ([stevehobbsdev](https://github.com/stevehobbsdev))
- Upgrade to Webpack 5, Jest 29, Babel 8 [\#2213](https://github.com/auth0/lock/pull/2213) ([stevehobbsdev](https://github.com/stevehobbsdev))
- bump dependencies to latest patch and fix typos [\#2210](https://github.com/auth0/lock/pull/2210) ([piwysocki](https://github.com/piwysocki))

---

This PR also includes a quick tweak to `.circleci/config.yml` that will allow automatic releasing to happen from the `beta` branch.
