### PR TITLE
Bump auth0-js to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "14.3.0",
       "license": "MIT",
       "dependencies": {
-        "auth0-js": "^9.29.0",
+        "auth0-js": "^10.0.0",
         "auth0-password-policies": "^3.1.0",
         "blueimp-md5": "^2.19.0",
         "classnames": "^2.3.2",
@@ -7225,8 +7225,9 @@
       }
     },
     "node_modules/auth0-js": {
-      "version": "9.32.0",
-      "integrity": "sha512-Vbt8W1sI3VLEdhaRNNP6Uq0qD5KUWQ4iSFn0nv03Xn4npC8r7YRUrvFrA27CCXK+ZV5fjy0Ajr/ElZ7ed97ukA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/auth0-js/-/auth0-js-10.0.0.tgz",
+      "integrity": "sha512-AuV8nhr/bRdlKI3+ESZ6si2N5ak32aP07suRApZicwIbM1OTfQmELMOnVEOlnhRKsiQAWLPDXUGOA3B/cDd8Jg==",
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "webpack-dev-server": "^5.2.1"
   },
   "dependencies": {
-    "auth0-js": "^9.29.0",
+    "auth0-js": "^10.0.0",
     "auth0-password-policies": "^3.1.0",
     "blueimp-md5": "^2.19.0",
     "classnames": "^2.3.2",


### PR DESCRIPTION
### What

This bumps the production `auth0-js` dependency from `^9.29.0` to `^10.0.0`.

### Why

The current range resolves to `auth0-js@9.32.0`, which is covered by the public high-severity advisory `GHSA-8qjv-jj2q-x832` / CWE-863. Updating to v10 clears the production dependency advisory for Lock.

### Tests

- `npm audit --omit=dev --json`
- `npm test -- src/__tests__/core/web_api/p2_api.test.js src/__tests__/core/web_api.test.js src/__tests__/core/actions.test.js`

Note: Full `npm audit` still reports dev dependency vulnerabilities; the production-only audit is clean.
