### PR TITLE
Release v12.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v12.3.0](https://github.com/auth0/lock/tree/v12.3.0) (2023-10-06)
+[Full Changelog](https://github.com/auth0/lock/compare/v12.2.0...v12.3.0)
+
+**Added**
+- [IAMRISK-2603] Add support for Arkose [\#2455](https://github.com/auth0/lock/pull/2455) ([srijonsaha](https://github.com/srijonsaha))
+
 ## [v12.2.0](https://github.com/auth0/lock/tree/v12.2.0) (2023-09-15)
 [Full Changelog](https://github.com/auth0/lock/compare/v12.1.0...v12.2.0)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ From CDN
 
 ```html
 <!-- Latest patch release (recommended for production) -->
-<script src="https://cdn.auth0.com/js/lock/12.2.0/lock.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/12.3.0/lock.min.js"></script>
 ```
 ### Configure Auth0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "12.2.0",
+  "version": "12.3.0",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION

**Added**
- [IAMRISK-2603] Add support for Arkose [\#2455](https://github.com/auth0/lock/pull/2455) ([srijonsaha](https://github.com/srijonsaha))


[IAMRISK-2603]: https://auth0team.atlassian.net/browse/IAMRISK-2603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ