### PR TITLE
Update circle config to use latest ship-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ workflows:
           requires:
             - build-and-test
           pkg-manager: yarn
+          node-version: 18.12.1
           context:
             - publish-npm
             - publish-gh


### PR DESCRIPTION
For now, Ship orb runs on Node 16.6.0 by default, we should configure it to run 18.12.1 for Lock.