### PR TITLE
WelcomeMessage header text marked as heading

### DIFF
--- a/src/ui/box/header.jsx
+++ b/src/ui/box/header.jsx
@@ -67,7 +67,7 @@ class WelcomeMessage extends React.Component {
     }
 
     return (
-      <div className={className} title={message}>
+      <div className={className} title={message} role="heading" aria-level="1">
         {message}
       </div>
     );


### PR DESCRIPTION
### Changes

role="heading" attribute and aria-level="1" attribute added to WelcomeMessage heading.

It adds heading semantics to markup without the risk of breaking any styles.

### References

This change resolves an issue in accessibility.
Header name and title appears to be heading for section of content, but is not marked as heading for screen reader users.

### Testing


* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
