### PR TITLE
Fix: social connection names not showing displayName correctly

### DIFF
--- a/src/connection/social/index.js
+++ b/src/connection/social/index.js
@@ -51,7 +51,7 @@ export const STRATEGIES = {
 
 export function displayName(connection) {
   if (['oauth1', 'oauth2'].indexOf(connection.get('strategy')) !== -1) {
-    return connection.get('name');
+    return connection.get('displayName') || connection.get('name');
   }
   return STRATEGIES[connection.get('strategy')];
 }


### PR DESCRIPTION
### Changes

This PR fixes a small bug where marketplace social connections are not showing the `displayName` correctly and defaults to Strategy ID instead.

### References


### Testing

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of the platform/language

* [x] Manual testing perform, here are screenshots:

### Screenshots

Before changes (notice `sign-in-with-slack`:
<img width="686" height="713" alt="Screenshot 2025-08-06 at 10 52 08 AM" src="https://github.com/user-attachments/assets/d7f03d90-c8b4-41c4-8b35-9f83cebff213" />

After changes (fixed, login now showing `Slack`):
<img width="686" height="713" alt="Screenshot 2025-08-06 at 10 53 09 AM" src="https://github.com/user-attachments/assets/eaa1a9d2-9424-4565-8be5-f1def3d198a0" />


### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All code quality tools/guidelines have been run/followed
* [ ] All relevant assets have been compiled
