### PR TITLE
fix: captcha not rendering for initial signup screen in classic login 

### DIFF
--- a/src/__tests__/core/remote_data.test.js
+++ b/src/__tests__/core/remote_data.test.js
@@ -2,7 +2,7 @@ import * as l from '../../core/index';
 
 const getSyncRemoteData = () => require('core/remote_data').syncRemoteData;
 
-jest.mock('sync', () => jest.fn());
+jest.mock('sync', () => jest.fn((model, key, options) => model));
 
 jest.mock('connection/enterprise', () => ({
   isADEnabled: () => true
@@ -11,11 +11,20 @@ jest.mock('connection/enterprise', () => ({
 jest.mock('core/index', () => ({
   useTenantInfo: () => true,
   id: () => 'id',
-  emitEvent: jest.fn()
+  emitEvent: jest.fn(),
+  setCaptcha: jest.fn(),
+  setPasswordlessCaptcha: jest.fn(), 
+  setPasswordResetCaptcha: jest.fn(),
+  setSignupChallenge: jest.fn()
 }));
 
 jest.mock('core/sso/data', () => ({
   fetchSSOData: jest.fn((id, adEnabled, cb) => cb(null, {}))
+}));
+
+jest.mock('core/web_api', () => ({
+  getChallenge: jest.fn(),
+  getSignupChallenge: jest.fn()
 }));
 
 describe('remote_data.syncRemoteData()', () => {
@@ -39,6 +48,116 @@ describe('remote_data.syncRemoteData()', () => {
         expect(sendADInformation).toBe(isAdEnabled);
         expect(l.emitEvent).toHaveBeenCalledWith('model', 'ssodata fetched', expect.anything());
       });
+    });
+  });
+
+  describe('captcha syncing', () => {
+    it('should sync both login captcha and signup captcha', () => {
+      const syncRemoteData = getSyncRemoteData();
+      syncRemoteData('mockModel');
+
+      const syncCalls = require('sync').mock.calls;
+      
+      const captchaCall = syncCalls.find(c => c[1] === 'captcha');
+      const signupCaptchaCall = syncCalls.find(c => c[1] === 'signupCaptcha');
+
+      expect(captchaCall).toBeDefined();
+      expect(signupCaptchaCall).toBeDefined();
+    });
+
+    it('should call webApi.getChallenge when captcha syncFn is executed', () => {
+      const mockModel = { get: jest.fn().mockReturnValue('test-id') };
+      const syncRemoteData = getSyncRemoteData();
+      
+      require('core/web_api').getChallenge.mockClear();
+      
+      syncRemoteData(mockModel);
+
+      const syncCalls = require('sync').mock.calls;
+      const captchaCall = syncCalls.find(c => c[1] === 'captcha');
+      
+      const mockCallback = jest.fn();
+      captchaCall[2].syncFn(mockModel, mockCallback);
+
+      expect(require('core/web_api').getChallenge).toHaveBeenCalledWith('test-id', expect.any(Function));
+    });
+
+    it('should call webApi.getSignupChallenge when signup captcha syncFn is executed', () => {
+      const mockModel = { get: jest.fn().mockReturnValue('test-id') };
+      const syncRemoteData = getSyncRemoteData();
+      
+      require('core/web_api').getSignupChallenge.mockClear();
+      
+      syncRemoteData(mockModel);
+
+      const syncCalls = require('sync').mock.calls;
+      const signupCaptchaCall = syncCalls.find(c => c[1] === 'signupCaptcha');
+      
+      const mockCallback = jest.fn();
+      signupCaptchaCall[2].syncFn(mockModel, mockCallback);
+
+      expect(require('core/web_api').getSignupChallenge).toHaveBeenCalledWith('test-id', expect.any(Function));
+    });
+
+    it('should sync both login captcha and signup captcha with proper keys', () => {
+      const syncRemoteData = getSyncRemoteData();
+      syncRemoteData('mockModel');
+
+      const syncCalls = require('sync').mock.calls;
+      const syncKeys = syncCalls.map(call => call[1]);
+      
+      expect(syncKeys).toContain('captcha');
+      expect(syncKeys).toContain('signupCaptcha');
+    });
+
+    it('should configure captcha syncs with syncFn functions', () => {
+      const syncRemoteData = getSyncRemoteData();
+      syncRemoteData('mockModel');
+
+      const syncCalls = require('sync').mock.calls;
+      const captchaCall = syncCalls.find(c => c[1] === 'captcha');
+      const signupCaptchaCall = syncCalls.find(c => c[1] === 'signupCaptcha');
+      
+      expect(captchaCall[2].syncFn).toEqual(expect.any(Function));
+      expect(signupCaptchaCall[2].syncFn).toEqual(expect.any(Function));
+    });
+
+    it('should handle webApi errors gracefully', () => {
+      const mockModel = { get: jest.fn().mockReturnValue('test-id') };
+      const syncRemoteData = getSyncRemoteData();
+      syncRemoteData(mockModel);
+
+      const syncCalls = require('sync').mock.calls;
+      const signupCaptchaCall = syncCalls.find(c => c[1] === 'signupCaptcha');
+      
+      require('core/web_api').getSignupChallenge.mockImplementation((id, cb) => {
+        cb(new Error('Network error'), null);
+      });
+
+      const mockCallback = jest.fn();
+      signupCaptchaCall[2].syncFn(mockModel, mockCallback);
+
+      expect(mockCallback).toHaveBeenCalledWith(null, null);
+    });
+
+    it('should handle successful webApi response', () => {
+      const mockModel = { get: jest.fn().mockReturnValue('test-id') };
+      const syncRemoteData = getSyncRemoteData();
+      syncRemoteData(mockModel);
+
+      const syncCalls = require('sync').mock.calls;
+      const signupCaptchaCall = syncCalls.find(c => c[1] === 'signupCaptcha');
+      
+      const mockCaptchaResponse = { required: true, siteKey: 'test-key' };
+      
+      require('core/web_api').getSignupChallenge.mockImplementation((id, cb) => {
+        cb(null, mockCaptchaResponse);
+      });
+
+      const mockCallback = jest.fn();
+      signupCaptchaCall[2].syncFn(mockModel, mockCallback);
+
+      expect(mockCallback).toHaveBeenCalledWith(null, mockCaptchaResponse);
     });
   });
 });

--- a/src/core/actions.js
+++ b/src/core/actions.js
@@ -18,8 +18,8 @@ import { isFieldValid, showInvalidField, hideInvalidFields, clearFields } from '
 export function setupLock(id, clientID, domain, options, hookRunner, emitEventFn, handleEventFn) {
   let m = l.setup(id, clientID, domain, options, hookRunner, emitEventFn, handleEventFn);
 
-  m = syncRemoteData(m);
-
+  m = syncRemoteData(m, options?.initialScreen);
+  
   preload(l.ui.logo(m) || defaultProps.logo);
 
   webApi.setupClient(

--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -6,7 +6,7 @@ import * as l from './index';
 import { isADEnabled } from '../connection/enterprise'; // shouldn't depend on this
 import sync, { isSuccess } from '../sync';
 import webApi from './web_api';
-import { setCaptcha, setPasswordlessCaptcha, setPasswordResetCaptcha } from '../core/index';
+import { setCaptcha, setPasswordlessCaptcha, setPasswordResetCaptcha, setSignupChallenge } from '../core/index';
 
 export function syncRemoteData(m) {
   if (l.useTenantInfo(m)) {
@@ -58,6 +58,15 @@ export function syncRemoteData(m) {
       });
     },
     successFn: setCaptcha
+  });
+
+  m = sync(m, 'signupCaptcha', {
+    syncFn: (m, cb) => {
+      webApi.getSignupChallenge(m.get('id'), (err, r) => {
+        cb(null, r);
+      });
+    },
+    successFn: setSignupChallenge
   });
 
   return m;

--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -62,7 +62,7 @@ export function syncRemoteData(m) {
 
   m = sync(m, 'signupCaptcha', {
     syncFn: (m, cb) => {
-      webApi.getChallenge(m.get('id'), (err, r) => {
+      webApi.getSignupChallenge(m.get('id'), (err, r) => {
         cb(null, r);
       });
     },

--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -6,7 +6,7 @@ import * as l from './index';
 import { isADEnabled } from '../connection/enterprise'; // shouldn't depend on this
 import sync, { isSuccess } from '../sync';
 import webApi from './web_api';
-import { setCaptcha, setPasswordlessCaptcha, setPasswordResetCaptcha, setSignupChallenge } from '../core/index';
+import { setCaptcha, setSignupChallenge } from '../core/index';
 
 export function syncRemoteData(m) {
   if (l.useTenantInfo(m)) {
@@ -62,7 +62,7 @@ export function syncRemoteData(m) {
 
   m = sync(m, 'signupCaptcha', {
     syncFn: (m, cb) => {
-      webApi.getSignupChallenge(m.get('id'), (err, r) => {
+      webApi.getChallenge(m.get('id'), (err, r) => {
         cb(null, r);
       });
     },

--- a/src/core/remote_data.js
+++ b/src/core/remote_data.js
@@ -8,7 +8,7 @@ import sync, { isSuccess } from '../sync';
 import webApi from './web_api';
 import { setCaptcha, setSignupChallenge } from '../core/index';
 
-export function syncRemoteData(m) {
+export function syncRemoteData(m, initialScreen = 'login') {
   if (l.useTenantInfo(m)) {
     m = sync(m, 'client', {
       syncFn: (m, cb) => fetchTenantSettings(l.tenantBaseUrl(m), cb),
@@ -51,23 +51,26 @@ export function syncRemoteData(m) {
     }
   });
 
-  m = sync(m, 'captcha', {
-    syncFn: (m, cb) => {
-      webApi.getChallenge(m.get('id'), (err, r) => {
-        cb(null, r);
-      });
-    },
-    successFn: setCaptcha
-  });
-
-  m = sync(m, 'signupCaptcha', {
-    syncFn: (m, cb) => {
-      webApi.getSignupChallenge(m.get('id'), (err, r) => {
-        cb(null, r);
-      });
-    },
-    successFn: setSignupChallenge
-  });
+  if (initialScreen === 'login') {
+    m = sync(m, 'captcha', {
+      syncFn: (m, cb) => {
+        webApi.getChallenge(m.get('id'), (err, r) => {
+          cb(null, r);
+        });
+      },
+      successFn: setCaptcha
+    });
+  }
+  else if (initialScreen === 'signUp') {
+    m = sync(m, 'signupCaptcha', {
+      syncFn: (m, cb) => {
+        webApi.getSignupChallenge(m.get('id'), (err, r) => {
+          cb(null, r);
+        });
+      },
+      successFn: setSignupChallenge
+    });
+  }
 
   return m;
 }

--- a/src/field/captcha/captcha_pane.jsx
+++ b/src/field/captcha/captcha_pane.jsx
@@ -17,6 +17,12 @@ export default class CaptchaPane extends React.Component {
     const captcha = getCaptchaConfig(lock, flow);
     const value = getFieldValue(lock, 'captcha');
     const isValid = !isFieldVisiblyInvalid(lock, 'captcha');
+
+    // If no captcha config, don't render anything
+    if (!captcha) {
+      return null;
+    }
+
     const provider = captcha.get('provider');
 
     if (isThirdPartyCaptcha(provider)) {

--- a/support/design/index.html
+++ b/support/design/index.html
@@ -341,7 +341,11 @@ body {
    },
    rememberLastLogin: false
  }).show();
+ 
 
+// TODO. Need to fix the captcha not showing issue when this option is selected
+// Jira Task: ten-321
+// Assignee: Princeton Ebanks
  new Auth0Lock(cid, domain, {
    allowedConnections: ["Username-Password-Authentication", "facebook", "twitter", "github", "auth0.com", "rolodato"],
    auth: { redirect: false, sso: false },

--- a/support/design/index.html
+++ b/support/design/index.html
@@ -343,9 +343,6 @@ body {
  }).show();
  
 
-// TODO. Need to fix the captcha not showing issue when this option is selected
-// Jira Task: ten-321
-// Assignee: Princeton Ebanks
  new Auth0Lock(cid, domain, {
    allowedConnections: ["Username-Password-Authentication", "facebook", "twitter", "github", "auth0.com", "rolodato"],
    auth: { redirect: false, sso: false },

--- a/test/captcha_initial_signup.test.js
+++ b/test/captcha_initial_signup.test.js
@@ -1,0 +1,110 @@
+import expect from 'expect.js';
+import * as h from './helper/ui';
+
+const lockOpts = {
+  allowedConnections: ['db'],
+  rememberLastLogin: false,
+  initialScreen: 'signUp'  // This is the key difference
+};
+
+const svgCaptchaRequiredResponse = {
+  required: true,
+  image: 'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==',
+  type: 'code'
+};
+
+const recaptchav2Response = {
+  required: true,
+  provider: 'recaptcha_v2',
+  siteKey: 'my_site_key'
+};
+
+describe('captcha with initialScreen: signUp', function () {
+  before(h.stubWebApis);
+  after(h.restoreWebApis);
+
+  describe('svg-captcha', () => {
+    describe('when initialScreen is set to signUp and signup challenge is required', function () {
+      beforeEach(function (done) {
+        // Stub both login challenge (not required) and signup challenge (required)
+        h.stubGetChallenge({ required: false });
+        h.stubGetSignupChallenge(svgCaptchaRequiredResponse);
+        
+        // Display lock with initialScreen: 'signUp'
+        this.lock = h.displayLock('', lockOpts, () => {
+          // Wait for the signup screen to be ready
+          h.waitUntilExists(this.lock, '.auth0-lock-with-terms', done);
+        });
+      });
+
+      afterEach(function () {
+        this.lock.hide();
+      });
+
+      it('should immediately show the signup screen', function () {
+        expect(h.isSignUpTabCurrent(this.lock)).to.be.ok();
+      });
+
+      it('should show the captcha input immediately without clicking signup tab', function (done) {
+        // This is the main test - captcha should be visible immediately
+        // without needing to click the signup tab
+        setTimeout(() => {
+          expect(h.qInput(this.lock, 'captcha', false)).to.be.ok();
+          done();
+        }, 500);
+      });
+
+      it('should submit the captcha provided by the user', function (done) {
+        h.signUpWithEmailPasswordAndCaptcha(this.lock, () => {
+          expect(h.wasSignUpAttemptedWith({ captcha: 'captchaValue' })).to.be.ok();
+          done();
+        });
+      });
+    });
+  });
+
+  describe('recaptcha_v2', () => {
+    describe('when initialScreen is set to signUp and signup challenge is required', function () {
+      beforeEach(function (done) {
+        // Stub both login challenge (not required) and signup challenge (required)
+        h.stubGetChallenge({ required: false });
+        h.stubGetSignupChallenge(recaptchav2Response);
+        
+        this.lock = h.displayLock('', lockOpts, () => {
+          h.waitUntilExists(this.lock, '.auth0-lock-with-terms', done);
+        });
+      });
+
+      afterEach(function () {
+        this.lock.hide();
+      });
+
+      it('should load the captcha script and show recaptcha immediately', function (done) {
+        h.waitUntilExists(this.lock, '.auth0-lock-recaptchav2', () => {
+          expect(h.q(this.lock, '.auth0-lock-recaptchav2')).to.be.ok();
+          done();
+        });
+      });
+    });
+  });
+
+  describe('when signup challenge is not required', () => {
+    beforeEach(function (done) {
+      // Both login and signup challenges not required
+      h.stubGetChallenge({ required: false });
+      h.stubGetSignupChallenge({ required: false });
+      
+      this.lock = h.displayLock('', lockOpts, () => {
+        h.waitUntilExists(this.lock, '.auth0-lock-with-terms', done);
+      });
+    });
+
+    afterEach(function () {
+      this.lock.hide();
+    });
+
+    it('should not show the captcha input when not required', function () {
+      expect(h.qInput(this.lock, 'captcha', false)).to.not.be.ok();
+    });
+  });
+});


### PR DESCRIPTION
### Changes

When a custom login page that uses Lock.js is initialized with the initialScreen: "signUp" value, we expect the Lock widget to render the signup prompt first. We also expect the initialization logic to render a CAPTCHA widget if a CAPTCHA is expected to be completed for signups.

The initialization does not render the CAPTCHA widget accordingly. The end-user might encounter an error if they submit the signup prompt without having solved a captcha.


### References

<!--
Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.
-->

### Testing

<!--
Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
-->

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [ ] This change has been tested on the latest version of the platform/language

### Screenshots

Before fix: Captcha Required, but does not render when `initialScreen` is set to 'signUp'

<img width="1698" height="739" alt="Screenshot 2025-09-26 at 11 49 17 AM" src="https://github.com/user-attachments/assets/d3743cb2-f67d-4f2d-9043-04d865c165dc" />


After fix: Captcha required and is rendered when `initialScreen` is set to 'signUp'

<img width="1512" height="718" alt="Screenshot 2025-09-26 at 11 18 53 AM" src="https://github.com/user-attachments/assets/620930cc-0082-49a3-8cc8-580d232f7e4e" />



https://github.com/user-attachments/assets/a7804a31-9e25-4cc6-b2ca-a380bacab0c9




https://github.com/user-attachments/assets/7669f00f-0380-46c1-8e61-6526b564543b




### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All code quality tools/guidelines have been run/followed
* [ ] All relevant assets have been compiled
