### PR TITLE
Release v12.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v12.2.1](https://github.com/auth0/lock/tree/v12.2.1) (2023-11-13)
+[Full Changelog](https://github.com/auth0/lock/compare/v12.2.0...v12.2.1)
+
+**Security**
+- Bump auth0-js to solve crypto-js vulnerability [\#2492](https://github.com/auth0/lock/pull/2492) ([frederikprijck](https://github.com/frederikprijck))
+
 ## [v12.3.0](https://github.com/auth0/lock/tree/v12.3.0) (2023-10-06)
 [Full Changelog](https://github.com/auth0/lock/compare/v12.2.0...v12.3.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "12.3.0",
+  "version": "12.2.1",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",


### PR DESCRIPTION
**Security**
- Bump auth0-js to solve crypto-js vulnerability [\#2492](https://github.com/auth0/lock/pull/2492) ([frederikprijck](https://github.com/frederikprijck))