### PR TITLE
Avoid publishing before browserstack has run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
             - browserstack-env
       - ship/node-publish:
           requires:
-            - build-and-test
+            - browserstack
           pkg-manager: yarn
           node-version: 18.12.1
           context:


### PR DESCRIPTION
### Changes

We shouldnt try and publish the SDK when browserstack isnt done.

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
