### PR TITLE
LoginSignUpTab - added selected stage of the element

### DIFF
--- a/src/connection/database/login_sign_up_tabs.jsx
+++ b/src/connection/database/login_sign_up_tabs.jsx
@@ -72,7 +72,7 @@ class LoginSignUpTab extends React.Component {
         {current ? (
           <span>{label}</span>
         ) : (
-          <a href={href || '#'} onClick={this.handleClick}>
+          <a href={href || '#'} onClick={this.handleClick} aria-current="page">
             {label}
           </a>
         )}

--- a/src/connection/database/login_sign_up_tabs.jsx
+++ b/src/connection/database/login_sign_up_tabs.jsx
@@ -68,11 +68,11 @@ class LoginSignUpTab extends React.Component {
     const className = current ? 'auth0-lock-tabs-current' : '';
 
     return (
-      <li className={className}>
+      <li className={className} aria-current={current}>
         {current ? (
           <span>{label}</span>
         ) : (
-          <a href={href || '#'} onClick={this.handleClick} aria-current="true">
+          <a href={href || '#'} onClick={this.handleClick}>
             {label}
           </a>
         )}

--- a/src/connection/database/login_sign_up_tabs.jsx
+++ b/src/connection/database/login_sign_up_tabs.jsx
@@ -72,7 +72,7 @@ class LoginSignUpTab extends React.Component {
         {current ? (
           <span>{label}</span>
         ) : (
-          <a href={href || '#'} onClick={this.handleClick} aria-current="page">
+          <a href={href || '#'} onClick={this.handleClick} aria-current="true">
             {label}
           </a>
         )}


### PR DESCRIPTION
### Changes

aria-current="true" added to link  inLoginSignUpTab to indicate which element is the current item 

<!--
Please describe both what is changing and why this is important. Include:
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
-->

### References

The current state of the link is not announced for screen reader users due to which users will not be aware to the state of the element.
<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
