### PR TITLE
[IAMRISK-3553] Swapped CAPTCHA on each reload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auth0-lock",
-  "version": "12.5.0",
+  "version": "12.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auth0-lock",
-      "version": "12.5.0",
+      "version": "12.5.1",
       "license": "MIT",
       "dependencies": {
         "auth0-js": "^9.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-lock",
-  "version": "12.5.0",
+  "version": "12.5.1",
   "description": "Auth0 Lock",
   "author": "Auth0 <support@auth0.com> (http://auth0.com)",
   "license": "MIT",

--- a/src/__tests__/connection/database/actions.test.js
+++ b/src/__tests__/connection/database/actions.test.js
@@ -1,12 +1,31 @@
 import Immutable, { List, Map } from 'immutable';
-import { signUp } from '../../../connection/database/actions';
+import {
+  signUp,
+  resetPasswordSuccess,
+  showResetPasswordActivity,
+  showLoginActivity, showSignUpActivity
+} from '../../../connection/database/actions';
 import { swap, setEntity } from '../../../store';
+import { swapCaptcha } from "../../../connection/captcha";
+import { hasScreen } from "../../../connection/database";
 
 const webApiMock = () => require('core/web_api');
 const coreActionsMock = () => require('core/actions');
+
 jest.mock('core/actions', () => ({
   validateAndSubmit: jest.fn()
 }));
+
+jest.mock('../../../connection/captcha', () => {
+  const originalCaptcha = jest.requireActual('../../../connection/captcha');
+  return {
+    __esModule: true,
+    ...originalCaptcha,
+    swapCaptcha: jest.fn((id, flow, wasInvalid, next) => {
+      next();
+    }),
+  }
+});
 
 jest.mock('core/web_api', () => ({
   signUp: jest.fn()
@@ -206,6 +225,194 @@ describe('database/actions.js', () => {
       user_metadata: {
         other_name: '123'
       }
+    });
+  });
+
+  describe('resetPasswordSuccess', () => {
+    it('runs swap CAPTCHA', () => {
+      const id = 2;
+      const m = Immutable.fromJS({
+        field: {
+          email: {
+            value: 'test@email.com'
+          },
+          password: {
+            value: 'testpass'
+          },
+          family_name: {
+            value: 'test-family-name'
+          },
+          given_name: {
+            value: 'test-given-name'
+          },
+          name: {
+            value: 'test-name'
+          },
+          nickname: {
+            value: 'test-nickname'
+          },
+          picture: {
+            value: 'test-pic'
+          },
+          other_prop: {
+            value: 'test-other'
+          }
+        },
+        database: {
+          additionalSignUpFields: [
+            { name: 'family_name', storage: 'root' },
+            { name: 'given_name', storage: 'root' },
+            { name: 'name', storage: 'root' },
+            { name: 'nickname', storage: 'root' },
+            { name: 'picture', storage: 'root' },
+            { name: 'other_prop' }
+          ]
+        },
+      });
+      swap(setEntity, 'lock', id, m);
+      resetPasswordSuccess(id);
+      expect(swapCaptcha.mock.calls.length).toEqual(1);
+    });
+  });
+
+  describe('showResetPasswordActivity', () => {
+    it('runs swap CAPTCHA', () => {
+      const id = 2;
+      const m = Immutable.fromJS({
+        field: {
+          email: {
+            value: 'test@email.com'
+          },
+          password: {
+            value: 'testpass'
+          },
+          family_name: {
+            value: 'test-family-name'
+          },
+          given_name: {
+            value: 'test-given-name'
+          },
+          name: {
+            value: 'test-name'
+          },
+          nickname: {
+            value: 'test-nickname'
+          },
+          picture: {
+            value: 'test-pic'
+          },
+          other_prop: {
+            value: 'test-other'
+          }
+        },
+        database: {
+          additionalSignUpFields: [
+            { name: 'family_name', storage: 'root' },
+            { name: 'given_name', storage: 'root' },
+            { name: 'name', storage: 'root' },
+            { name: 'nickname', storage: 'root' },
+            { name: 'picture', storage: 'root' },
+            { name: 'other_prop' }
+          ]
+        },
+      });
+      swap(setEntity, 'lock', id, m);
+      showResetPasswordActivity(id);
+      expect(swapCaptcha.mock.calls.length).toEqual(1);
+    });
+  });
+
+  describe('showLoginActivity', () => {
+    it('runs swap CAPTCHA', () => {
+      const id = 2;
+      const m = Immutable.fromJS({
+        field: {
+          email: {
+            value: 'test@email.com'
+          },
+          password: {
+            value: 'testpass'
+          },
+          family_name: {
+            value: 'test-family-name'
+          },
+          given_name: {
+            value: 'test-given-name'
+          },
+          name: {
+            value: 'test-name'
+          },
+          nickname: {
+            value: 'test-nickname'
+          },
+          picture: {
+            value: 'test-pic'
+          },
+          other_prop: {
+            value: 'test-other'
+          }
+        },
+        database: {
+          additionalSignUpFields: [
+            { name: 'family_name', storage: 'root' },
+            { name: 'given_name', storage: 'root' },
+            { name: 'name', storage: 'root' },
+            { name: 'nickname', storage: 'root' },
+            { name: 'picture', storage: 'root' },
+            { name: 'other_prop' }
+          ]
+        },
+      });
+      swap(setEntity, 'lock', id, m);
+      showLoginActivity(id);
+      expect(swapCaptcha.mock.calls.length).toEqual(1);
+    });
+  });
+
+  describe('showSignupActivity', () => {
+    it('runs swap CAPTCHA', () => {
+      const id = 2;
+      const m = Immutable.fromJS({
+        field: {
+          email: {
+            value: 'test@email.com'
+          },
+          password: {
+            value: 'testpass'
+          },
+          family_name: {
+            value: 'test-family-name'
+          },
+          given_name: {
+            value: 'test-given-name'
+          },
+          name: {
+            value: 'test-name'
+          },
+          nickname: {
+            value: 'test-nickname'
+          },
+          picture: {
+            value: 'test-pic'
+          },
+          other_prop: {
+            value: 'test-other'
+          }
+        },
+        database: {
+          additionalSignUpFields: [
+            { name: 'family_name', storage: 'root' },
+            { name: 'given_name', storage: 'root' },
+            { name: 'name', storage: 'root' },
+            { name: 'nickname', storage: 'root' },
+            { name: 'picture', storage: 'root' },
+            { name: 'other_prop' }
+          ]
+        },
+      });
+      swap(setEntity, 'lock', id, m);
+      showSignUpActivity(id);
+      expect(swapCaptcha.mock.calls.length).toEqual(1);
     });
   });
 });

--- a/src/__tests__/connection/database/actions.test.js
+++ b/src/__tests__/connection/database/actions.test.js
@@ -229,7 +229,6 @@ describe('database/actions.js', () => {
 
   describe('exported functions', () => {
     const id = 2;
-    const hookRunner = jest.fn((str, m, context, fn) => fn());
     const mCaptcha = Immutable.fromJS({
       field: {
         email: {

--- a/src/__tests__/connection/database/actions.test.js
+++ b/src/__tests__/connection/database/actions.test.js
@@ -229,7 +229,8 @@ describe('database/actions.js', () => {
 
   describe('exported functions', () => {
     const id = 2;
-    const m = Immutable.fromJS({
+    const hookRunner = jest.fn((str, m, context, fn) => fn());
+    const mCaptcha = Immutable.fromJS({
       field: {
         email: {
           value: 'test@email.com'
@@ -266,11 +267,17 @@ describe('database/actions.js', () => {
           { name: 'other_prop' }
         ]
       },
+      captcha: {
+        provider: 'auth0'
+      },
+      passwordResetCaptcha: {
+        provider: 'auth0'
+      },
     });
 
     describe('resetPasswordSuccess', () => {
       it('runs swap CAPTCHA', () => {
-        swap(setEntity, 'lock', id, m);
+        swap(setEntity, 'lock', id, mCaptcha);
         resetPasswordSuccess(id);
         expect(swapCaptcha.mock.calls.length).toEqual(1);
       });
@@ -278,7 +285,7 @@ describe('database/actions.js', () => {
 
     describe('showResetPasswordActivity', () => {
       it('runs swap CAPTCHA', () => {
-        swap(setEntity, 'lock', id, m);
+        swap(setEntity, 'lock', id, mCaptcha);
         showResetPasswordActivity(id);
         expect(swapCaptcha.mock.calls.length).toEqual(1);
       });
@@ -286,7 +293,7 @@ describe('database/actions.js', () => {
 
     describe('showLoginActivity', () => {
       it('runs swap CAPTCHA', () => {
-        swap(setEntity, 'lock', id, m);
+        swap(setEntity, 'lock', id, mCaptcha);
         showLoginActivity(id);
         expect(swapCaptcha.mock.calls.length).toEqual(1);
       });
@@ -294,7 +301,7 @@ describe('database/actions.js', () => {
 
     describe('showSignupActivity', () => {
       it('runs swap CAPTCHA', () => {
-        swap(setEntity, 'lock', id, m);
+        swap(setEntity, 'lock', id, mCaptcha);
         showSignUpActivity(id);
         expect(swapCaptcha.mock.calls.length).toEqual(1);
       });

--- a/src/__tests__/connection/database/actions.test.js
+++ b/src/__tests__/connection/database/actions.test.js
@@ -7,7 +7,6 @@ import {
 } from '../../../connection/database/actions';
 import { swap, setEntity } from '../../../store';
 import { swapCaptcha } from "../../../connection/captcha";
-import { hasScreen } from "../../../connection/database";
 
 const webApiMock = () => require('core/web_api');
 const coreActionsMock = () => require('core/actions');
@@ -228,191 +227,78 @@ describe('database/actions.js', () => {
     });
   });
 
-  describe('resetPasswordSuccess', () => {
-    it('runs swap CAPTCHA', () => {
-      const id = 2;
-      const m = Immutable.fromJS({
-        field: {
-          email: {
-            value: 'test@email.com'
-          },
-          password: {
-            value: 'testpass'
-          },
-          family_name: {
-            value: 'test-family-name'
-          },
-          given_name: {
-            value: 'test-given-name'
-          },
-          name: {
-            value: 'test-name'
-          },
-          nickname: {
-            value: 'test-nickname'
-          },
-          picture: {
-            value: 'test-pic'
-          },
-          other_prop: {
-            value: 'test-other'
-          }
+  describe('exported functions', () => {
+    const id = 2;
+    const m = Immutable.fromJS({
+      field: {
+        email: {
+          value: 'test@email.com'
         },
-        database: {
-          additionalSignUpFields: [
-            { name: 'family_name', storage: 'root' },
-            { name: 'given_name', storage: 'root' },
-            { name: 'name', storage: 'root' },
-            { name: 'nickname', storage: 'root' },
-            { name: 'picture', storage: 'root' },
-            { name: 'other_prop' }
-          ]
+        password: {
+          value: 'testpass'
         },
-      });
-      swap(setEntity, 'lock', id, m);
-      resetPasswordSuccess(id);
-      expect(swapCaptcha.mock.calls.length).toEqual(1);
+        family_name: {
+          value: 'test-family-name'
+        },
+        given_name: {
+          value: 'test-given-name'
+        },
+        name: {
+          value: 'test-name'
+        },
+        nickname: {
+          value: 'test-nickname'
+        },
+        picture: {
+          value: 'test-pic'
+        },
+        other_prop: {
+          value: 'test-other'
+        }
+      },
+      database: {
+        additionalSignUpFields: [
+          { name: 'family_name', storage: 'root' },
+          { name: 'given_name', storage: 'root' },
+          { name: 'name', storage: 'root' },
+          { name: 'nickname', storage: 'root' },
+          { name: 'picture', storage: 'root' },
+          { name: 'other_prop' }
+        ]
+      },
     });
-  });
 
-  describe('showResetPasswordActivity', () => {
-    it('runs swap CAPTCHA', () => {
-      const id = 2;
-      const m = Immutable.fromJS({
-        field: {
-          email: {
-            value: 'test@email.com'
-          },
-          password: {
-            value: 'testpass'
-          },
-          family_name: {
-            value: 'test-family-name'
-          },
-          given_name: {
-            value: 'test-given-name'
-          },
-          name: {
-            value: 'test-name'
-          },
-          nickname: {
-            value: 'test-nickname'
-          },
-          picture: {
-            value: 'test-pic'
-          },
-          other_prop: {
-            value: 'test-other'
-          }
-        },
-        database: {
-          additionalSignUpFields: [
-            { name: 'family_name', storage: 'root' },
-            { name: 'given_name', storage: 'root' },
-            { name: 'name', storage: 'root' },
-            { name: 'nickname', storage: 'root' },
-            { name: 'picture', storage: 'root' },
-            { name: 'other_prop' }
-          ]
-        },
+    describe('resetPasswordSuccess', () => {
+      it('runs swap CAPTCHA', () => {
+        swap(setEntity, 'lock', id, m);
+        resetPasswordSuccess(id);
+        expect(swapCaptcha.mock.calls.length).toEqual(1);
       });
-      swap(setEntity, 'lock', id, m);
-      showResetPasswordActivity(id);
-      expect(swapCaptcha.mock.calls.length).toEqual(1);
     });
-  });
 
-  describe('showLoginActivity', () => {
-    it('runs swap CAPTCHA', () => {
-      const id = 2;
-      const m = Immutable.fromJS({
-        field: {
-          email: {
-            value: 'test@email.com'
-          },
-          password: {
-            value: 'testpass'
-          },
-          family_name: {
-            value: 'test-family-name'
-          },
-          given_name: {
-            value: 'test-given-name'
-          },
-          name: {
-            value: 'test-name'
-          },
-          nickname: {
-            value: 'test-nickname'
-          },
-          picture: {
-            value: 'test-pic'
-          },
-          other_prop: {
-            value: 'test-other'
-          }
-        },
-        database: {
-          additionalSignUpFields: [
-            { name: 'family_name', storage: 'root' },
-            { name: 'given_name', storage: 'root' },
-            { name: 'name', storage: 'root' },
-            { name: 'nickname', storage: 'root' },
-            { name: 'picture', storage: 'root' },
-            { name: 'other_prop' }
-          ]
-        },
+    describe('showResetPasswordActivity', () => {
+      it('runs swap CAPTCHA', () => {
+        swap(setEntity, 'lock', id, m);
+        showResetPasswordActivity(id);
+        expect(swapCaptcha.mock.calls.length).toEqual(1);
       });
-      swap(setEntity, 'lock', id, m);
-      showLoginActivity(id);
-      expect(swapCaptcha.mock.calls.length).toEqual(1);
     });
-  });
 
-  describe('showSignupActivity', () => {
-    it('runs swap CAPTCHA', () => {
-      const id = 2;
-      const m = Immutable.fromJS({
-        field: {
-          email: {
-            value: 'test@email.com'
-          },
-          password: {
-            value: 'testpass'
-          },
-          family_name: {
-            value: 'test-family-name'
-          },
-          given_name: {
-            value: 'test-given-name'
-          },
-          name: {
-            value: 'test-name'
-          },
-          nickname: {
-            value: 'test-nickname'
-          },
-          picture: {
-            value: 'test-pic'
-          },
-          other_prop: {
-            value: 'test-other'
-          }
-        },
-        database: {
-          additionalSignUpFields: [
-            { name: 'family_name', storage: 'root' },
-            { name: 'given_name', storage: 'root' },
-            { name: 'name', storage: 'root' },
-            { name: 'nickname', storage: 'root' },
-            { name: 'picture', storage: 'root' },
-            { name: 'other_prop' }
-          ]
-        },
+    describe('showLoginActivity', () => {
+      it('runs swap CAPTCHA', () => {
+        swap(setEntity, 'lock', id, m);
+        showLoginActivity(id);
+        expect(swapCaptcha.mock.calls.length).toEqual(1);
       });
-      swap(setEntity, 'lock', id, m);
-      showSignUpActivity(id);
-      expect(swapCaptcha.mock.calls.length).toEqual(1);
+    });
+
+    describe('showSignupActivity', () => {
+      it('runs swap CAPTCHA', () => {
+        swap(setEntity, 'lock', id, m);
+        showSignUpActivity(id);
+        expect(swapCaptcha.mock.calls.length).toEqual(1);
+      });
     });
   });
-});
+  })
+

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -309,21 +309,42 @@ function resetPasswordError(id, error) {
 }
 
 export function showLoginActivity(id, fields = ['password']) {
-  swapCaptcha(id, Flow.PASSWORD_RESET, false, () => {
+  const m = read(getEntity, 'lock', id);
+  const captchaConfig = l.captcha(m);
+  const captchaProvider = captchaConfig.get('provider');
+  if (captchaProvider === 'arkose') {
     swap(updateEntity, 'lock', id, setScreen, 'login', fields);
-  });
+  } else {
+    swapCaptcha(id, 'login', false, () => {
+      swap(updateEntity, 'lock', id, setScreen, 'login', fields);
+    });
+  }
 }
 
 export function showSignUpActivity(id, fields = ['password']) {
-  swapCaptcha(id, Flow.PASSWORD_RESET, false, () => {
+  const m = read(getEntity, 'lock', id);
+  const captchaConfig = l.captcha(m);
+  const captchaProvider = captchaConfig.get('provider');
+  if (captchaProvider === 'arkose') {
     swap(updateEntity, 'lock', id, setScreen, 'signUp', fields);
-  });
+  } else {
+    swapCaptcha(id, 'login', false, () => {
+      swap(updateEntity, 'lock', id, setScreen, 'signUp', fields);
+    });
+  }
 }
 
 export function showResetPasswordActivity(id, fields = ['password']) {
-  swapCaptcha(id, Flow.PASSWORD_RESET, false, () => {
+  const m = read(getEntity, 'lock', id);
+  const captchaConfig = l.passwordResetCaptcha(m);
+  const captchaProvider = captchaConfig.get('provider');
+  if (captchaProvider === 'arkose') {
     swap(updateEntity, 'lock', id, setScreen, 'forgotPassword', fields);
-  });
+  } else {
+    swapCaptcha(id, 'login', false, () => {
+      swap(updateEntity, 'lock', id, setScreen, 'forgotPassword', fields);
+    });
+  }
 }
 
 export function cancelResetPassword(id) {

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -305,15 +305,21 @@ function resetPasswordError(id, error) {
 }
 
 export function showLoginActivity(id, fields = ['password']) {
-  swap(updateEntity, 'lock', id, setScreen, 'login', fields);
+  swapCaptcha(id, Flow.PASSWORD_RESET, false, () => {
+    swap(updateEntity, 'lock', id, setScreen, 'login', fields);
+  });
 }
 
 export function showSignUpActivity(id, fields = ['password']) {
-  swap(updateEntity, 'lock', id, setScreen, 'signUp', fields);
+  swapCaptcha(id, Flow.PASSWORD_RESET, false, () => {
+    swap(updateEntity, 'lock', id, setScreen, 'signUp', fields);
+  });
 }
 
 export function showResetPasswordActivity(id, fields = ['password']) {
-  swap(updateEntity, 'lock', id, setScreen, 'forgotPassword', fields);
+  swapCaptcha(id, Flow.PASSWORD_RESET, false, () => {
+    swap(updateEntity, 'lock', id, setScreen, 'forgotPassword', fields);
+  });
 }
 
 export function cancelResetPassword(id) {

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -259,7 +259,7 @@ export function resetPassword(id) {
   });
 }
 
-function resetPasswordSuccess(id) {
+export function resetPasswordSuccess(id) {
   const m = read(getEntity, 'lock', id);
   if (hasScreen(m, 'login')) {
     swapCaptcha(id, Flow.PASSWORD_RESET, false, () => {

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -311,8 +311,7 @@ function resetPasswordError(id, error) {
 export function showLoginActivity(id, fields = ['password']) {
   const m = read(getEntity, 'lock', id);
   const captchaConfig = l.captcha(m);
-  const captchaProvider = captchaConfig.get('provider');
-  if (captchaProvider === 'arkose') {
+  if (captchaConfig && captchaConfig.get('provider') === 'arkose') {
     swap(updateEntity, 'lock', id, setScreen, 'login', fields);
   } else {
     swapCaptcha(id, 'login', false, () => {
@@ -324,8 +323,7 @@ export function showLoginActivity(id, fields = ['password']) {
 export function showSignUpActivity(id, fields = ['password']) {
   const m = read(getEntity, 'lock', id);
   const captchaConfig = l.captcha(m);
-  const captchaProvider = captchaConfig.get('provider');
-  if (captchaProvider === 'arkose') {
+  if (captchaConfig && captchaConfig.get('provider') === 'arkose') {
     swap(updateEntity, 'lock', id, setScreen, 'signUp', fields);
   } else {
     swapCaptcha(id, 'login', false, () => {
@@ -337,8 +335,7 @@ export function showSignUpActivity(id, fields = ['password']) {
 export function showResetPasswordActivity(id, fields = ['password']) {
   const m = read(getEntity, 'lock', id);
   const captchaConfig = l.passwordResetCaptcha(m);
-  const captchaProvider = captchaConfig.get('provider');
-  if (captchaProvider === 'arkose') {
+  if (captchaConfig && captchaConfig.get('provider') === 'arkose') {
     swap(updateEntity, 'lock', id, setScreen, 'forgotPassword', fields);
   } else {
     swapCaptcha(id, 'login', false, () => {

--- a/src/connection/database/actions.js
+++ b/src/connection/database/actions.js
@@ -262,12 +262,14 @@ export function resetPassword(id) {
 function resetPasswordSuccess(id) {
   const m = read(getEntity, 'lock', id);
   if (hasScreen(m, 'login')) {
-    swap(
-      updateEntity,
-      'lock',
-      id,
-      m => setScreen(l.setSubmitting(m, false), 'login', ['']) // array with one empty string tells the function to not clear any field
-    );
+    swapCaptcha(id, Flow.PASSWORD_RESET, false, () => {
+      swap(
+          updateEntity,
+          'lock',
+          id,
+          m => setScreen(l.setSubmitting(m, false), 'login', ['']) // array with one empty string tells the function to not clear any field
+      );
+    });
 
     // TODO: should be handled by box
     setTimeout(() => {
@@ -278,7 +280,9 @@ function resetPasswordSuccess(id) {
     if (l.ui.autoclose(m)) {
       closeLock(id);
     } else {
-      swap(updateEntity, 'lock', id, m => l.setSubmitting(m, false).set('passwordResetted', true));
+      swapCaptcha(id, Flow.PASSWORD_RESET, false, () => {
+        swap(updateEntity, 'lock', id, m => l.setSubmitting(m, false).set('passwordResetted', true));
+      });
     }
   }
 }


### PR DESCRIPTION
### Changes

Updates swap code so that CAPTCHA gets swapped along with the form

### References

[Ticket 1](https://auth0team.atlassian.net/browse/IAMRISK-3552?atlOrigin=eyJpIjoiMzhkOTE3NTNhODkwNDY1N2I5Y2ViMDRlZDE2NjE3OTIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)
[Ticket 2](https://auth0team.atlassian.net/browse/IAMRISK-3553?atlOrigin=eyJpIjoiZmYyMjFhYzhkMTZhNGQ4N2ExODk5YWRkMGE4YjA5MTMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

### Testing

This can be tested via layer0 by pulling down the changes and running through the instructions under `DEVELOPMENT.md` for `Testing Lock locally through the Universal Login Page`

* [ ] This change adds unit test coverage N/A
* [ ] This change adds integration test coverage N/A 
* [x] This change has been tested on the latest version of the platform/language

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [x] All relevant assets have been compiled

### Video of Fix


https://github.com/auth0/lock/assets/60672637/c89164f3-9def-4d31-ba12-bc774b07e7d4

