### PR TITLE
Do not run tests on browserstack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ workflows:
             - browserstack-env
       - ship/node-publish:
           requires:
-            - build-and-test
+            - browserstack
           pkg-manager: yarn
           node-version: 18.12.1
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - store_artifacts:
           path: build
 
-  browserstack:
+  e2e:
     executor: docker-executor
     environment:
       LANG: en_US.UTF-8
@@ -66,20 +66,18 @@ jobs:
           command: yarn build
       - run:
           name: Browser Tests
-          command: yarn test:e2e:browserstack
+          command: yarn test:e2e
 
 workflows:
   build-test-report:
     jobs:
       - build-and-test
-      - browserstack:
+      - e2e:
           requires:
             - build-and-test
-          context:
-            - browserstack-env
       - ship/node-publish:
           requires:
-            - browserstack
+            - e2e
           pkg-manager: yarn
           node-version: 18.12.1
           context:


### PR DESCRIPTION
### Changes

The tests on BS are very unreliable. Since we only run them on chrome, we should be okay to run them locally (on CI) using Karma instead.

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled
