### PR TITLE
Combine two tests to reduce flakeyness

### DIFF
--- a/test/captcha.corporate.test.js
+++ b/test/captcha.corporate.test.js
@@ -131,15 +131,11 @@ describe('captcha (corporate connection)', function () {
         this.lock.hide();
       });
 
-      it('should load the captcha script', function (done) {
+      it('should load the captcha script and show the captcha input', function (done) {
         h.waitUntilExists(this.lock, '.auth0-lock-recaptchav2', () => {
           expect(h.q(this.lock, '.auth0-lock-recaptchav2')).to.be.ok();
           done();
         });
-      });
-
-      it('should show the captcha input', function () {
-        expect(h.q(this.lock, '.auth0-lock-recaptchav2')).to.be.ok();
       });
 
       it('should not submit the form if the captcha is not provided', function (done) {


### PR DESCRIPTION
### Changes

The removed test seems to be [flakey in CI](https://github.com/auth0/lock/actions/runs/6454537714/job/17520286576?pr=2461) and it performs the same assertion as the test that ran before it. So combine these tests into one rather than fixing the second to wait

### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All code quality tools/guidelines have been run/followed
* [ ] All relevant assets have been compiled
