### PR TITLE
Use latest ship-orb in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@0.7.8
+  ship: auth0/ship@0
 executors:
   docker-executor:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@0.2.0
+  ship: auth0/ship@0.7.8
 executors:
   docker-executor:
     docker:


### PR DESCRIPTION
This is to fix [the build](https://app.circleci.com/pipelines/github/auth0/lock/1286/workflows/06857e5a-7ef2-49ac-a15d-79bca265e135/jobs/3438), which currently fails thanks to not being able to correctly determine whether the version being built has already been published. This bug is fixed in [this PR](https://github.com/auth0/ship-orb/pull/14).