### PR TITLE
Zooming and scaling must not be disabled

### DIFF
--- a/support/design/index.html
+++ b/support/design/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Design</title>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2, user-scalable=1"/>
 <style>
 body {
   background-color: #1f1f24;

--- a/support/design/modal.html
+++ b/support/design/modal.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <title>Design</title>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=2, user-scalable=1"/>
 <style>
 body {
   background-color: #1f1f24;

--- a/support/index.html
+++ b/support/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta
     name="viewport"
-    content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0"
+    content="width=device-width, initial-scale=1, maximum-scale=2, user-scalable=1"
   />
   <link rel="stylesheet" href="https://cdn.auth0.com/styleguide/core/2.0.5/core.min.css" />
   <link

--- a/support/playground/index.html
+++ b/support/playground/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, user-scalable=yes" />
 
   <title>Auth0 Lock Passwordless Playground</title>
 


### PR DESCRIPTION
Setting user-scalable to 0 is against Web Content Accessibility Guidelines (WCAG). WCAG requires a minimum of 2× scaling

### Changes



Changing the user-scalable="no" parameter from the content attribute of the <meta name="viewport"> element in order to allow zooming and ensuring the maximum-scale parameter is not less than 2.

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

### References

https://dequeuniversity.com/rules/axe/4.6/meta-viewport

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
