### PR TITLE
Use latest ship orb, allow publish from v11 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@0.2.0
+  ship: auth0/ship@0
 executors:
   docker-executor:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,3 +88,4 @@ workflows:
             branches:
               only:
                 - master
+                - v11


### PR DESCRIPTION
### Changes

This cherry-picks the commit that updated the ship orb in #2234 and also configures circle to allow publishing to npm from the v11 branch

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
